### PR TITLE
Add codespell support with configuration and fixes

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,23 @@
+# Codespell configuration is within pyproject.toml
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Codespell
+        uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579  # v2.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,9 @@ repos:
     hooks:
       - id: nbstripout
         language_version: python3
+  
+  - repo: https://github.com/codespell-project/codespell
+    # Configuration for codespell is in .pre-commit-config.yaml
+    rev: v2.4.1
+    hooks:
+    - id: codespell

--- a/neuralfetch-repo/neuralfetch/download.py
+++ b/neuralfetch-repo/neuralfetch/download.py
@@ -584,7 +584,7 @@ class Datalad(BaseDownload):
         Parameters
             path: Path to store the dataset (will clone repo to that folder)
             url: Url of the datalad repository
-            threads: Number of threads to parallize dataset download
+            threads: Number of threads to parallelize dataset download
             folders: List of folders to clone explicitly (otherwise everything is cloned).
                 Contains a tuple of str and bool. Bool defines if str is a glob
         """
@@ -920,7 +920,7 @@ class Figshare(BaseDownload):
         file_info = []
 
         for i in item_ids:
-            # page_size set to arbritary high value to return items
+            # page_size set to arbitrary high value to return items
             r = requests.get(f"{BASE_URL}/articles/{i}/files?page_size=1000")
             file_metadata = json.loads(r.text)
             for j in file_metadata:

--- a/neuralfetch-repo/neuralfetch/studies/li2022petit.py
+++ b/neuralfetch-repo/neuralfetch/studies/li2022petit.py
@@ -118,7 +118,7 @@ class Li2022Petit(study.Study):
             path = path / self.__class__.__name__
         client = download.Openneuro(study=dataset_id, dset_dir=path)
         client.download()
-        # TODO when available, automatize download of transcripts files
+        # TODO when available, automate download of transcripts files
 
     def iter_timelines(self) -> tp.Iterator[dict[str, tp.Any]]:
         if not self.path.exists():

--- a/neuralset-repo/neuralset/dataloader.py
+++ b/neuralset-repo/neuralset/dataloader.py
@@ -100,7 +100,7 @@ class SegmentsMixin:
     @property
     def events(self) -> pd.DataFrame:
         """All of the events spanned by all the segments"""
-        # TODO FIXME why are segments events with both an index AND and Index colum
+        # TODO FIXME why are segments events with both an index AND and Index column
         # TODO discuss should the trigger event be in events? Probably not
         return pd.concat([seg.events for seg in self.segments]).drop_duplicates()
 

--- a/neuralset-repo/neuralset/events/study.py
+++ b/neuralset-repo/neuralset/events/study.py
@@ -365,7 +365,7 @@ class Study(base.Step):
 
     def _download(self) -> None:
         """Download dataset.
-        Needs to be overriden by user.
+        Needs to be overridden by user.
         """
         raise NotImplementedError("Dataset not available to download yet.")
 

--- a/neuralset-repo/neuralset/events/transforms/splitting.py
+++ b/neuralset-repo/neuralset/events/transforms/splitting.py
@@ -425,7 +425,7 @@ class SimilaritySplitter(base.BaseModel):
         return assigned_splits
 
     def compute_clusters(self, events: pd.DataFrame) -> pd.DataFrame:
-        """Filter events by the event types defined in the extractor and compute cluster assigments."""
+        """Filter events by the event types defined in the extractor and compute cluster assignments."""
         self.extractor.prepare(events)
         splitted_events = events[
             events["type"].isin(ev.EventTypesHelper(self.extractor.event_types).names)

--- a/neuralset-repo/neuralset/events/transforms/text.py
+++ b/neuralset-repo/neuralset/events/transforms/text.py
@@ -438,7 +438,7 @@ class AddSummary(EventsTransform):
         Simply return the summary, without any introduction.
         """
         messages = [
-            {"role": "system", "content": "You are a professionnal text summarizer."},
+            {"role": "system", "content": "You are a professional text summarizer."},
             {"role": "user", "content": prompt + text},
         ]
         outputs = self.pipeline(

--- a/neuralset-repo/neuralset/extractors/image.py
+++ b/neuralset-repo/neuralset/extractors/image.py
@@ -225,7 +225,7 @@ class BaseImage(BaseStatic, HuggingFaceMixin):
                 for latent in latents:
                     # notes: - aggregating with a batch would be slightly more efficient
                     # but code would be messier
-                    # - aggregating in cuda avoids transfering too much data to cpu
+                    # - aggregating in cuda avoids transferring too much data to cpu
                     latent = self._aggregate_tokens(latent)
                     yield latent.cpu().numpy()
 
@@ -292,7 +292,7 @@ class HuggingFaceImage(BaseImage):
 
     def _get_hidden_states(self, images: torch.Tensor) -> list[torch.Tensor]:
         """Extract hidden_states as n_layers n_layers x (batch, tokens,  features)"""
-        # this method is overriden in experimental extractors for more hugging face models
+        # this method is overridden in experimental extractors for more hugging face models
         out = self.model._full_predict(images)  # type: ignore
         out = getattr(out, "vision_model_output", out)  # for clip
         states = out.hidden_states

--- a/neuralset-repo/neuralset/extractors/meta.py
+++ b/neuralset-repo/neuralset/extractors/meta.py
@@ -111,7 +111,7 @@ class AggregatedExtractor(base.BaseExtractor):
     event_types: str | tuple[str, ...] = "Event"
     extractors: list[base.BaseExtractor]
     extractor_aggregation: tp.Literal["cat", "stack", "mean", "sum"] = "cat"
-    frequency: tp.Literal["native"] = "native"  # defered to sub-extractors
+    frequency: tp.Literal["native"] = "native"  # deferred to sub-extractors
 
     def model_post_init(self, log__: tp.Any) -> None:
         """Check that extractors are all static or all dynamic."""
@@ -335,7 +335,7 @@ class HuggingFacePCA(ExtractorPCA):
                 layers.append(pca.fit_transform(layer))
                 del layer  # free memory if need be
             embds.clear()
-            # avoid keeping files open, explicitely delete cache
+            # avoid keeping files open, explicitly delete cache
             del feat.infra._state.cache_dict
             del feat
         # back to N * Layer * prod(*Embd)

--- a/neuralset-repo/neuralset/extractors/neuro.py
+++ b/neuralset-repo/neuralset/extractors/neuro.py
@@ -306,7 +306,7 @@ class MneRaw(BaseExtractor):
 
     def prepare(self, obj: DataframeOrEventsOrSegments) -> None:
         """Specify how to load and preprocess the event.
-        Can be overriden by user.
+        Can be overridden by user.
         """
         events: list[etypes.MneRaw]
         events = self._event_types_helper.extract(obj)  # type: ignore

--- a/neuralset-repo/neuralset/extractors/test_neuro.py
+++ b/neuralset-repo/neuralset/extractors/test_neuro.py
@@ -1605,7 +1605,7 @@ def test_hrf() -> None:
 
     # TODO add error if no prepare
 
-    # raise if events from heterogenous timelines
+    # raise if events from heterogeneous timelines
     # FIXME should be an error at BaseExtractor level
     # with pytest.raises(ValueError):
     #     hrf(events, start=5, duration=5.)

--- a/neuralset-repo/neuralset/extractors/text.py
+++ b/neuralset-repo/neuralset/extractors/text.py
@@ -259,7 +259,7 @@ class HuggingFaceText(BaseStatic, HuggingFaceMixin):
     contextualized: bool
         True by default, the context of the event is used to compute the embeddings.
     pretrained: bool or "part-reversal"
-        use pretrained model if True, untrained intial model if False, or custom
+        use pretrained model if True, untrained initial model if False, or custom
         scrambling of the model pretrained weights if "part-reveral"
 
     Note
@@ -493,7 +493,7 @@ class HuggingFaceText(BaseStatic, HuggingFaceMixin):
                 # erase variables / free memory
                 del hidden_states, hidden_state, word_state, states, outputs, inputs
                 if self.device == "accelerate" and torch.cuda.is_available():
-                    # in case of multi-GPU models, explicitely empty cache "just in case"
+                    # in case of multi-GPU models, explicitly empty cache "just in case"
                     torch.cuda.empty_cache()
 
 

--- a/neuralset-repo/neuralset/test_segments.py
+++ b/neuralset-repo/neuralset/test_segments.py
@@ -80,7 +80,7 @@ def test_find_intersect(reloaded: bool, tmp_path: Path, validated: bool = True) 
 
         sel = events.type == "a"
 
-        # Test case: find overlaping events
+        # Test case: find overlapping events
         found = seg.find_overlap(
             events=events, triggers=sel, duration=events.loc[sel].duration.item()
         )

--- a/neuraltrain-repo/neuraltrain/metrics/metrics.py
+++ b/neuraltrain-repo/neuraltrain/metrics/metrics.py
@@ -198,7 +198,7 @@ class Rank(torchmetrics.Metric):
         true_scores: torch.Tensor,
         retrieval_size: int | None,
     ) -> torch.Tensor:
-        """Average ranks obtained with stricly greater-than and greater-than-or-equals operations
+        """Average ranks obtained with strictly greater-than and greater-than-or-equals operations
         to account for repeated scores.
 
         E.g., the zero-based rank of prediction "1" in [0, 1, 1, 1, 2] will be 2 (instead of 1

--- a/neuraltrain-repo/neuraltrain/models/common.py
+++ b/neuraltrain-repo/neuraltrain/models/common.py
@@ -574,7 +574,7 @@ class ChannelMergerModel(nn.Module):
 
 class LayerScale(nn.Module):
     """Layer scale from [Touvron et al 2021] (https://arxiv.org/pdf/2103.17239.pdf).
-    This rescales diagonaly residual outputs close to 0 initially, then learnt.
+    This rescales diagonally residual outputs close to 0 initially, then learnt.
     """
 
     def __init__(self, channels: int, init: float = 0.1, boost: float = 5.0):

--- a/neuraltrain-repo/neuraltrain/models/test_green.py
+++ b/neuraltrain-repo/neuraltrain/models/test_green.py
@@ -34,7 +34,7 @@ def test_green(fake_meg, use_default_config):
             n_freqs=5,  # Learning 5 wavelets
             dropout=0.5,  # Dropout rate of 0.5 in FC layers
             hidden_dim=[100],  # Use 100 units in the hidden layer
-            bi_out=[20],  # Use a BiMap layer outputing a 20x20 matrix
+            bi_out=[20],  # Use a BiMap layer outputting a 20x20 matrix
         )
 
     sfreq = 100

--- a/neuraltrain-repo/neuraltrain/models/test_luna.py
+++ b/neuraltrain-repo/neuraltrain/models/test_luna.py
@@ -76,7 +76,11 @@ def test_wrapper_mapping():
 
     for v in mapping.values():
         assert v.startswith("model."), f"Expected 'model.' prefix, got {v!r}"
-    assert mapping["cross_attn.temparature"] == "model.cross_attn.temperature"
+    # Misspelled source key is intentional: tests the typo-fix mapping
+    assert (
+        mapping["cross_attn.temparature"]  # codespell:ignore temparature
+        == "model.cross_attn.temperature"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/neuraltrain-repo/neuraltrain/utils.py
+++ b/neuraltrain-repo/neuraltrain/utils.py
@@ -496,7 +496,7 @@ class TimedIterator(tp.Generic[X]):
     Parameters
     ----------
     iterable: iterable
-        The iterable to analyze, ususally a torch Dataloader
+        The iterable to analyze, usually a torch Dataloader
     store_last: int
         maximum number of durations to keep in memory
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,3 +45,10 @@ known-first-party = ["neuralset", "neuraltrain", "neuralfetch"]
 
 [tool.mypy]
 plugins = ["pydantic.mypy"]
+
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git,.gitignore,.gitattributes,*.css'
+check-hidden = true
+# ignore-regex = ''
+# ignore-words-list = ''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,11 @@ plugins = ["pydantic.mypy"]
 
 [tool.codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = '.git,.gitignore,.gitattributes,*.css'
+skip = '.git,.git-meta,.gitignore,.gitattributes,*.css'
 check-hidden = true
-# ignore-regex = ''
-# ignore-words-list = ''
+# Ignore URLs: URL paths may contain sequences that look like typos
+ignore-regex = 'https?://\S+'
+# fro: PyTorch Frobenius norm parameter, e.g. x.norm(p="fro")
+# toi, rouge: French words ("you", "red") used in accent-insensitive matching tests
+# fo: test timeline identifier string
+ignore-words-list = 'fro,toi,rouge,fo'


### PR DESCRIPTION
Add codespell configuration and fix existing typos.

More about codespell: https://github.com/codespell-project/codespell

I personally introduced it to over a hundred projects already, mostly with a positive
feedback (see the
[improveit-dashboard README](https://github.com/yarikoptic/improveit-dashboard/blob/master/READMEs/yarikoptic.md)).

The CI workflow has `permissions:` set to `contents: read` only, so it should be safe.

## Changes

### Configuration & Infrastructure
- Added `[tool.codespell]` section to `pyproject.toml` (pre-existed, now tuned)
- GitHub Actions workflow `.github/workflows/codespell.yml` runs on push/PR to main
- Pre-commit hook configured in `.pre-commit-config.yaml`
- Skip list: `.git,.git-meta,.gitignore,.gitattributes,*.css`

### False-positive Protection
- `ignore-regex = 'https?://\S+'` — URLs may contain sequences that look like typos
  (e.g. `https://cvnlab.slite.page/...` was hitting `slite`)
- `ignore-words-list = 'fro,toi,rouge,fo'`:
  - `fro` — PyTorch Frobenius norm parameter (`x.norm(p="fro")`)
  - `toi`, `rouge` — French words ("you", "red") used in accent-insensitive
    matching tests in `test_transforms.py`
  - `fo` — test timeline identifier string
- `test_luna.py` keeps the intentionally-misspelled state-dict key
  `cross_attn.temparature` (the test's docstring describes it as
  "includes temperature typo fix") and is now protected with an inline
  `# codespell:ignore temparature` comment so codespell won't "fix" it

### Typo Fixes (non-ambiguous)
All changes are in comments, docstrings, or string literals — no public API
names, state-dict keys, or test fixture values were touched.

- parallize → parallelize
- arbritary → arbitrary
- automatize → automate
- colum → column
- overlaping → overlapping
- overriden → overridden (3x)
- assigments → assignments
- professionnal → professional (LLM system prompt)
- transfering → transferring
- defered → deferred
- explicitely → explicitly (2x)
- heterogenous → heterogeneous
- intial → initial
- ususally → usually
- stricly → strictly
- diagonaly → diagonally
- outputing → outputting

## Testing

- `uvx codespell` passes with zero errors (exit code 0)
- All fixes are in inert locations (comments/docstrings/LLM prompt)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) and love to typo-free code
