### PR TITLE
Add additional time filtering in extractors

### DIFF
--- a/neuralset-repo/neuralset/extractors/base.py
+++ b/neuralset-repo/neuralset/extractors/base.py
@@ -233,7 +233,9 @@ class BaseExtractor(base._Module, base.NamedModel):
                 raise TypeError(msg)
             trigger = triggers[0]
 
-        ns_events = self._get_relevant_events(events, trigger)
+        ns_events = self._get_relevant_events(
+            events, trigger, start=start, duration=duration
+        )
 
         # If there is no valid event, return default values or raise error.
         if not ns_events:
@@ -294,8 +296,15 @@ class BaseExtractor(base._Module, base.NamedModel):
 
         return tensor
 
-    def _get_relevant_events(self, events: tp.Any, trigger: Event | None) -> list[Event]:
-        """Select only relevant events and convert them into ns.event.Event"""
+    def _get_relevant_events(
+        self,
+        events: tp.Any,
+        trigger: Event | None,
+        *,
+        start: float,
+        duration: float,
+    ) -> list[Event]:
+        """Select the extractor-relevant events for the segment window and aggregation."""
         # if trigger-aggregation, we only extract data from the trigger event
         if self.aggregation == "trigger":
             event_types = self._event_types_helper.classes
@@ -310,6 +319,16 @@ class BaseExtractor(base._Module, base.NamedModel):
         if ns_events and len(timelines := {e.timeline for e in ns_events}) > 1:
             msg = f"Multiple timelines {timelines} in events passed to extractor {self!r}: {ns_events}"
             raise ValueError(msg)
+
+        if self.aggregation != "trigger":
+            stop = start + duration
+            in_window = [
+                e for e in ns_events if e.start < stop and e.start + e.duration > start
+            ]
+            # fall back to full list when nothing overlaps, so raw-data events
+            # (Meg, Audio, Fmri) called outside their nominal range still reach
+            # the zero-fill in _tarrays_to_tensor (see test_first_samp).
+            ns_events = in_window or ns_events
 
         if self.aggregation in ("first", "trigger", "single"):
             if self.aggregation == "single" and len(ns_events) > 1:

--- a/neuralset-repo/neuralset/extractors/neuro.py
+++ b/neuralset-repo/neuralset/extractors/neuro.py
@@ -1650,13 +1650,20 @@ class FmriExtractor(BaseExtractor):
         return resamp_data, new_trs
 
     def _get_relevant_events(
-        self, events: tp.Any, trigger: etypes.Event | None
+        self,
+        events: tp.Any,
+        trigger: etypes.Event | None,
+        *,
+        start: float,
+        duration: float,
     ) -> list[etypes.Event]:
         """Filter Fmri events by preproc/space, then delegate aggregation to base."""
         fmri_events = self._auto_filter_fmri_events(
             self._event_types_helper.extract(events),  # type: ignore[arg-type]
         )
-        return super()._get_relevant_events(fmri_events, trigger)
+        return super()._get_relevant_events(
+            fmri_events, trigger, start=start, duration=duration
+        )
 
     def _preprocess_event(self, event: etypes.Fmri) -> FmriTimedArray:
         rec = event.read()

--- a/neuralset-repo/neuralset/extractors/test_base.py
+++ b/neuralset-repo/neuralset/extractors/test_base.py
@@ -214,6 +214,22 @@ def test_aggreg(aggreg: tp.Literal["first", "trigger"], expected: list[float]) -
     np.testing.assert_array_almost_equal(out, expected)
 
 
+def test_single_aggregation_scoped_to_window() -> None:
+    """``aggregation='single'`` counts events inside the segment window,
+    not across the whole input (typical when the caller passes a full
+    recording's DataFrame rather than a segment-scoped subset)."""
+    feat = Time(frequency=3, aggregation="single")
+    events = [
+        etypes.Image(start=s, duration=0.5, timeline="stuff", filepath=__file__)
+        for s in [0.0, 2.0, 4.0]
+    ]
+    # One overlaps [2, 3): picked, no raise.
+    feat(events, start=2.0, duration=1.0)
+    # Two overlap [0, 3): still ambiguous.
+    with pytest.raises(ValueError, match="expected only one"):
+        feat(events, start=0.0, duration=3.0)
+
+
 def test_trigger_outside_window() -> None:
     feat = ns.extractors.WordFrequency(aggregation="trigger")
     trigger = etypes.Word(text="Hello", start=0, duration=1, timeline="stuff")

--- a/neuralset-repo/neuralset/extractors/test_neuro.py
+++ b/neuralset-repo/neuralset/extractors/test_neuro.py
@@ -1641,7 +1641,8 @@ def test_fmri_space_selection(tmp_path: Path) -> None:
     # from_space="auto" + SurfaceProjector → prefers fsaverage
     _surf5: tp.Any = {"name": "SurfaceProjector", "mesh": "fsaverage5"}
     feat = ns.extractors.FmriExtractor(projection=_surf5, from_space="auto")
-    relevant = feat._get_relevant_events(events, trigger=None)
+    window: tp.Any = dict(start=0.0, duration=1.0)  # dummy — we test space filtering
+    relevant = feat._get_relevant_events(events, trigger=None, **window)
     assert len(relevant) == 1
     ta = feat._preprocess_event(relevant[0])  # type: ignore[arg-type]
     assert ta.header is not None
@@ -1649,7 +1650,7 @@ def test_fmri_space_selection(tmp_path: Path) -> None:
 
     # explicit from_space overrides
     feat = ns.extractors.FmriExtractor(from_space=mni)
-    relevant = feat._get_relevant_events(events, trigger=None)
+    relevant = feat._get_relevant_events(events, trigger=None, **window)
     assert len(relevant) == 1
     ta = feat._preprocess_event(relevant[0])  # type: ignore[arg-type]
     assert ta.header is not None and ta.header["space"] == mni
@@ -1657,7 +1658,7 @@ def test_fmri_space_selection(tmp_path: Path) -> None:
     # single space + from_space=None → passes through
     feat = ns.extractors.FmriExtractor()
     single = [_mk(tmp_path, space="T1w")]
-    relevant = feat._get_relevant_events(single, trigger=None)
+    relevant = feat._get_relevant_events(single, trigger=None, **window)
     assert len(relevant) == 1
     ta = feat._preprocess_event(relevant[0])  # type: ignore[arg-type]
     assert ta.header is not None and ta.header["space"] == "T1w"
@@ -1665,12 +1666,12 @@ def test_fmri_space_selection(tmp_path: Path) -> None:
     # multiple spaces + from_space=None → raises
     feat = ns.extractors.FmriExtractor()
     with pytest.raises(ValueError, match="Multiple spaces"):
-        feat._get_relevant_events(events, trigger=None)
+        feat._get_relevant_events(events, trigger=None, **window)
 
     # multiple spaces + from_space=None + projection → also raises (no silent auto)
     feat = ns.extractors.FmriExtractor(projection=_surf5)
     with pytest.raises(ValueError, match="Multiple spaces"):
-        feat._get_relevant_events(events, trigger=None)
+        feat._get_relevant_events(events, trigger=None, **window)
 
     # from_preproc filters
     mixed = [
@@ -1678,7 +1679,7 @@ def test_fmri_space_selection(tmp_path: Path) -> None:
         _mk(tmp_path, space="T1w", preproc="fmriprep"),
     ]
     feat = ns.extractors.FmriExtractor(from_preproc="deepprep")
-    relevant = feat._get_relevant_events(mixed, trigger=None)
+    relevant = feat._get_relevant_events(mixed, trigger=None, **window)
     assert len(relevant) == 1
     ta = feat._preprocess_event(relevant[0])  # type: ignore[arg-type]
     assert ta.header is not None and ta.header["preproc"] == "deepprep"


### PR DESCRIPTION
While there was no issue in standard conditions using segments for filtering + TimedArray, this PR adds an extra filtering to avoid any weird behavior in non-standard settings