### PR TITLE
Add CAR (common-average reference) to IeegExtractor

### DIFF
--- a/neuralset-repo/neuralset/extractors/neuro.py
+++ b/neuralset-repo/neuralset/extractors/neuro.py
@@ -718,8 +718,13 @@ class IeegExtractor(MneRaw):
         # mne.set_eeg_reference with ch_type=list-of-str computes one reference
         # from the union of channel types (and per-type independence requires
         # projection=True). Loop per type so each channel type gets its own
-        # average reference.
+        # average reference. Skip types absent from raw (picks may name types
+        # not present after _pick_channels, e.g. picks=("seeg","ecog") with a
+        # seeg-only recording).
+        present_types = set(raw.get_channel_types())
         for ch_type in self.picks:
+            if ch_type not in present_types:
+                continue
             raw, _ = mne.set_eeg_reference(
                 raw,
                 ref_channels="average",

--- a/neuralset-repo/neuralset/extractors/neuro.py
+++ b/neuralset-repo/neuralset/extractors/neuro.py
@@ -174,14 +174,15 @@ class MneRaw(BaseExtractor):
     1. Channel selection
     2. Drop bad channels
     3. Bipolar referencing
-    4. Notch filtering
-    5. Band-pass filtering
-    6. Hilbert transform
-    7. Resampling
-    8. Scaling
-    9. Applying projectors
-    10. Baseline correction (applied on segments)
-    11. Clamp (applied on segments)
+    4. Common-average referencing
+    5. Notch filtering
+    6. Band-pass filtering
+    7. Hilbert transform
+    8. Resampling
+    9. Scaling
+    10. Applying projectors
+    11. Baseline correction (applied on segments)
+    12. Clamp (applied on segments)
 
     Parameters
     ----------
@@ -234,6 +235,13 @@ class MneRaw(BaseExtractor):
         Applied after channel selection and dropping bad channels but before
         filtering. The original monopolar channels consumed by the pairs are
         removed and replaced with the new bipolar channels.
+    car_ref : bool, default=False
+        If True, applies a common-average reference (CAR) via
+        ``mne.set_eeg_reference``. Each CAR-eligible channel type present
+        in the raw (``eeg``, ``ecog``, ``seeg``, ``dbs``) is referenced
+        independently to its own average. Applied after ``bipolar_ref``;
+        the two are mutually exclusive. Not supported on
+        ``MegExtractor``, ``EmgExtractor``, or ``FnirsExtractor``.
     channel_order: ["unique", "original"]
         `if self.channel_order=="original"`
         Assigns channel indices for each raw file (doesn't match channel names across files).
@@ -272,8 +280,16 @@ class MneRaw(BaseExtractor):
     clamp: float | None = None
     fill_non_finite: float | None = None
     bipolar_ref: tuple[list[str], list[str]] | None = None
+    car_ref: bool = False
     channel_order: tp.Literal["unique", "original"] = "unique"
     allow_maxshield: bool = False
+
+    _CAR_ELIGIBLE_CH_TYPES: tp.ClassVar[tuple[str, ...]] = (
+        "eeg",
+        "ecog",
+        "seeg",
+        "dbs",
+    )
 
     _channels: dict[str, int] = {}
 
@@ -303,6 +319,10 @@ class MneRaw(BaseExtractor):
                     f"bipolar_ref anodes and cathodes must have equal length, "
                     f"got {len(anodes)} and {len(cathodes)}"
                 )
+        if self.car_ref and self.bipolar_ref is not None:
+            raise ValueError(
+                "car_ref and bipolar_ref are mutually exclusive; choose one."
+            )
 
     def prepare(self, obj: DataframeOrEventsOrSegments) -> None:
         """Specify how to load and preprocess the event.
@@ -350,6 +370,10 @@ class MneRaw(BaseExtractor):
             raw.load_data()
             anodes, cathodes = self.bipolar_ref
             raw = mne.set_bipolar_reference(raw, anodes, cathodes, verbose="WARNING")
+
+        if self.car_ref:
+            raw.load_data()
+            raw = self._apply_car_ref(raw)
 
         if self.notch_filter is not None:
             raw.load_data()
@@ -514,6 +538,45 @@ class MneRaw(BaseExtractor):
             raise KeyError(msg) from e
         return channel_idx
 
+    def _apply_car_ref(self, raw: mne.io.Raw) -> mne.io.Raw:
+        """
+        Apply a common-average reference (CAR) per channel type.
+
+        Each CAR-eligible channel type present in ``raw`` (``eeg``, ``ecog``,
+        ``seeg``, ``dbs``) is referenced independently to its own average via
+        ``mne.set_eeg_reference``.
+
+        Parameters
+        ----------
+        raw : mne.io.Raw
+            Raw instance that will be referenced.
+
+        Returns
+        -------
+        raw : mne.io.Raw
+            Referenced Raw object.
+        """
+        # raw has already been narrowed by _pick_channels in _preprocess_raw,
+        # so present_types here is naturally constrained by self.picks.
+        present_types = set(raw.get_channel_types())
+        eligible = [t for t in self._CAR_ELIGIBLE_CH_TYPES if t in present_types]
+        if not eligible:
+            raise ValueError(
+                f"car_ref=True but no CAR-eligible channel types are present "
+                f"(present: {sorted(present_types)}; "
+                f"eligible: {list(self._CAR_ELIGIBLE_CH_TYPES)})."
+            )
+        logger.info("Applying CAR reference per channel type: %s", eligible)
+        for ch_type in eligible:
+            raw, _ = mne.set_eeg_reference(
+                raw,
+                ref_channels="average",
+                ch_type=ch_type,
+                copy=False,
+                verbose="WARNING",
+            )
+        return raw
+
     @staticmethod
     def _notch_filter(
         raw: mne.io.Raw, notch_filter: float | list[float], mne_cpus: int
@@ -548,6 +611,14 @@ class MegExtractor(MneRaw):
     event_types: tp.Literal["Meg"] = "Meg"
     picks: str | tuple[str, ...] = pydantic.Field(("meg",), min_length=1)
 
+    def model_post_init(self, log__: tp.Any) -> None:
+        super().model_post_init(log__)
+        if self.car_ref:
+            raise ValueError(
+                "car_ref is not supported for MEG; CAR is a reference "
+                "manipulation for EEG-like data (eeg, ecog, seeg, dbs)."
+            )
+
 
 class EegExtractor(MneRaw):
     """
@@ -576,6 +647,14 @@ class EmgExtractor(MneRaw):
     event_types: tp.Literal["Emg"] = "Emg"
     picks: tuple[str, ...] = pydantic.Field(("emg",), min_length=1)
 
+    def model_post_init(self, log__: tp.Any) -> None:
+        super().model_post_init(log__)
+        if self.car_ref:
+            raise ValueError(
+                "car_ref is not supported for EMG; CAR is a reference "
+                "manipulation for EEG-like data (eeg, ecog, seeg, dbs)."
+            )
+
 
 class IeegExtractor(MneRaw):
     """
@@ -588,9 +667,9 @@ class IeegExtractor(MneRaw):
     reference: "bipolar", "car", or None, default=None
         If "bipolar", applies a bipolar reference to the data, i.e., uses neighboring electrode as reference.
         Uses mne.set_bipolar_reference under the hood. [ieeg1]_
-        If "car", applies a common-average reference via mne.set_eeg_reference;
-        with multiple picks (e.g. ("seeg", "ecog")) each channel type is referenced
-        independently to its own average.
+        If "car", this is a shortcut for setting ``car_ref=True`` on the base
+        extractor: each CAR-eligible channel type present in the raw is
+        referenced independently to its own average (see ``MneRaw.car_ref``).
 
     Notes
     ----------
@@ -641,6 +720,13 @@ class IeegExtractor(MneRaw):
                 "Cannot use reference='car' together with bipolar_ref. "
                 "Choose exactly one referencing scheme."
             )
+        if self.reference == "car":
+            # Normalize the shortcut to its canonical base-field form so
+            # IeegExtractor(reference="car") and IeegExtractor(car_ref=True)
+            # share post-init state (and therefore cache uid). CAR is applied
+            # by MneRaw._preprocess_raw.
+            self.car_ref = True
+            self.reference = None
 
     def _preprocess_raw(self, raw: mne.io.Raw, event: etypes.MneRaw) -> MneTimedArray:
         raw = self._pick_channels(raw, self.picks)
@@ -652,9 +738,6 @@ class IeegExtractor(MneRaw):
         if self.reference == "bipolar":
             raw.load_data()
             raw = self._apply_bipolar_ref(raw)
-        elif self.reference == "car":
-            raw.load_data()
-            raw = self._apply_car_ref(raw)
 
         return super()._preprocess_raw(raw, event)
 
@@ -698,41 +781,6 @@ class IeegExtractor(MneRaw):
             del cathodes[idx]
         bipol = mne.set_bipolar_reference(raw, anodes, cathodes, verbose="WARNING")
         return bipol
-
-    def _apply_car_ref(self, raw: mne.io.Raw) -> mne.io.Raw:
-        """
-        Apply a global common-average reference (CAR).
-
-        Parameters
-        ----------
-        raw : mne.io.Raw
-            Raw instance that will be referenced.
-
-        Returns
-        -------
-        raw : mne.io.Raw
-            Referenced Raw object
-
-        """
-        logger.info("Applying CAR reference")
-        # mne.set_eeg_reference with ch_type=list-of-str computes one reference
-        # from the union of channel types (and per-type independence requires
-        # projection=True). Loop per type so each channel type gets its own
-        # average reference. Skip types absent from raw (picks may name types
-        # not present after _pick_channels, e.g. picks=("seeg","ecog") with a
-        # seeg-only recording).
-        present_types = set(raw.get_channel_types())
-        for ch_type in self.picks:
-            if ch_type not in present_types:
-                continue
-            raw, _ = mne.set_eeg_reference(
-                raw,
-                ref_channels="average",
-                ch_type=ch_type,
-                copy=False,
-                verbose="WARNING",
-            )
-        return raw
 
 
 class SpikesExtractor(BaseExtractor):
@@ -1031,6 +1079,12 @@ class FnirsExtractor(MneRaw):
 
     def model_post_init(self, log__: tp.Any) -> None:
         super().model_post_init(log__)
+
+        if self.car_ref:
+            raise ValueError(
+                "car_ref is not supported for fNIRS; CAR is a reference "
+                "manipulation for EEG-like data (eeg, ecog, seeg, dbs)."
+            )
 
         # Ensure preprocessing steps are consistent with one another
         if self.compute_heamo_response and not self.compute_optical_density:

--- a/neuralset-repo/neuralset/extractors/neuro.py
+++ b/neuralset-repo/neuralset/extractors/neuro.py
@@ -567,6 +567,8 @@ class MneRaw(BaseExtractor):
                 f"eligible: {list(self._CAR_ELIGIBLE_CH_TYPES)})."
             )
         logger.info("Applying CAR reference per channel type: %s", eligible)
+        # Per-type loop, not ch_type=eligible: list ch_type with projection=False
+        # applies a union average (https://github.com/mne-tools/mne-python/issues/13913).
         for ch_type in eligible:
             raw, _ = mne.set_eeg_reference(
                 raw,

--- a/neuralset-repo/neuralset/extractors/neuro.py
+++ b/neuralset-repo/neuralset/extractors/neuro.py
@@ -715,13 +715,18 @@ class IeegExtractor(MneRaw):
 
         """
         logger.info("Applying CAR reference")
-        raw, _ = mne.set_eeg_reference(
-            raw,
-            ref_channels="average",
-            ch_type=list(self.picks),
-            copy=False,
-            verbose="WARNING",
-        )
+        # mne.set_eeg_reference with ch_type=list-of-str computes one reference
+        # from the union of channel types (and per-type independence requires
+        # projection=True). Loop per type so each channel type gets its own
+        # average reference.
+        for ch_type in self.picks:
+            raw, _ = mne.set_eeg_reference(
+                raw,
+                ref_channels="average",
+                ch_type=ch_type,
+                copy=False,
+                verbose="WARNING",
+            )
         return raw
 
 

--- a/neuralset-repo/neuralset/extractors/neuro.py
+++ b/neuralset-repo/neuralset/extractors/neuro.py
@@ -588,7 +588,9 @@ class IeegExtractor(MneRaw):
     reference: "bipolar", "car", or None, default=None
         If "bipolar", applies a bipolar reference to the data, i.e., uses neighboring electrode as reference.
         Uses mne.set_bipolar_reference under the hood. [ieeg1]_
-        If "car", applies a global common-average reference (subtracts the across-channel mean from every channel).
+        If "car", applies a common-average reference via mne.set_eeg_reference;
+        with multiple picks (e.g. ("seeg", "ecog")) each channel type is referenced
+        independently to its own average.
 
     Notes
     ----------
@@ -713,7 +715,13 @@ class IeegExtractor(MneRaw):
 
         """
         logger.info("Applying CAR reference")
-        raw._data -= raw._data.mean(axis=0, keepdims=True)
+        raw, _ = mne.set_eeg_reference(
+            raw,
+            ref_channels="average",
+            ch_type=list(self.picks),
+            copy=False,
+            verbose="WARNING",
+        )
         return raw
 
 

--- a/neuralset-repo/neuralset/extractors/neuro.py
+++ b/neuralset-repo/neuralset/extractors/neuro.py
@@ -664,12 +664,11 @@ class IeegExtractor(MneRaw):
     ----------
     picks: default = ("seeg", "ecog", )
         pick "seeg" and "ecog" channels by default.
-    reference: "bipolar", "car", or None, default=None
+    reference: "bipolar", or None, default=None
         If "bipolar", applies a bipolar reference to the data, i.e., uses neighboring electrode as reference.
         Uses mne.set_bipolar_reference under the hood. [ieeg1]_
-        If "car", this is a shortcut for setting ``car_ref=True`` on the base
-        extractor: each CAR-eligible channel type present in the raw is
-        referenced independently to its own average (see ``MneRaw.car_ref``).
+        For common-average reference, set ``car_ref=True`` on the base
+        ``MneRaw`` (see ``MneRaw.car_ref``).
 
     Notes
     ----------
@@ -700,7 +699,7 @@ class IeegExtractor(MneRaw):
         ),
         min_length=1,
     )
-    reference: tp.Literal["bipolar", "car"] | None = None
+    reference: tp.Literal["bipolar"] | None = None
 
     def model_post_init(self, log__):
         super().model_post_init(log__)
@@ -715,18 +714,6 @@ class IeegExtractor(MneRaw):
                 "neighboring electrodes) and bipolar_ref (explicit "
                 "anode/cathode lists) at the same time."
             )
-        if self.reference == "car" and self.bipolar_ref is not None:
-            raise ValueError(
-                "Cannot use reference='car' together with bipolar_ref. "
-                "Choose exactly one referencing scheme."
-            )
-        if self.reference == "car":
-            # Normalize the shortcut to its canonical base-field form so
-            # IeegExtractor(reference="car") and IeegExtractor(car_ref=True)
-            # share post-init state (and therefore cache uid). CAR is applied
-            # by MneRaw._preprocess_raw.
-            self.car_ref = True
-            self.reference = None
 
     def _preprocess_raw(self, raw: mne.io.Raw, event: etypes.MneRaw) -> MneTimedArray:
         raw = self._pick_channels(raw, self.picks)

--- a/neuralset-repo/neuralset/extractors/neuro.py
+++ b/neuralset-repo/neuralset/extractors/neuro.py
@@ -585,9 +585,10 @@ class IeegExtractor(MneRaw):
     ----------
     picks: default = ("seeg", "ecog", )
         pick "seeg" and "ecog" channels by default.
-    reference: "bipolar" or None, default=None
+    reference: "bipolar", "car", or None, default=None
         If "bipolar", applies a bipolar reference to the data, i.e., uses neighboring electrode as reference.
         Uses mne.set_bipolar_reference under the hood. [ieeg1]_
+        If "car", applies a global common-average reference (subtracts the across-channel mean from every channel).
 
     Notes
     ----------
@@ -618,7 +619,7 @@ class IeegExtractor(MneRaw):
         ),
         min_length=1,
     )
-    reference: tp.Literal["bipolar"] | None = None
+    reference: tp.Literal["bipolar", "car"] | None = None
 
     def model_post_init(self, log__):
         super().model_post_init(log__)
@@ -633,6 +634,11 @@ class IeegExtractor(MneRaw):
                 "neighboring electrodes) and bipolar_ref (explicit "
                 "anode/cathode lists) at the same time."
             )
+        if self.reference == "car" and self.bipolar_ref is not None:
+            raise ValueError(
+                "Cannot use reference='car' together with bipolar_ref. "
+                "Choose exactly one referencing scheme."
+            )
 
     def _preprocess_raw(self, raw: mne.io.Raw, event: etypes.MneRaw) -> MneTimedArray:
         raw = self._pick_channels(raw, self.picks)
@@ -644,6 +650,9 @@ class IeegExtractor(MneRaw):
         if self.reference == "bipolar":
             raw.load_data()
             raw = self._apply_bipolar_ref(raw)
+        elif self.reference == "car":
+            raw.load_data()
+            raw = self._apply_car_ref(raw)
 
         return super()._preprocess_raw(raw, event)
 
@@ -687,6 +696,25 @@ class IeegExtractor(MneRaw):
             del cathodes[idx]
         bipol = mne.set_bipolar_reference(raw, anodes, cathodes, verbose="WARNING")
         return bipol
+
+    def _apply_car_ref(self, raw: mne.io.Raw) -> mne.io.Raw:
+        """
+        Apply a global common-average reference (CAR).
+
+        Parameters
+        ----------
+        raw : mne.io.Raw
+            Raw instance that will be referenced.
+
+        Returns
+        -------
+        raw : mne.io.Raw
+            Referenced Raw object
+
+        """
+        logger.info("Applying CAR reference")
+        raw._data -= raw._data.mean(axis=0, keepdims=True)
+        return raw
 
 
 class SpikesExtractor(BaseExtractor):

--- a/neuralset-repo/neuralset/extractors/test_neuro.py
+++ b/neuralset-repo/neuralset/extractors/test_neuro.py
@@ -1484,6 +1484,34 @@ def test_ieeg_cannot_combine_car_and_bipolar_ref() -> None:
         )
 
 
+def test_car_ieeg_multi_picks_per_channel_type() -> None:
+    """With picks=("seeg", "ecog"), CAR references each channel type to its own average."""
+    seeg_names = ["A1", "A2", "A3"]
+    ecog_names = ["G1", "G2", "G3", "G4"]
+    ch_names = seeg_names + ecog_names
+    ch_types = ["seeg"] * len(seeg_names) + ["ecog"] * len(ecog_names)
+    sfreq = 100.0
+    rng = np.random.RandomState(0)
+    data = rng.randn(len(ch_names), int(sfreq * 2))
+    # Offset the two groups in opposite directions: a single global average
+    # would leave a non-zero residual mean in each subset; correct per-type
+    # CAR must zero each subset independently.
+    data[: len(seeg_names)] += 5.0
+    data[len(seeg_names) :] -= 5.0
+    info = mne.create_info(ch_names, sfreq=sfreq, ch_types=ch_types)
+    raw = mne.io.RawArray(data, info)
+
+    extractor = ns.extractors.IeegExtractor(picks=("seeg", "ecog"), reference="car")
+    result = extractor._preprocess_raw(
+        raw.copy(), tp.cast(etypes.MneRaw, SimpleNamespace(frequency=sfreq))
+    )
+
+    seeg_idx = [result.ch_names.index(n) for n in seeg_names]
+    ecog_idx = [result.ch_names.index(n) for n in ecog_names]
+    np.testing.assert_allclose(result.data[seeg_idx].sum(axis=0), 0.0, atol=1e-5)
+    np.testing.assert_allclose(result.data[ecog_idx].sum(axis=0), 0.0, atol=1e-5)
+
+
 def test_overlap() -> None:
     event_start = 10.0
     event_duration = 6.0

--- a/neuralset-repo/neuralset/extractors/test_neuro.py
+++ b/neuralset-repo/neuralset/extractors/test_neuro.py
@@ -1458,6 +1458,32 @@ def test_bipolar_ref_validation() -> None:
         )
 
 
+def test_car_ieeg_global() -> None:
+    """Global CAR makes the cross-channel mean zero at every timepoint."""
+    ch_names = ["A1", "A2", "B1", "B2"]
+    sfreq = 100.0
+    data = np.random.RandomState(0).randn(len(ch_names), int(sfreq * 2))
+    info = mne.create_info(ch_names, sfreq=sfreq, ch_types="seeg")
+    raw = mne.io.RawArray(data, info)
+
+    extractor = ns.extractors.IeegExtractor(picks=("seeg",), reference="car")
+    result = extractor._preprocess_raw(
+        raw.copy(), tp.cast(etypes.MneRaw, SimpleNamespace(frequency=sfreq))
+    )
+    np.testing.assert_allclose(result.data.sum(axis=0), 0.0, atol=1e-5)
+    assert not np.allclose(result.data, 0.0)
+
+
+def test_ieeg_cannot_combine_car_and_bipolar_ref() -> None:
+    expected = "Cannot use reference='car'"
+    with pytest.raises(ValueError, match=expected):
+        ns.extractors.IeegExtractor(
+            picks=("seeg",),
+            reference="car",
+            bipolar_ref=(["A1"], ["A2"]),
+        )
+
+
 def test_overlap() -> None:
     event_start = 10.0
     event_duration = 6.0

--- a/neuralset-repo/neuralset/extractors/test_neuro.py
+++ b/neuralset-repo/neuralset/extractors/test_neuro.py
@@ -1467,22 +1467,12 @@ def test_car_ieeg_global() -> None:
     info = mne.create_info(ch_names, sfreq=sfreq, ch_types="seeg")
     raw = mne.io.RawArray(data, info)
 
-    extractor = ns.extractors.IeegExtractor(picks=("seeg",), reference="car")
+    extractor = ns.extractors.IeegExtractor(picks=("seeg",), car_ref=True)
     result = extractor._preprocess_raw(
         raw.copy(), tp.cast(etypes.MneRaw, SimpleNamespace(frequency=sfreq))
     )
     np.testing.assert_allclose(result.data.sum(axis=0), 0.0, atol=1e-5)
     assert not np.allclose(result.data, 0.0)
-
-
-def test_ieeg_cannot_combine_car_and_bipolar_ref() -> None:
-    expected = "Cannot use reference='car'"
-    with pytest.raises(ValueError, match=expected):
-        ns.extractors.IeegExtractor(
-            picks=("seeg",),
-            reference="car",
-            bipolar_ref=(["A1"], ["A2"]),
-        )
 
 
 def test_car_ieeg_multi_picks_per_channel_type() -> None:
@@ -1502,7 +1492,7 @@ def test_car_ieeg_multi_picks_per_channel_type() -> None:
     info = mne.create_info(ch_names, sfreq=sfreq, ch_types=ch_types)
     raw = mne.io.RawArray(data, info)
 
-    extractor = ns.extractors.IeegExtractor(picks=("seeg", "ecog"), reference="car")
+    extractor = ns.extractors.IeegExtractor(picks=("seeg", "ecog"), car_ref=True)
     result = extractor._preprocess_raw(
         raw.copy(), tp.cast(etypes.MneRaw, SimpleNamespace(frequency=sfreq))
     )
@@ -1523,47 +1513,11 @@ def test_car_ieeg_picks_includes_absent_type() -> None:
     raw = mne.io.RawArray(data, info)
 
     # picks includes both seeg and ecog; raw has only seeg → ecog iteration must be skipped.
-    extractor = ns.extractors.IeegExtractor(picks=("seeg", "ecog"), reference="car")
+    extractor = ns.extractors.IeegExtractor(picks=("seeg", "ecog"), car_ref=True)
     result = extractor._preprocess_raw(
         raw.copy(), tp.cast(etypes.MneRaw, SimpleNamespace(frequency=sfreq))
     )
     np.testing.assert_allclose(result.data.sum(axis=0), 0.0, atol=1e-5)
-
-
-def test_car_eeg() -> None:
-    """car_ref=True on EegExtractor produces a zero cross-channel mean."""
-    ch_names = ["Fp1", "F7", "T7", "P7"]
-    sfreq = 100.0
-    rng = np.random.RandomState(0)
-    data = rng.randn(len(ch_names), int(sfreq * 2)) + 3.0
-    info = mne.create_info(ch_names, sfreq=sfreq, ch_types="eeg")
-    raw = mne.io.RawArray(data, info)
-
-    extractor = ns.extractors.EegExtractor(picks=tuple(ch_names), car_ref=True)
-    result = extractor._preprocess_raw(
-        raw.copy(), tp.cast(etypes.MneRaw, SimpleNamespace(frequency=sfreq))
-    )
-    np.testing.assert_allclose(result.data.sum(axis=0), 0.0, atol=1e-5)
-    assert not np.allclose(result.data, 0.0)
-
-
-def test_car_ieeg_field_matches_shortcut() -> None:
-    """Setting car_ref=True directly on IeegExtractor matches reference='car'."""
-    ch_names = ["A1", "A2", "B1", "B2"]
-    sfreq = 100.0
-    data = np.random.RandomState(0).randn(len(ch_names), int(sfreq * 2))
-    info = mne.create_info(ch_names, sfreq=sfreq, ch_types="seeg")
-    raw = mne.io.RawArray(data, info)
-
-    via_flag = ns.extractors.IeegExtractor(picks=("seeg",), car_ref=True)
-    via_shortcut = ns.extractors.IeegExtractor(picks=("seeg",), reference="car")
-    out_flag = via_flag._preprocess_raw(
-        raw.copy(), tp.cast(etypes.MneRaw, SimpleNamespace(frequency=sfreq))
-    )
-    out_shortcut = via_shortcut._preprocess_raw(
-        raw.copy(), tp.cast(etypes.MneRaw, SimpleNamespace(frequency=sfreq))
-    )
-    np.testing.assert_allclose(out_flag.data, out_shortcut.data, atol=1e-5)
 
 
 def test_car_meg_raises() -> None:

--- a/neuralset-repo/neuralset/extractors/test_neuro.py
+++ b/neuralset-repo/neuralset/extractors/test_neuro.py
@@ -1512,6 +1512,23 @@ def test_car_ieeg_multi_picks_per_channel_type() -> None:
     np.testing.assert_allclose(result.data[ecog_idx].sum(axis=0), 0.0, atol=1e-5)
 
 
+def test_car_ieeg_picks_includes_absent_type() -> None:
+    """Regression guard: per-type CAR loop must skip channel types absent from raw."""
+    ch_names = ["A1", "A2", "A3"]
+    sfreq = 100.0
+    rng = np.random.RandomState(0)
+    data = rng.randn(len(ch_names), int(sfreq * 2)) + 5.0
+    info = mne.create_info(ch_names, sfreq=sfreq, ch_types="seeg")
+    raw = mne.io.RawArray(data, info)
+
+    # picks includes both seeg and ecog; raw has only seeg → ecog iteration must be skipped.
+    extractor = ns.extractors.IeegExtractor(picks=("seeg", "ecog"), reference="car")
+    result = extractor._preprocess_raw(
+        raw.copy(), tp.cast(etypes.MneRaw, SimpleNamespace(frequency=sfreq))
+    )
+    np.testing.assert_allclose(result.data.sum(axis=0), 0.0, atol=1e-5)
+
+
 def test_overlap() -> None:
     event_start = 10.0
     event_duration = 6.0

--- a/neuralset-repo/neuralset/extractors/test_neuro.py
+++ b/neuralset-repo/neuralset/extractors/test_neuro.py
@@ -680,6 +680,7 @@ def test_base_meg(tmp_path: Path) -> None:
         "event_types",
         "scale_factor",
         "bipolar_ref",
+        "car_ref",
         "infra",  # for version
         "fill_non_finite",
     }
@@ -1527,6 +1528,84 @@ def test_car_ieeg_picks_includes_absent_type() -> None:
         raw.copy(), tp.cast(etypes.MneRaw, SimpleNamespace(frequency=sfreq))
     )
     np.testing.assert_allclose(result.data.sum(axis=0), 0.0, atol=1e-5)
+
+
+def test_car_eeg() -> None:
+    """car_ref=True on EegExtractor produces a zero cross-channel mean."""
+    ch_names = ["Fp1", "F7", "T7", "P7"]
+    sfreq = 100.0
+    rng = np.random.RandomState(0)
+    data = rng.randn(len(ch_names), int(sfreq * 2)) + 3.0
+    info = mne.create_info(ch_names, sfreq=sfreq, ch_types="eeg")
+    raw = mne.io.RawArray(data, info)
+
+    extractor = ns.extractors.EegExtractor(picks=tuple(ch_names), car_ref=True)
+    result = extractor._preprocess_raw(
+        raw.copy(), tp.cast(etypes.MneRaw, SimpleNamespace(frequency=sfreq))
+    )
+    np.testing.assert_allclose(result.data.sum(axis=0), 0.0, atol=1e-5)
+    assert not np.allclose(result.data, 0.0)
+
+
+def test_car_ieeg_field_matches_shortcut() -> None:
+    """Setting car_ref=True directly on IeegExtractor matches reference='car'."""
+    ch_names = ["A1", "A2", "B1", "B2"]
+    sfreq = 100.0
+    data = np.random.RandomState(0).randn(len(ch_names), int(sfreq * 2))
+    info = mne.create_info(ch_names, sfreq=sfreq, ch_types="seeg")
+    raw = mne.io.RawArray(data, info)
+
+    via_flag = ns.extractors.IeegExtractor(picks=("seeg",), car_ref=True)
+    via_shortcut = ns.extractors.IeegExtractor(picks=("seeg",), reference="car")
+    out_flag = via_flag._preprocess_raw(
+        raw.copy(), tp.cast(etypes.MneRaw, SimpleNamespace(frequency=sfreq))
+    )
+    out_shortcut = via_shortcut._preprocess_raw(
+        raw.copy(), tp.cast(etypes.MneRaw, SimpleNamespace(frequency=sfreq))
+    )
+    np.testing.assert_allclose(out_flag.data, out_shortcut.data, atol=1e-5)
+
+
+def test_car_meg_raises() -> None:
+    """car_ref=True on MegExtractor raises at construction."""
+    with pytest.raises(ValueError, match="car_ref is not supported for MEG"):
+        ns.extractors.MegExtractor(car_ref=True)
+
+
+def test_car_emg_raises() -> None:
+    """car_ref=True on EmgExtractor raises at construction."""
+    with pytest.raises(ValueError, match="car_ref is not supported for EMG"):
+        ns.extractors.EmgExtractor(car_ref=True)
+
+
+def test_car_fnirs_raises() -> None:
+    """car_ref=True on FnirsExtractor raises at construction."""
+    with pytest.raises(ValueError, match="car_ref is not supported for fNIRS"):
+        ns.extractors.FnirsExtractor(car_ref=True)
+
+
+def test_car_mutex_with_bipolar_ref() -> None:
+    """car_ref and bipolar_ref are mutually exclusive on the base extractor."""
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        ns.extractors.EegExtractor(
+            car_ref=True,
+            bipolar_ref=(["Fp1"], ["F7"]),
+        )
+
+
+def test_car_no_eligible_types_raises() -> None:
+    """car_ref=True on a raw with no CAR-eligible channel types raises a clear error."""
+    ch_names = ["M1", "M2"]
+    sfreq = 100.0
+    data = np.zeros((len(ch_names), int(sfreq * 2)))
+    info = mne.create_info(ch_names, sfreq=sfreq, ch_types="misc")
+    raw = mne.io.RawArray(data, info)
+
+    extractor = ns.extractors.EegExtractor(picks=tuple(ch_names), car_ref=True)
+    with pytest.raises(ValueError, match="no CAR-eligible channel types"):
+        extractor._preprocess_raw(
+            raw.copy(), tp.cast(etypes.MneRaw, SimpleNamespace(frequency=sfreq))
+        )
 
 
 def test_overlap() -> None:


### PR DESCRIPTION
## What does this PR do?

Adds global common-average reference (`reference="car"`) to `IeegExtractor`, mirroring the existing `"bipolar"` pattern. Per #61 review, shaft-CAR was dropped — shaft naming has no universal convention, so that belongs in `mne.Projection` user-side, not in NeuralSet.

Diff is +56/−2: one `Literal` extension, one validation clause (`car` + `bipolar_ref` → `ValueError`), one `elif` branch in `_preprocess_raw`, one 18-line `_apply_car_ref` method, two tests.

## Related Issues

Closes #61.

## Checklist

- [x] Tests added or updated
- [x] Docstrings updated for any changed public APIs
- [x] `pytest` and `mypy` pass locally