### PR TITLE
Update cache clearing logic in study.py

### DIFF
--- a/neuralset-repo/neuralset/events/study.py
+++ b/neuralset-repo/neuralset/events/study.py
@@ -396,8 +396,8 @@ class Study(base.Step):
             raise RuntimeError(f"Directory is empty: {self.path}")
         logger.info(f"Success: Study downloaded to {self.path}.")
         _set_dir_permissions(self.path)
-        if hasattr(base.Step, "query"):  # exca >=0.5.24
-            base.Step.query(self).clear_cache()  # type: ignore[attr-defined]
+        if hasattr(base.Step, "lookup"):  # exca >=0.5.24
+            self.lookup().clear_cache()  # type: ignore[attr-defined]
         else:
             self.clear_cache()  # type: ignore
 

--- a/neuralset-repo/neuralset/events/study.py
+++ b/neuralset-repo/neuralset/events/study.py
@@ -396,7 +396,10 @@ class Study(base.Step):
             raise RuntimeError(f"Directory is empty: {self.path}")
         logger.info(f"Success: Study downloaded to {self.path}.")
         _set_dir_permissions(self.path)
-        self.clear_cache()
+        if hasattr(base.Step, "query"):  # exca >=0.5.24
+            base.Step.query(self).clear_cache()  # type: ignore[attr-defined]
+        else:
+            self.clear_cache()  # type: ignore
 
     def _cls_kwargs(self) -> dict[str, tp.Any]:
         """Descriptor for the study instance parametrization"""


### PR DESCRIPTION
## What does this PR do?

Change in the API with `exca >= 0.5.24`

## Checklist

- [x] Tests added or updated
- [x] Docstrings updated for any changed public APIs
- [x] `pytest` and `mypy` pass locally
