### PR TITLE
docs(neuralfetch) + trigger CI on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,10 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-on: [push]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
   # Architecture: 3 test/check jobs + 1 lint job. Each job's steps are gated
   # by dorny/paths-filter so unchanged packages are skipped entirely (the main

--- a/docs/neuralfetch/install.md
+++ b/docs/neuralfetch/install.md
@@ -17,6 +17,12 @@ all_studies = ns.Study.catalog()
 print(f"{len(all_studies)} studies available")
 ```
 
+To run the example tutorials, also install `neuralset` with the `tutorials` extra:
+
+```bash
+pip install 'neuralset[tutorials]'
+```
+
 ## Developer Install
 
 For active development or to try the latest features:
@@ -45,9 +51,6 @@ source .venv/bin/activate
 ```bash
 # from the repo root
 uv pip install -e 'neuralfetch-repo/.'
-
-# or, for the full feature set with all dataset support:
-uv pip install -e 'neuralfetch-repo/.[dev,all]'
 ```
 
 **Step 3:** For strict type checking (optional):
@@ -88,9 +91,6 @@ pip install uv
 ```bash
 # from the repo root
 uv pip install -e 'neuralfetch-repo/.'
-
-# or, for the full feature set with all dataset support:
-uv pip install -e 'neuralfetch-repo/.[dev,all]'
 ```
 
 **Step 4:** For strict type checking (optional):


### PR DESCRIPTION
1. `docs/neuralfetch/install.md` — drops phantom `[dev,all]` extra, points tutorial users to `neuralset[tutorials]`

2. `.github/workflows/ci.yml` — fires CI on PRs 
