### PR TITLE
Drop stale RELEASE_PLAN.md reference in image extractor error

### DIFF
--- a/neuralset-repo/neuralset/extractors/image.py
+++ b/neuralset-repo/neuralset/extractors/image.py
@@ -301,7 +301,7 @@ class HuggingFaceImage(BaseImage):
                 f"Model {self.model_name!r} returned hidden_states=None. "
                 "This is a known regression in transformers>=5 where some "
                 "encoders (CLIP, SAM, ViT) no longer collect intermediate "
-                "hidden states. See RELEASE_PLAN.md for the tracking item."
+                "hidden states."
             )
         return states  # type: ignore
 


### PR DESCRIPTION
## Summary
- `HuggingFaceImage._get_hidden_states` raises a `RuntimeError` when `hidden_states` is `None`, and the message ends with "See RELEASE_PLAN.md for the tracking item." That file does not exist in the repo, so the pointer dead-ends.
- Drop just the dangling sentence; the rest of the message (regression in `transformers>=5` for CLIP/SAM/ViT encoders) is unchanged.

## Test plan
- [ ] `ruff` / `ruff format` (pre-commit) pass locally.
- [ ] No other references to `RELEASE_PLAN.md` introduced.


Made with [Cursor](https://cursor.com)