### PR TITLE
Switch Excel engine from openpyxl to calamine (~6× faster) in Nieuwland and Chen studies

### DIFF
--- a/neuralfetch-repo/neuralfetch/studies/chen2023large.py
+++ b/neuralfetch-repo/neuralfetch/studies/chen2023large.py
@@ -84,7 +84,7 @@ class Chen2023Large(study.Study):
     description: tp.ClassVar[str] = """
         EEG recordings for 123 participants while viewing 28 video clips targeting nine categories of emotion
     """
-    requirements: tp.ClassVar[tuple[str, ...]] = ("openxl",)
+    requirements: tp.ClassVar[tuple[str, ...]] = ("python_calamine",)
     _info: tp.ClassVar[study.StudyInfo] = study.StudyInfo(
         num_timelines=123,
         num_subjects=123,
@@ -225,7 +225,7 @@ class Chen2023Large(study.Study):
     @cached_property
     def _stimulus_info(self) -> pd.DataFrame:
         stim_df = pd.read_excel(
-            self._get_filename("stimuli_info", {"": ""}), skipfooter=6
+            self._get_filename("stimuli_info", {"": ""}), skipfooter=6, engine="calamine"
         )
         rename_cols = {
             "Video index": "video_index",

--- a/neuralfetch-repo/neuralfetch/studies/chen2023large.py
+++ b/neuralfetch-repo/neuralfetch/studies/chen2023large.py
@@ -84,7 +84,7 @@ class Chen2023Large(study.Study):
     description: tp.ClassVar[str] = """
         EEG recordings for 123 participants while viewing 28 video clips targeting nine categories of emotion
     """
-    requirements: tp.ClassVar[tuple[str, ...]] = ("python_calamine",)
+    requirements: tp.ClassVar[tuple[str, ...]] = ("python-calamine",)
     _info: tp.ClassVar[study.StudyInfo] = study.StudyInfo(
         num_timelines=123,
         num_subjects=123,

--- a/neuralfetch-repo/neuralfetch/studies/nieuwland2018large.py
+++ b/neuralfetch-repo/neuralfetch/studies/nieuwland2018large.py
@@ -89,7 +89,7 @@ class Nieuwland2018Large(study.Study):
         "EEG recordings from 334 participants across 9 laboratories reading sentences in "
         "RSVP to test phonological predictions."
     )
-    requirements: tp.ClassVar[tuple[str, ...]] = ("openpyxl",)
+    requirements: tp.ClassVar[tuple[str, ...]] = ("python_calamine",)
     _info: tp.ClassVar[study.StudyInfo] = study.StudyInfo(
         num_timelines=335,
         num_subjects=295,
@@ -216,8 +216,13 @@ def _preproc_stimuli(path: str):
                 xls = archive.read("Stimuli/Sentence Materials/REPLICATION_ITEMS.xlsx")
                 f.write(xls)
 
-    delong = pd.read_excel(xls_file, sheet_name="Delong_Replication")
-    control = pd.read_excel(xls_file, sheet_name="Control_experiment")
+    sheets = pd.read_excel(
+        xls_file,
+        sheet_name=["Delong_Replication", "Control_experiment"],
+        engine="calamine",
+    )
+    delong = sheets["Delong_Replication"]
+    control = sheets["Control_experiment"]
 
     def badchar(string):
         for k in " :,=.":

--- a/neuralfetch-repo/neuralfetch/studies/nieuwland2018large.py
+++ b/neuralfetch-repo/neuralfetch/studies/nieuwland2018large.py
@@ -89,7 +89,7 @@ class Nieuwland2018Large(study.Study):
         "EEG recordings from 334 participants across 9 laboratories reading sentences in "
         "RSVP to test phonological predictions."
     )
-    requirements: tp.ClassVar[tuple[str, ...]] = ("python_calamine",)
+    requirements: tp.ClassVar[tuple[str, ...]] = ("python-calamine",)
     _info: tp.ClassVar[study.StudyInfo] = study.StudyInfo(
         num_timelines=335,
         num_subjects=295,


### PR DESCRIPTION
This PR replaces the default openpyxl engine with calamine for `pd.read_excel` calls in `Nieuwland2018Large._preproc_stimuli` and `Chen2023Large._stimulus_info`, and merges Nieuwland's two separate sheet reads into one call (one file open instead of two). Also fixes a pre-existing typo in `Chen2023Large.requirements`: `"openxl"` → `"python-calamine"`.


