### PR TITLE
Fix THINGS-images download by unlinking pre-created temp zip

### DIFF
--- a/neuralfetch-repo/neuralfetch/utils.py
+++ b/neuralfetch-repo/neuralfetch/utils.py
@@ -415,6 +415,7 @@ def download_things_images(
 
     with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp_file:
         tmp_path = Path(tmp_file.name)
+    tmp_path.unlink()
 
     try:
         download_file(zip_url, tmp_path, show_progress=True)


### PR DESCRIPTION
## What does this PR do?

Fix `download_things_images()` so the temporary zip path is unlinked before
calling `download_file()`.

Without this, the temp file already exists at size 0 when `pooch.retrieve(...)`
is invoked, and the THINGS archive download can result in an empty file that
later fails extraction as an invalid zip.

## Related Issues

Fixes #21 

## Checklist

- [ ] Tests added or updated
- [x] Docstrings updated for any changed public APIs
- [x] `pytest` and `mypy` pass locally
