### PR TITLE
Fix: quickstart crashes and missing deps

### DIFF
--- a/docs/_static/code-selector.js
+++ b/docs/_static/code-selector.js
@@ -330,19 +330,25 @@ document.addEventListener("DOMContentLoaded", function () {
 
   // Quickstart presets: each maps to a (task, device, study) triple
   var presets = {
-    "bel-language":       { taskKey: "language",            deviceKey: "meg",      study: "Bel2026PetitListenSample" },
-    "li2022-language":    { taskKey: "language",            deviceKey: "fmri_proj", study: "Li2022PetitSample" },
-    "grootswagers-image": { taskKey: "image",               deviceKey: "eeg",      study: "Grootswagers2022HumanSample" },
-    "allen-image":        { taskKey: "image",               deviceKey: "fmri",     study: "Allen2022MassiveSample" },
-    "fake-classif":       { taskKey: "word_classification", deviceKey: "fmri",     study: "Fake2025Fmri" },
+    "bel-language":       { taskKey: "language",            deviceKey: "meg",       study: "Bel2026PetitListenSample",       installDeps: "openneuro-py" },
+    "li2022-language":    { taskKey: "language",            deviceKey: "fmri_proj", study: "Li2022PetitSample",              installDeps: "openneuro-py praatio" },
+    "grootswagers-image": { taskKey: "image",               deviceKey: "eeg",      study: "Grootswagers2022HumanSample",    installDeps: "openneuro-py pyunpack boto3 osfclient" },
+    "allen-image":        { taskKey: "image",               deviceKey: "fmri",     study: "Allen2022MassiveSample",         installDeps: "awscli" },
+    "fake-classif":       { taskKey: "word_classification", deviceKey: "fmri",     study: "Fake2025Fmri",                   installDeps: "" },
   };
 
   var isQuickstart = !!document.querySelector('.code-selector[data-quickstart]');
 
   // ── Template builders ─────────────────────────────────────────────────
 
-  function buildDataBlock(tsk, dev, studyName) {
-    var lines = [
+  function buildDataBlock(tsk, dev, studyName, installDeps) {
+    var lines = [];
+    if (installDeps) {
+      lines.push("# First install study dependencies:");
+      lines.push("# pip install neuralfetch " + installDeps);
+      lines.push("");
+    }
+    lines.push(
       "import neuralset as ns",
       "from torch.utils.data import DataLoader",
       "",
@@ -350,7 +356,7 @@ document.addEventListener("DOMContentLoaded", function () {
       'infra = {"folder": ns.CACHE_FOLDER / "cache"}',
       "",
       "# 1. Load study"
-    ];
+    );
     if (studyName === "YourStudy") {
       lines.push(
         "# No built-in dataset for this task/device combo — replace 'YourStudy' below"
@@ -361,9 +367,13 @@ document.addEventListener("DOMContentLoaded", function () {
       '    name="' + studyName + '",',
       "    path=ns.CACHE_FOLDER,",
       "    infra=infra,",
-      ")",
-      "study.download()",
+      ")"
     );
+    if (studyName.indexOf("Fake") !== 0) {
+      lines.push("study.download()");
+    } else {
+      lines.push("# No download needed — Fake studies generate data on the fly");
+    }
     lines.push(
       "events = study.run()",
       'print(events[["type", "start", "duration", "timeline"]].head(10))',
@@ -516,23 +526,25 @@ document.addEventListener("DOMContentLoaded", function () {
   }
 
   function render() {
-    var tskKey, devKey, studyName;
+    var tskKey, devKey, studyName, installDeps;
 
     if (isQuickstart) {
       var p = presets[val("sel-preset")] || presets["bel-language"];
       tskKey = p.taskKey;
       devKey = p.deviceKey;
       studyName = p.study;
+      installDeps = p.installDeps || "";
     } else {
       tskKey = val("sel-task") || "language";
       devKey = val("sel-device") || "meg";
       studyName = (studyMap[tskKey] || {})[devKey] || "YourStudy";
+      installDeps = "";
     }
 
     var tsk = task[tskKey] || task.language;
     var dev = device[devKey] || device.meg;
 
-    var dataBlock = buildDataBlock(tsk, dev, studyName);
+    var dataBlock = buildDataBlock(tsk, dev, studyName, installDeps);
     dataEl.innerHTML = highlightPython(dataBlock);
     addCopyButton(dataEl, dataBlock);
 

--- a/neuralfetch-repo/neuralfetch/studies/allen2022massive.py
+++ b/neuralfetch-repo/neuralfetch/studies/allen2022massive.py
@@ -161,6 +161,7 @@ class Allen2022Massive(study.Study):
         "scipy>=1.11.4",
         "h5py>=3.10.0",
         "requests>=2.31.0",
+        "awscli",
     )
 
     SESSIONS_PER_SUBJECT: tp.ClassVar[dict[int, int]] = {

--- a/neuralfetch-repo/pyproject.toml
+++ b/neuralfetch-repo/pyproject.toml
@@ -22,6 +22,14 @@ dependencies = [
 # Study auto-discovery by neuralset; value = scan root module path.
 [project.optional-dependencies]
 all = ["neuralset[all]", "matplotlib"]
+quickstart = [
+  "openneuro-py",
+  "praatio",
+  "pyunpack",
+  "boto3",
+  "osfclient>=0.0.5",
+  "awscli",
+]
 
 [project.entry-points."neuralset.studies"]
 neuralfetch = "neuralfetch"


### PR DESCRIPTION
- Skip study.download() for Fake2025Fmri (raises NotImplementedError)
- Add awscli to Allen2022Massive.requirements (was missing)
- Add neuralfetch[quickstart] extra with all study-specific deps
- Add per-preset install hint comments in generated quickstart code

