### PR TITLE
Propagate bids fields to new events from transforms

### DIFF
--- a/neuralset-repo/neuralset/events/study.py
+++ b/neuralset-repo/neuralset/events/study.py
@@ -223,7 +223,11 @@ class EventsTransform(base.Step):
             @functools.wraps(original)
             def _validated_run(self: tp.Any, *args: tp.Any, **kw: tp.Any) -> pd.DataFrame:
                 result = original(self, *args, **kw)
-                return utils.standardize_events(result, auto_fill=False)
+                try:
+                    return utils.standardize_events(result, auto_fill=False)
+                except ValueError as exc:
+                    exc.add_note(f"in {type(self).__name__}._run output")
+                    raise
 
             cls._run = _validated_run  # type: ignore[assignment]
 

--- a/neuralset-repo/neuralset/events/test_etypes.py
+++ b/neuralset-repo/neuralset/events/test_etypes.py
@@ -337,6 +337,34 @@ def test_validate_events_bids_nan_recovery() -> None:
         assert pd.api.types.is_string_dtype(recovered[entity].dtype)
 
 
+def test_per_timeline_invariant_propagation() -> None:
+    ev = dict(type="Motor", start=0.0, duration=1.0)
+    bids = dict(subject="s1", session="ses1", task="t1", run="r1", study="StudyA")
+    rows = [
+        {**ev, "timeline": "tl1", **bids},
+        {**ev, "timeline": "tl1", "start": 0.5},
+        {**ev, "timeline": "tl2", "subject": "s2"},
+    ]
+    df = ns.events.standardize_events(pd.DataFrame(rows), auto_fill=False)
+    for col, val in bids.items():
+        assert df.iloc[1][col] == val, col
+    assert df[df.timeline == "tl2"].iloc[0]["subject"] == "s2"
+    # all-empty: no error, stays empty
+    out = ns.events.standardize_events(
+        pd.DataFrame([{**ev, "start": t, "timeline": "tl1"} for t in (0.0, 1.0)]),
+        auto_fill=False,
+    )
+    assert (out["subject"] == "").all()
+    # conflict raises, names the column
+    with pytest.raises(ValueError, match="'subject'"):
+        ns.events.standardize_events(
+            pd.DataFrame(
+                rows + [{**ev, "start": 2.0, "timeline": "tl1", "subject": "other"}]
+            ),
+            auto_fill=False,
+        )
+
+
 def test_normalize_rejects_nan_duration() -> None:
     """Events with missing or NaN duration are rejected early (lightweight path)."""
     missing: tp.Any = {"type": "Motor", "start": 0.0, "timeline": "tl1"}

--- a/neuralset-repo/neuralset/events/transforms/test_transforms.py
+++ b/neuralset-repo/neuralset/events/transforms/test_transforms.py
@@ -272,20 +272,10 @@ def _make_sentence_events(
     add_sentence_to_words: bool = True,
 ) -> pd.DataFrame:
     """make dataset and apply Sentence transform"""
-    # context event
-    events = [
-        dict(
-            type="Text",
-            start=-0.1,
-            duration=len(words),
-            text=text,
-            timeline="foo",
-            language="english",
-        )
-    ]
-    # word events
+    common = dict(timeline="foo", language="english")
+    events = [dict(type="Text", start=-0.1, duration=len(words), text=text, **common)]
     events += [
-        dict(type="Word", start=float(i), duration=0.1, text=word, timeline="foo")
+        dict(type="Word", start=float(i), duration=0.1, text=word, **common)
         for i, word in enumerate(words)
     ]
     df = ns.events.standardize_events(pd.DataFrame(events))
@@ -301,6 +291,7 @@ def test_sentence_to_word_standard() -> None:
     df = _make_sentence_events(text, words)
     assert df.iloc[2].sentence == "he runs. "
     assert df.iloc[-1].sentence == "she eats"
+    assert (df[df.type == "Sentence"].language == "english").all()
 
     # tokenization
     words = "I don't run".split()

--- a/neuralset-repo/neuralset/events/transforms/text.py
+++ b/neuralset-repo/neuralset/events/transforms/text.py
@@ -182,7 +182,7 @@ class AddSentenceToWords(EventsTransform):
         events.loc[:, "sentence_char"] = np.nan
         events["sentence"] = ""
 
-        sentences = []
+        sentences: list[dict[str, tp.Any]] = []
         for context in contexts.itertuples():
             # find words that are enclosed in this context (requires unique timeline)
             encl = _segs.find_enclosed(
@@ -206,13 +206,9 @@ class AddSentenceToWords(EventsTransform):
                 index=sel,
             )
             events.loc[sel, info.columns] = info
-            # create sentence events
-            context_sentences = [s.to_dict() for s in _extract_sentences(events)]
-            subject = getattr(context, "subject", None)
-            if subject is not None:
-                for s in context_sentences:
-                    s["subject"] = subject
-            sentences.extend(context_sentences)
+            # create sentence events; standardize_events backfills BIDS/study
+            # from sibling rows in the same timeline.
+            sentences.extend(s.to_dict() for s in _extract_sentences(events))
         sentences = [s for s in sentences if s["text"] != MISSING_SENTENCE]
         sentence_df = pd.DataFrame(sentences)
         events = pd.concat([events, sentence_df], ignore_index=True)

--- a/neuralset-repo/neuralset/events/transforms/utils.py
+++ b/neuralset-repo/neuralset/events/transforms/utils.py
@@ -65,6 +65,9 @@ def _extract_sentences(events) -> list[ev.Sentence]:
                 text = w0.sentence
                 if not (isinstance(text, str) and text):
                     text = MISSING_SENTENCE
+                language = getattr(w0, "language", "")
+                if not isinstance(language, str):
+                    language = ""
                 sentences.append(
                     ev.Sentence(
                         start=w0.start - eps,
@@ -74,6 +77,7 @@ def _extract_sentences(events) -> list[ev.Sentence]:
                         + 2 * eps,
                         timeline=w0.timeline,
                         text=text,
+                        language=language,
                     )
                 )
                 words = []

--- a/neuralset-repo/neuralset/events/utils.py
+++ b/neuralset-repo/neuralset/events/utils.py
@@ -14,6 +14,7 @@ import warnings
 from collections import defaultdict
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 import ujson
 from exca.cachedict import DumpContext
@@ -218,6 +219,65 @@ def query_with_index(df: pd.DataFrame, query: str) -> pd.DataFrame:
     return result
 
 
+def _propagate_bids(df: pd.DataFrame) -> pd.DataFrame:
+    """Ensure BIDS entity and ``study`` columns exist as strings, fill
+    empty values from siblings in the same timeline, raise on conflicts.
+
+    Mutates ``df`` in place.
+    """
+    invariants = BIDS_ENTITIES + ("study",)
+    # Fast path: skip factorize when every column is fully populated or
+    # fully empty (nothing to propagate in either case).
+    any_work = False
+    for col in invariants:
+        if col not in df.columns:
+            df[col] = BIDS_ENTITY_DEFAULT
+        s = df[col].fillna(BIDS_ENTITY_DEFAULT).astype(str)
+        df[col] = s
+        has_empty = (s == BIDS_ENTITY_DEFAULT).any()
+        if not any_work and has_empty and (s != BIDS_ENTITY_DEFAULT).any():
+            any_work = True
+    if not any_work:
+        return df
+    tl_codes, _ = pd.factorize(df["timeline"], sort=False)
+    n_tls = int(tl_codes.max()) + 1 if len(tl_codes) else 0
+    for col in invariants:
+        codes, uniques = pd.factorize(df[col], sort=False)
+        empty_locs = np.where(uniques == BIDS_ENTITY_DEFAULT)[0]
+        empty_code = int(empty_locs[0]) if len(empty_locs) else -2
+        has = codes != empty_code
+        if not has.any():
+            continue
+        # First non-empty index per timeline: reverse-assign so smallest wins
+        # (equivalent to groupby(timeline)[col].first() but vectorized).
+        first_idx = np.full(n_tls, -1, dtype=np.int64)
+        wh = np.flatnonzero(has)
+        first_idx[tl_codes[wh[::-1]]] = wh[::-1]
+        has_per_tl = first_idx >= 0
+        safe = np.where(has_per_tl, first_idx, 0)
+        fill_codes = codes[safe[tl_codes]]
+        conflict = has & has_per_tl[tl_codes] & (codes != fill_codes)
+        if conflict.any():
+            bad = np.unique(tl_codes[conflict])
+            sample_mask = (tl_codes == bad[0]) & has
+            sample_vals = sorted(np.unique(uniques[codes[sample_mask]]).tolist())
+            sample_tl = df["timeline"].iloc[int(np.flatnonzero(sample_mask)[0])]
+            n = len(bad)
+            raise ValueError(
+                f"Column {col!r} has conflicting non-empty values within "
+                f"{n} timeline{'' if n == 1 else 's'}; BIDS entities and "
+                f"'study' must be invariant per timeline (transform wrote "
+                f"bad values, or timelines were merged). Example: "
+                f"timeline={sample_tl!r} has values={sample_vals}."
+            )
+        need = (~has) & has_per_tl[tl_codes]
+        if need.any():
+            arr = df[col].to_numpy().copy()
+            arr[need] = uniques[fill_codes[need]]
+            df[col] = arr
+    return df
+
+
 def standardize_events(
     events: pd.DataFrame,
     auto_fill: bool = True,
@@ -225,8 +285,10 @@ def standardize_events(
     """Normalize an events DataFrame into canonical form.
 
     Sorts by (timeline, start ASC, duration DESC) preserving first-seen
-    timeline order, fills BIDS entity columns, reorders columns, and adds
-    a computed ``stop`` column. Always returns a new DataFrame.
+    timeline order, propagates per-timeline invariants
+    (``subject``/``session``/``task``/``run``/``study``), reorders
+    columns, and adds a computed ``stop`` column. Always returns a new
+    DataFrame.
 
     Parameters
     ----------
@@ -300,10 +362,7 @@ def standardize_events(
         ignore_index=True,
     )
     df = df.drop(columns=["_tl_order"])
-    for entity in BIDS_ENTITIES:
-        if entity not in df.columns:
-            df[entity] = BIDS_ENTITY_DEFAULT
-        df[entity] = df[entity].fillna(BIDS_ENTITY_DEFAULT).astype(str)
+    df = _propagate_bids(df)
     important = ["type", "start", "duration", "timeline"] + list(BIDS_ENTITIES)
     columns = important + [c for c in df.columns if c not in important]
     df = df.loc[:, columns]

--- a/neuralset-repo/neuralset/utils.py
+++ b/neuralset-repo/neuralset/utils.py
@@ -78,7 +78,7 @@ def match_list(A, B, on_replace="delete"):
     return A_sel.astype(int), B_sel.astype(int)
 
 
-ISSUED_WARNINGS = set()
+ISSUED_WARNINGS: set[str] = set()
 
 
 def warn_once(message: str) -> None:


### PR DESCRIPTION
## What does this PR do?

transforms add events to the dataframes and those events can lack the bids field, this propagates it when needed

[full] = no missing bids
[half] = half missing fields for each timeline


shape | main | branch | ratio
-- | -- | -- | --
1k tl × 100 = 100k [full] | 11 ms | 12 ms | 1.15×
1k tl × 100 = 100k [half] | 11 ms | 43 ms | 4.06×
100k tl × 100 = 10M [full] | 1 969 ms | 2 034 ms | 1.03×
100k tl × 100 = 10M [half] | 1 790 ms | 5 110 ms | 2.85×

## Checklist

- [x] Tests added or updated
- [x] Docstrings updated for any changed public APIs
- [x] `pytest` and `mypy` pass locally
