### PR TITLE
CONTRIBUTING.md: add neuralbench, complete neuraltrain extras

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ The repo contains several packages, each in its own directory:
 | `neuralset-repo/` | **neuralset** | Core pipeline: events, extractors, segmenters, dataloaders |
 | `neuralfetch-repo/` | **neuralfetch** | Curated study catalog — download & access public brain datasets |
 | `neuraltrain-repo/` | **neuraltrain** | Deep learning tools: models, losses, metrics, optimizers |
+| `neuralbench-repo/` | **neuralbench** | Benchmark framework: tasks, models, training loops, evaluation |
 
 ## Ways to contribute
 
@@ -27,7 +28,8 @@ git clone https://github.com/facebookresearch/neuroai.git
 cd neuroai
 pip install -e 'neuralset-repo/.[dev,all]'
 pip install -e 'neuralfetch-repo/.[dev]'
-pip install -e 'neuraltrain-repo/.[dev]'
+pip install -e 'neuraltrain-repo/.[dev,all]'
+pip install -e 'neuralbench-repo/.[dev]'
 ```
 
 ## Pull requests


### PR DESCRIPTION
## What does this PR do?

**`neuralbench-repo` missing entirely** from the package table and the install block. `docs/conf.py:26,329` imports `neuralbench`, so Sphinx autosummary raises `ModuleNotFoundError: no module named neuralbench.callbacks` at `event 'builder-inited'` before any page renders.

**`neuraltrain[dev]` is insufficient for the docs.** The `[dev]` group only contains test/lint tooling (pytest, ruff, mypy). The docs tutorial `neuraltrain/tutorials/02_models/02_models.py` runs under sphinx-gallery during `make html` and imports `x_transformers` (via `neuraltrain.models.transformer.build` at line 91), which lives in the `[models]` extras (covered by `[all]`). So `make html` fails with `ModuleNotFoundError: No module named 'x_transformers'` after 19/20 gallery examples have run successfully.