### PR TITLE
add 'neuralfetch' to neuralset dependencies

### DIFF
--- a/neuralset-repo/pyproject.toml
+++ b/neuralset-repo/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
   "nibabel>=5.1.0",
   "tqdm>=4.65.0",
   "exca>=0.5.20",
+  "neuralfetch",
   "rapidfuzz",
   "packaging",
   "ujson",


### PR DESCRIPTION
## What does this PR do?

adds neuralfetch as a dependency to neuralset

## Related Issues

fixes #11 

## Checklist

- [x] Tests added or updated
- [x] Docstrings updated for any changed public APIs
- [x] `pytest` and `mypy` pass locally
