### PR TITLE
Extends ChunkEvents to Fmri and MneRaw + improve safety

### DIFF
--- a/neuralbench-repo/neuralbench/transforms.py
+++ b/neuralbench-repo/neuralbench/transforms.py
@@ -136,13 +136,12 @@ class SimilaritySplit(_transf.EventsTransform):
             ].map(sentence_split_mapping)
 
             # Chunk Audio events based on Word segments
-            events = _transf.chunk_events(
-                events,
+            events = _transf.ChunkEvents(
                 event_type_to_chunk="Audio",
-                event_type_to_use="Word",
+                event_type_to_split_by="Word",
                 min_duration=3.0,
                 max_duration=120.0,
-            )
+            )(events)
 
         elif self.stim_event_type == "Keystroke":  # Designed for Levy2025Brain
             # For the Typing dataset, we need to transfer the clusters from the sentences to the

--- a/neuralset-repo/neuralset/events/etypes.py
+++ b/neuralset-repo/neuralset/events/etypes.py
@@ -415,63 +415,48 @@ class BaseSplittableEvent(BaseDataEvent):
         """Cache UID incorporating file path, offset and duration.
 
         Used as ``item_uid`` by extractors that process splittable events
-        (audio, video, MNE, fMRI). The format ensures that chunked and
-        non-chunked events for the same file get distinct cache entries.
-
-        Precision is millisecond (``:.3f``), which is sufficient
-        for all current chunking granularities.
+        (audio, video, MNE, fMRI) to ensures that chunked events get
+        distinct cache entries (millisecond granularity)
         """
         return f"{self.study_relative_path()}_{self.offset:.3f}_{self.duration:.3f}"
 
-    def _split(
-        self, timepoints: list[float], min_duration: float | None = None
-    ) -> tp.Sequence["BaseSplittableEvent"]:
-        """Split the event at specified timepoints into multiple sub-events.
-
-        Given n ordered timepoints, returns n + 1 corresponding events for each section.
+    def _split(self, timepoints: list[float]) -> tp.Sequence["BaseSplittableEvent"]:
+        """Given n ordered timepoints, returns n + 1 corresponding events for each section.
         Timepoints are relative to the event start, not the absolute timeline time.
 
         Parameters
         ----------
         timepoints : list of float
             Ordered list of split points in seconds (relative to event start)
-        min_duration : float, optional
-            Minimum duration in seconds for resulting segments. Timepoints that would
-            create segments shorter than this are filtered out.
 
         Returns
         -------
         list of BaseSplittableEvent
             List of new event instances representing each segment
 
-        Raises
-        ------
-        ValueError
-            If timepoints are not strictly increasing
+        Note
+        ----
+        The chunks partition the data exactly (no gaps/overlaps). To this end,
+        each timepoint is snapped to the sample grid via ``round()``, so a
+        non-aligned value can shift by up to half a sample period.
 
         Examples
         --------
         .. code-block:: python
 
             audio = Audio(start=0, timeline="t1", filepath="audio.wav", duration=10.0)
-            # Split at 3s and 7s with minimum 2s segments
-            segments = audio._split([3.0, 7.0], min_duration=2.0)
+            segments = audio._split([3.0, 7.0])
             # Returns 3 sounds: [0-3s], [3-7s], [7-10s]
         """
-        # keep only timepoints that are within the sound duration
+        # keep only timepoints strictly inside the event
         timepoints = [t for t in timepoints if 0 < t < self.duration]
         timepoints = sorted(set(timepoints))
-        if min_duration:
-            round_decimals = max(0, int(-np.floor(np.log10(1 / self.frequency))) + 1)
-            delta_before = np.round(np.diff(timepoints, prepend=0), round_decimals)
-            delta_after = np.round(
-                np.diff(timepoints, append=self.duration), round_decimals
-            )
-            timepoints = [
-                t
-                for t, db, da in zip(timepoints, delta_before, delta_after)
-                if db >= min_duration and da >= min_duration
-            ]
+        # Snap so that each chunk's ``read()`` does not round
+        # offset/duration independently and drift by a sample
+        if self.frequency:
+            sr = Frequency(self.frequency)
+            timepoints = sorted({sr.to_sec(sr.to_ind(t)) for t in timepoints})
+            timepoints = [t for t in timepoints if 0 < t < self.duration]
         timepoints.append(self.duration)
 
         start = 0.0
@@ -885,7 +870,8 @@ class MneRaw(BaseSplittableEvent):
     """Brain recording saved as MNE Raw object.
 
     Base class for neurophysiological recordings (MEG, EEG, etc.) that can be
-    loaded using MNE-Python.
+    loaded using MNE-Python. Supports chunking via :meth:`_split` inherited
+    from :class:`BaseSplittableEvent`.
 
     Parameters
     ----------
@@ -899,6 +885,8 @@ class MneRaw(BaseSplittableEvent):
       (use for FIF files with nonzero first_samp)
     - Guards against ``start=0`` when ``raw.first_samp > 0``
     - Subject ID is cast to string to handle numeric IDs from dataframes
+    - Like Audio/Video, :meth:`read` crops the raw to ``[offset, offset+duration]``
+      so that only the chunk's data is loaded into memory.
 
     Examples
     --------
@@ -918,10 +906,6 @@ class MneRaw(BaseSplittableEvent):
         return float("nan") if v == "auto" else v
 
     def model_post_init(self, log__: tp.Any) -> None:
-        if self.offset:
-            raise ValueError(
-                "offset is not supported for MneRaw events (chunking not yet implemented)"
-            )
         self.subject = self.subject
         if self._missing_duration_or_frequency() or pd.isna(self.start):
             raw = self.read()
@@ -959,6 +943,20 @@ class MneRaw(BaseSplittableEvent):
             kwargs["clean_names"] = True
         with utils.ignore_all():
             return mne.io.read_raw(self.filepath, **kwargs)
+
+    def read(self) -> tp.Any:
+        # Crop here, not in ``_read`` — ``_read`` is bypassed under ``_special_loader``.
+        raw = super().read()
+        if self.duration:
+            sr = Frequency(raw.info["sfreq"])
+            start_samp = sr.to_ind(self.offset)
+            end_samp = min(start_samp + sr.to_ind(self.duration), raw.n_times)
+            if start_samp > 0 or end_samp < raw.n_times:  # chunked
+                # copy first — ``crop`` mutates in place, and ``super().read()``
+                # could return a cached/shared Raw (e.g. via ``_special_loader``).
+                raw = raw.copy()
+                raw.crop(tmin=sr.to_sec(start_samp), tmax=sr.to_sec(end_samp - 1))
+        return raw
 
 
 class Meg(MneRaw):
@@ -1058,6 +1056,10 @@ class Fmri(BaseSplittableEvent):
     the **left hemisphere** (containing ``hemi-L``); the right hemisphere
     is derived automatically by replacing ``hemi-L`` with ``hemi-R``.
 
+    Supports chunking via :meth:`_split` inherited from
+    :class:`BaseSplittableEvent`; :meth:`read` crops to
+    ``[offset, offset+duration]`` so chunks load only their own slice.
+
     Parameters
     ----------
     subject : str
@@ -1084,10 +1086,6 @@ class Fmri(BaseSplittableEvent):
     spec: FmriSpec | None = None
 
     def model_post_init(self, log__: tp.Any) -> None:
-        if self.offset:
-            raise ValueError(
-                "offset is not supported for Fmri events (chunking not yet implemented)"
-            )
         if not self.frequency or pd.isna(self.frequency):
             raise ValueError(
                 "Frequency must be provided for Fmri event: "
@@ -1097,6 +1095,18 @@ class Fmri(BaseSplittableEvent):
         if not self.duration or pd.isna(self.duration):
             self.duration = self.read().shape[-1] / self.frequency
         super().model_post_init(log__)
+
+    def read(self) -> tp.Any:
+        # Crop here, not in ``_read`` — ``_read`` is bypassed under ``_special_loader``.
+        img = super().read()
+        if not self.duration:  # autofill
+            return img
+        sr = Frequency(self.frequency)
+        start_vol = sr.to_ind(self.offset)
+        end_vol = start_vol + sr.to_ind(self.duration)
+        if start_vol == 0 and end_vol >= img.shape[-1]:
+            return img
+        return img.slicer[..., start_vol:end_vol]  # chunked
 
     def _read(self) -> tp.Any:
         import nibabel

--- a/neuralset-repo/neuralset/events/test_etypes.py
+++ b/neuralset-repo/neuralset/events/test_etypes.py
@@ -317,8 +317,11 @@ def test_split_event(tmp_path: Path) -> None:
         dict(type="Audio", start=1, timeline="whatever", filepath=fp, duration=np.nan)
     )
 
-    res = event._split(timepoints=[0, 1.49, 2 * 1.49, 3 * 1.49], min_duration=1.49)
-    assert {ev.offset for ev in res} == {0, 1.49, 2 * 1.49}
+    res = event._split(timepoints=[1.49, 2 * 1.49])
+    # ``_split`` snaps timepoints to sample boundaries (see etypes), so 1.49
+    # at 120 Hz lands on ~179/120 = 1.4916..., off by <1 sample.
+    offsets = sorted(ev.offset for ev in res)
+    assert offsets == pytest.approx([0, 1.49, 2 * 1.49], abs=1 / Fs)
 
 
 def test_validate_events_bids_nan_recovery() -> None:
@@ -449,3 +452,19 @@ def test_fmri_surface_read(tmp_path: Path) -> None:
     )
     assert event.read().get_fdata().shape == (n_v * 2, n_t)
     assert event.read_mask() is None
+
+
+def test_fmri_volume_chunked_read(tmp_path: Path) -> None:
+    """Chunked Fmri reads (no SpecialLoader) partition the volume exactly.
+
+    Feeds ``_split`` off-grid timepoints to exercise sample-grid snapping:
+    at TR=2s, 5.7s and 14.3s must snap to 6.0s and 14.0s (nearest sample).
+    SpecialLoader-backed path is covered by ``test_transforms.test_chunk_neuro``.
+    """
+    event = make_fmri_event(tmp_path, space="T1w", frequency=0.5)
+    full = event.read().get_fdata()
+    chunks = event._split([5.7, 14.3])
+    assert [c.start for c in chunks] == [0.0, 6.0, 14.0]
+    assert [c.duration for c in chunks] == [6.0, 8.0, 6.0]
+    concat = np.concatenate([ch.read().get_fdata() for ch in chunks], axis=-1)
+    np.testing.assert_array_equal(concat, full)

--- a/neuralset-repo/neuralset/events/transforms/__init__.py
+++ b/neuralset-repo/neuralset/events/transforms/__init__.py
@@ -4,13 +4,14 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""Re-export module: all transform classes live in submodules
-(basic, text, splitting, chunking, audio, video)."""
+"""Re-export module: all transform classes live in submodules"""
 
-from ..study import EventsTransform as EventsTransform  # noqa: F401
-from ..utils import query_with_index as query_with_index  # noqa: F401
-from .audio import *  # noqa: F401,F403
-from .basic import *  # noqa: F401,F403
-from .chunking import *  # noqa: F401,F403
-from .splitting import *  # noqa: F401,F403
-from .text import *  # noqa: F401,F403
+# flake8: noqa: F401, F403
+# ruff: noqa: F401, F403
+from ..study import EventsTransform as EventsTransform
+from ..utils import query_with_index as query_with_index
+from .audio import *
+from .basic import *
+from .chunking import *
+from .splitting import *
+from .text import *

--- a/neuralset-repo/neuralset/events/transforms/chunking.py
+++ b/neuralset-repo/neuralset/events/transforms/chunking.py
@@ -9,67 +9,283 @@ import typing as tp
 import numpy as np
 import pandas as pd
 
+from .. import etypes as ev
 from ..study import EventsTransform
-from .utils import chunk_events
+
+Tiling = tp.Literal["equal", "max"]
+
+
+class _Section(tp.NamedTuple):
+    """Contiguous ``[start, stop)`` span, label-homogeneous by construction."""
+
+    start: float
+    stop: float
+
+    @property
+    def duration(self) -> float:
+        return self.stop - self.start
+
+    def tile(
+        self, min_duration: float, max_duration: float, tiling: Tiling
+    ) -> list["_Section"]:
+        """Partition into sub-sections per ``tiling`` strategy.
+
+        ``"equal"``: maximally equal-sized chunks, each in ``[min_duration, max_duration]``.
+        Raises if ``2 * min_duration > max_duration`` (bounds unsatisfiable) or
+        if the section is shorter than ``min_duration``.
+
+        ``"max"``: chunks of exactly ``max_duration`` plus a trailing partial
+        covering the remainder. ``min_duration`` is unused here.
+        """
+        tol = ChunkEvents._SAMPLE_GRID_TOL
+        if tiling == "equal":
+            if 2 * min_duration > max_duration + tol:
+                raise ValueError(
+                    f"min_duration={min_duration} must be <= "
+                    f"max_duration/2={max_duration / 2} so uniform tiling "
+                    f"always yields chunks in [min_duration, max_duration]"
+                )
+            if self.duration < min_duration - tol:
+                raise ValueError(
+                    f"section [{self.start:.3f}, {self.stop:.3f}) (duration "
+                    f"{self.duration:.3f}s) cannot tile into "
+                    f"[{min_duration}, {max_duration}]. Set ``min_duration`` "
+                    f"below the shortest section, merge short same-split runs "
+                    f"in ``event_type_to_split_by`` before chunking, or use "
+                    f'``tiling="max"`` to drop short trailing pieces instead.'
+                )
+            n = max(1, int(np.ceil(self.duration / max_duration - tol)))
+            dur = self.duration / n
+            return [
+                _Section(self.start + i * dur, self.start + (i + 1) * dur)
+                for i in range(n)
+            ]
+        # tiling == "max"
+        if not np.isfinite(max_duration):
+            return [self]  # post-filter handles ``duration < min_duration``
+        n_full = int(self.duration / max_duration + tol)
+        out = [
+            _Section(self.start + i * max_duration, self.start + (i + 1) * max_duration)
+            for i in range(n_full)
+        ]
+        if self.duration - n_full * max_duration > tol:
+            out.append(_Section(self.start + n_full * max_duration, self.stop))
+        return out
+
+
+def _build_sections(
+    event: ev.BaseSplittableEvent,
+    use_rows: pd.DataFrame | None = None,
+    allow_sample_leakage: bool = False,
+) -> list[_Section]:
+    """Partition ``event`` into label-homogeneous sections.
+
+    Boundaries sit at the midpoint of the silence gap between consecutive
+    rows of different ``split``. First section absorbs any leading silence;
+    last extends to ``event.start + event.duration``. Returns a single
+    section covering the whole event when ``use_rows`` is None/empty.
+
+    Raises if a split transition leaves less than ``1 / frequency`` of
+    silence (unless ``allow_sample_leakage=True``): ``event._split``'s
+    nearest-grid snap of the midpoint isn't guaranteed to stay in the gap
+    below that, so a labeled sample could end up in the wrong chunk.
+    """
+    tol = ChunkEvents._SAMPLE_GRID_TOL
+    e_start, e_stop = event.start, event.start + event.duration
+    if use_rows is None or len(use_rows) == 0:
+        return [_Section(e_start, e_stop)]
+    mask = (use_rows.start + use_rows.duration > e_start + tol) & (
+        use_rows.start < e_stop - tol
+    )
+    rows = use_rows[mask].sort_values("start").reset_index(drop=True)
+    if rows.empty:
+        return [_Section(e_start, e_stop)]
+    freq = float(event.frequency)
+    min_gap = 1.0 / freq if freq > 0 else 0.0
+    splits = rows.split.astype(str)
+    boundaries = [e_start]
+    for i in range(1, len(rows)):
+        if splits.iloc[i] == splits.iloc[i - 1]:
+            continue
+        prev_stop = rows.iloc[i - 1].start + rows.iloc[i - 1].duration
+        next_start = rows.iloc[i].start
+        if not allow_sample_leakage and next_start - prev_stop < min_gap - tol:
+            raise ValueError(
+                f"label leakage: split transition at {prev_stop:.3f}s "
+                f"({splits.iloc[i - 1]!r} → {splits.iloc[i]!r}) must leave "
+                f"at least 1/frequency = {min_gap:.3f}s of silence at {freq} Hz. "
+                f"Pass ``allow_sample_leakage=True`` to accept up to 1 sample "
+                f"of mislabeling at the boundary."
+            )
+        boundaries.append((prev_stop + next_start) / 2)
+    boundaries.append(e_stop)
+    return [
+        _Section(boundaries[i], boundaries[i + 1]) for i in range(len(boundaries) - 1)
+    ]
 
 
 class ChunkEvents(EventsTransform):
+    """Chunk long events into shorter events.
+
+    Typical use: keep long recordings under a deep-learning model's memory
+    budget (e.g. Wav2Vec).
+
+    Parameters
+    ----------
+    event_type_to_chunk : str
+        Splittable event type to chunk. Any
+        :class:`~neuralset.events.etypes.BaseSplittableEvent` subclass
+        (Audio, Video, Meg, Eeg, Fmri, ...).
+    max_duration : float, default=``np.inf``
+        Upper bound on chunk duration in seconds.
+    min_duration : float, default=0.0
+        Lower bound on chunk duration. Behavior when impossible depends on
+        ``tiling`` (see below).
+    tiling : {"max", "equal"}, default ``"max"``
+        How each section is sub-divided:
+
+        - ``"max"``: emit chunks of exactly ``max_duration`` until the section
+          is exhausted; the trailing partial chunk is dropped iff its
+          duration is ``< min_duration``.
+        - ``"equal"``: equal-sized chunks, each in ``[min_duration, max_duration]``.
+          Requires ``2 * min_duration <= max_duration``. Raises if a section
+          is shorter than ``min_duration``.
+    event_type_to_split_by : str, optional
+        Align chunk boundaries with train/val/test labels carried by another
+        event type's ``split`` column, to avoid label leakage at split
+        transitions. When set, chunk boundaries follow same-``split`` runs
+        and each run is sub-tiled per ``tiling``.
+    allow_sample_leakage : bool, default=False
+        Only relevant when ``event_type_to_split_by`` is set. If True,
+        accept up to 1 sample of mislabeling at split transitions with
+        sub-sample silence gaps (e.g. coarse-TR Fmri); otherwise raise.
+
+    Invariants
+    ----------
+    - Every emitted chunk has ``duration >= min_duration``.
+    - Every emitted chunk is label-homogeneous when ``event_type_to_split_by`` is set.
+    - ``"equal"`` is lossless: concatenation reconstructs the input event.
+    - ``"max"`` may silently drop sections/trailing pieces shorter than ``min_duration``.
+
+    Raises
+    ------
+    ValueError
+        - ``tiling="equal"`` and a same-``split`` run shorter than ``min_duration``
+          (cannot tile without losing labeled data — switch to ``tiling="max"``
+          to drop short pieces instead).
+        - Two consecutive differently-labeled runs are less than one
+          sample apart (cannot separate without label leakage).
+
+    Examples
+    --------
+    Simple chunking (each ``x`` = one sample; sound sampled at 1 Hz)::
+
+        input:
+            max_duration: 4
+            events:
+                sound:   [x x x x x x x x x x x x x]     # 13 s
+        out (tiling="max"):   # tile with max duration + trail
+            events:
+                sound1:  [x x x x]
+                sound2:          [x x x x]
+                sound3:                  [x x x x]
+                sound4:                          [x]     # short trailing chunk
+        out (tiling="equal"):  # tile with ~ same length
+            events:
+                sound1:  [x x x]
+                sound2:        [x x x]
+                sound3:              [x x x x]           # 3.25 s ideal, rounded to whole sample
+                sound4:                      [x x x]
+
+    With train/test split labels::
+
+        input:
+            max_duration: 4
+            event_type_to_split_by: Word
+            events:
+                sound:   [x x x x x x x x x x x x x]     # 13 s
+                word:     1 1 1 - - 2 2 2 2 2 2 2 2      # 1=test, 2=train, -=silence
+        out (tiling="equal"):                            # split-aligned, then sub-tiled
+            events:
+                sound1:  [x x x x]                       # test run
+                sound2:          [x x x]                 # train run, 3 equal chunks
+                sound3:                [x x x]
+                sound4:                      [x x x]
     """
-    This functions chunks long events (audio or video) into shorter events. It supports two modes:
 
-    1. **Duration-based chunking** (if `event_type_to_use` is None):
-
-       - Each event of type `event_type_to_chunk` is split into consecutive chunks with duration between `min_duration` and `max_duration`.
-       - Ensures that no chunk exceeds `max_duration`.
-
-    This avoids OOM errors when feeding long events into a deep learning model (e.g. Wav2Vec).
-
-        Example::
-
-            input:
-                min_duration: 2
-                max_duration: 3
-                events:
-                    sound:    [.......]
-            out:
-                events:
-                    sound1:   [...]
-                    sound2:      [....]
-
-    2. **Split-based chunking** (if :code:`event_type_to_use` is not :code:`None`):
-
-       - Events of type :code:`event_type_to_chunk` are split according to the train/val/test splits of :code:`event_type_to_use`.
-       - Ensures each chunk respects :code:`min_duration` and :code:`max_duration`.
-       - Prevents data leakage when processing long events with a deep learning model (e.g. Wav2Vec.
-       - Requires that the splits for :code:`event_type_to_use` are already assigned.
-
-        Example::
-
-            input:
-                max_duration: 2
-                event_type_to_use: Word
-                events:
-                    sound:    [.......]
-                    word :    [1112233]
-            out:
-                events:
-                    sound1:   [..]
-                    sound2:     [.]
-                    sound3:      [..]
-                    sound4:        [..]
-
-    """
-
-    event_type_to_chunk: tp.Literal["Audio", "Video"]
-    event_type_to_use: str | None = None
-    min_duration: float | None = None
+    event_type_to_chunk: str
+    event_type_to_split_by: str | None = None
+    min_duration: float = 0.0
     max_duration: float = np.inf
+    tiling: Tiling = "max"
+    allow_sample_leakage: bool = False
+
+    # Slack for sample-aligned float compares; absorbs float noise without
+    # masking real mismatches so long as ``event.frequency << 1 / tol``
+    # (i.e. tol << one sample period). Enforced per-event in ``_chunk_timeline``.
+    _SAMPLE_GRID_TOL: tp.ClassVar[float] = 1e-6
+
+    def model_post_init(self, log__: object) -> None:
+        super().model_post_init(log__)
+        cls = ev.Event._CLASSES.get(self.event_type_to_chunk)
+        if cls is None or not issubclass(cls, ev.BaseSplittableEvent):
+            splittable = [
+                n
+                for n, c in ev.Event._CLASSES.items()
+                if issubclass(c, ev.BaseSplittableEvent)
+            ]
+            raise ValueError(
+                f"{self.event_type_to_chunk!r} is not a splittable event type. "
+                f"Use one of {splittable}"
+            )
+        if (
+            self.tiling == "equal"
+            and 2 * self.min_duration > self.max_duration + self._SAMPLE_GRID_TOL
+        ):
+            raise ValueError(
+                f"min_duration={self.min_duration} must be <= "
+                f"max_duration/2={self.max_duration / 2} for tiling='equal' "
+                f"so chunks always land in [min_duration, max_duration]"
+            )
 
     def _run(self, events: pd.DataFrame) -> pd.DataFrame:
-        return chunk_events(
-            events,
-            self.event_type_to_chunk,
-            self.event_type_to_use,
-            self.min_duration,
-            self.max_duration,
+        if self.event_type_to_split_by is not None and "split" not in events.columns:
+            raise RuntimeError("Events must have a split column")
+        chunked = [self._chunk_timeline(df) for _, df in events.groupby("timeline")]
+        return pd.concat(chunked).reset_index(drop=True)
+
+    def _chunk_timeline(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Return one timeline's events with target rows replaced by their chunks."""
+        to_chunk = df.type == self.event_type_to_chunk
+        if not any(to_chunk):
+            return df
+        use_rows = (
+            df.loc[df.type == self.event_type_to_split_by]
+            if self.event_type_to_split_by is not None
+            else None
         )
+        rows = df.loc[to_chunk]
+        added: list[dict] = []
+        for row in rows.itertuples(index=False):
+            event = ev.BaseSplittableEvent.from_dict(row)
+            if event.frequency * self._SAMPLE_GRID_TOL >= 1:
+                raise ValueError(
+                    f"event frequency {event.frequency} Hz is too high for the "
+                    f"sample-grid tolerance {self._SAMPLE_GRID_TOL}s "
+                    f"(>= 1 sample period); boundary compares would mask real "
+                    f"1-sample mismatches."
+                )
+            sections = _build_sections(event, use_rows, self.allow_sample_leakage)
+            tiled = [
+                sub
+                for s in sections
+                for sub in s.tile(self.min_duration, self.max_duration, self.tiling)
+            ]
+            rel_tps = [t.start - event.start for t in tiled[1:]]
+            pieces = event._split(rel_tps)
+            added.extend(
+                p.to_dict()
+                for p in pieces
+                if p.duration >= self.min_duration - self._SAMPLE_GRID_TOL
+            )
+        return pd.concat([df.drop(rows.index), pd.DataFrame(added)])

--- a/neuralset-repo/neuralset/events/transforms/test_chunking.py
+++ b/neuralset-repo/neuralset/events/transforms/test_chunking.py
@@ -1,0 +1,276 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import functools
+import types
+import typing as tp
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import neuralset as ns
+from neuralset.events import etypes
+from neuralset.events import transforms as _transf
+from neuralset.events.transforms import chunking
+
+from .test_transforms import create_wav
+
+
+@pytest.mark.parametrize(
+    "tiling,min_d,max_d,expected",
+    [
+        ("equal", 0.0, 3.0, [(0.0, 2.5), (2.5, 5.0), (5.0, 7.5), (7.5, 10.0)]),
+        ("equal", 0.0, np.inf, [(0.0, 10.0)]),  # no cap → single chunk
+        ("equal", 2.5, 3.0, "min_duration"),  # 2*min > max
+        ("equal", 20.0, 50.0, "cannot tile"),  # section < min_duration
+        ("max", 0.0, 3.0, [(0.0, 3.0), (3.0, 6.0), (6.0, 9.0), (9.0, 10.0)]),
+        ("max", 0.0, np.inf, [(0.0, 10.0)]),
+        ("max", 0.0, 5.0, [(0.0, 5.0), (5.0, 10.0)]),  # exact fit, no trailing
+        # "max" doesn't enforce 2*min<=max — trailing is the caller's to drop.
+        ("max", 5.0, 3.0, [(0.0, 3.0), (3.0, 6.0), (6.0, 9.0), (9.0, 10.0)]),
+        ("max", 20.0, 50.0, [(0.0, 10.0)]),  # section < max → whole-section trailing
+    ],
+)
+def test_section_tile(
+    tiling: chunking.Tiling,
+    min_d: float,
+    max_d: float,
+    expected: list[tuple[float, float]] | str,
+) -> None:
+    section = chunking._Section(0.0, 10.0)
+    if isinstance(expected, str):
+        with pytest.raises(ValueError, match=expected):
+            section.tile(min_d, max_d, tiling)
+    else:
+        assert section.tile(min_d, max_d, tiling) == expected
+
+
+def _words(*specs: tuple[float, float, str]) -> pd.DataFrame:
+    """Build a Word-events DataFrame from ``(start, duration, split)`` tuples."""
+    const = dict(type="Word", text="a", language="english", timeline="foo")
+    dicts = [dict(start=s, duration=d, split=split, **const) for s, d, split in specs]
+    return pd.DataFrame(dicts)
+
+
+@pytest.mark.parametrize(
+    "frequency,rows,allow_leakage,expected",
+    [
+        # No / empty use_rows → one section spanning the whole event.
+        (100.0, None, False, [(0.0, 10.0)]),
+        (100.0, _words(), False, [(0.0, 10.0)]),
+        # 3 train + 1 test word: coalesce same-split, split at midpoint of gap [3.5, 5.0].
+        (
+            100.0,
+            _words(
+                (0.5, 1.0, "train"),
+                (1.5, 1.0, "train"),
+                (2.5, 1.0, "train"),
+                (5.0, 2.0, "test"),
+            ),
+            False,
+            [(0.0, 4.25), (4.25, 10.0)],
+        ),
+        # Fmri-at-coarse-TR: TR=2 s ≫ 0.3 s gap
+        # no sample-aligned boundary separates the differently-labeled runs
+        (0.5, _words((1.0, 0.5, "train"), (1.8, 0.5, "test")), False, "label leakage"),
+        (
+            0.5,
+            _words((1.0, 0.5, "train"), (1.8, 0.5, "test")),
+            True,
+            [(0.0, 1.65), (1.65, 10.0)],
+        ),
+    ],
+)
+def test_build_sections(
+    frequency: float,
+    rows: pd.DataFrame | None,
+    allow_leakage: bool,
+    expected: list[tuple[float, float]] | str,
+) -> None:
+    event: tp.Any = types.SimpleNamespace(start=0.0, duration=10.0, frequency=frequency)
+    if isinstance(expected, str):
+        with pytest.raises(ValueError, match=expected):
+            chunking._build_sections(event, rows, allow_leakage)
+    else:
+        assert chunking._build_sections(event, rows, allow_leakage) == expected
+
+
+@pytest.mark.parametrize(
+    "kwargs,match",
+    [
+        (dict(event_type_to_chunk="NotAnEvent"), "not a splittable"),
+        (
+            dict(
+                event_type_to_chunk="Audio",
+                min_duration=1.0,
+                max_duration=1.5,
+                tiling="equal",
+            ),
+            "min_duration",
+        ),
+        # Same config under ``"max"`` is accepted (post-filter handles it).
+        (
+            dict(event_type_to_chunk="Audio", min_duration=1.0, max_duration=1.5),
+            None,
+        ),
+    ],
+)
+def test_chunk_events_config_validation(kwargs: dict, match: str | None) -> None:
+    """``model_post_init`` rejects (or accepts when ``match is None``)."""
+    if match is None:
+        _transf.ChunkEvents(**kwargs)
+    else:
+        with pytest.raises(ValueError, match=match):
+            _transf.ChunkEvents(**kwargs)
+
+
+def test_chunk_meg_first_samp() -> None:
+    """Chunking a FIF with ``raw.first_samp > 0`` (Mne2013Sample has first_samp ≈ 6k).
+
+    Verifies ``Event.start``/``offset`` bookkeeping when the source event's
+    absolute start is nonzero, and that ``MneRaw.read()`` crops relative to the
+    data (not absolute time) so chunks partition the full raw exactly — both in
+    sample count and in content (catches off-by-one or wrong-position crops).
+    """
+    events = ns.Study(name="Mne2013Sample", path=ns.CACHE_FOLDER).run()
+    row = events.loc[events.type == "Meg"].iloc[0]
+    event = etypes.Meg.from_dict(row)
+    assert event.start > 0, "Mne2013Sample should have first_samp > 0"
+    full_data = event.read().get_data()
+    target_dur = event.duration / 3.3  # off-grid to exercise boundary snapping
+    chunked = _transf.ChunkEvents(event_type_to_chunk="Meg", max_duration=target_dur)(
+        events
+    )
+    chunks = [
+        etypes.Meg.from_dict(r)
+        for r in chunked.loc[chunked.type == "Meg"].itertuples(index=False)
+    ]
+    # tiling="max": floor(3.3) = 3 chunks at target_dur + 1 trailing remainder.
+    assert len(chunks) == 4
+    assert chunks[0].start == event.start and chunks[0].offset == 0.0
+    # First 3 are exactly target_dur (within sample-snap); last is the remainder.
+    for ch in chunks[:3]:
+        assert ch.duration == pytest.approx(target_dur, abs=1 / event.frequency)
+    for a, b in zip(chunks, chunks[1:]):
+        assert b.start == pytest.approx(a.start + a.duration)
+        assert b.offset == pytest.approx(a.offset + a.duration)
+    last_chunk_stop = chunks[-1].start + chunks[-1].duration
+    assert last_chunk_stop == pytest.approx(event.start + event.duration)
+    # ``1/freq`` = sample-snap slack; ``1e-6`` = float-compare tol.
+    assert all(ch.duration <= target_dur + 1 / event.frequency + 1e-6 for ch in chunks)
+    # chunk data concatenates to the full raw exactly — proves the crop is
+    # contiguous (no gap/overlap) and positioned correctly relative to first_samp.
+    concat = np.concatenate([ch.read().get_data() for ch in chunks], axis=1)
+    assert concat.shape == full_data.shape
+    np.testing.assert_array_equal(concat, full_data)
+
+
+@pytest.mark.parametrize(
+    # Meg + Fnirs (low sfreq, custom ``_read``) + Fmri cover all chunking routes.
+    # ``expected_by_word`` = number of same-``split`` runs: Meg has 2 (train/test);
+    # Fnirs + Fmri have 4 each (train/test/val/train).
+    "study_name,expected_by_word",
+    [("Test2023Meg", 2), ("Test2024Fnirs", 4), ("Test2023Fmri", 4)],
+)
+def test_chunk_events_neuro(
+    test_data_path: Path, study_name: str, expected_by_word: int
+) -> None:
+    """Word-split and max-duration chunking: counts, label homogeneity, exact partition.
+
+    Label-leakage safety is especially critical for Fmri at coarse TR, where
+    naive boundary rounding could pull a TR across a split transition.
+    Non-SpecialLoader partitioning is covered by ``test_chunk_meg_first_samp``
+    (MneRaw) and ``test_etypes.test_fmri_volume_chunked_read`` (Fmri).
+    """
+    event_type = study_name.removeprefix("Test")[4:]  # drop "Test" + YYYY
+    events = ns.Study(
+        name=study_name, path=test_data_path, query="timeline_index<1"
+    ).run()
+
+    chunker = functools.partial(_transf.ChunkEvents, event_type_to_chunk=event_type)
+    by_word = chunker(event_type_to_split_by="Word")(events)
+    word_chunks = by_word[by_word.type == event_type]
+    assert len(word_chunks) == expected_by_word
+    words = events[events.type == "Word"]
+    for c_start, c_dur in zip(word_chunks.start, word_chunks.duration):
+        c_stop = c_start + c_dur
+        overlap = words[(words.start + words.duration > c_start) & (words.start < c_stop)]
+        labels = set(overlap.split.astype(str))
+        assert len(labels) <= 1, (
+            f"label leakage in chunk [{c_start}, {c_stop}): overlapping splits {labels}"
+        )
+
+    # Off-grid cap to avoid accidental alignment with the sample period.
+    row = events.loc[events.type == event_type].iloc[0]
+    event = etypes.BaseSplittableEvent.from_dict(row)
+    max_duration = row.duration / 2.7
+    # ``"equal"`` here; ``"max"`` covered by ``test_chunk_meg_first_samp``.
+    by_max = chunker(max_duration=max_duration, tiling="equal")(events)
+    rows = by_max.loc[by_max.type == event_type].itertuples(index=False)
+    chunks = [etypes.BaseSplittableEvent.from_dict(r) for r in rows]
+    assert len(chunks) == 3  # ceil(2.7)
+    # Chunk reads must partition the underlying data exactly (catches gaps/overlaps
+    # from independent rounding). Time is the last axis for both MneRaw and Fmri.
+    get = "get_fdata" if event_type == "Fmri" else "get_data"
+    full = getattr(event.read(), get)()
+    concat = np.concatenate([getattr(c.read(), get)() for c in chunks], axis=-1)
+    np.testing.assert_array_equal(concat, full)
+
+
+@pytest.mark.parametrize(
+    "audio_duration,expected_durations,expected_offsets",
+    [
+        (22.0, [10.0, 10.0], [0.0, 10.0]),  # trailing 2 s < min_duration → dropped
+        (25.0, [10.0, 10.0, 5.0], [0.0, 10.0, 20.0]),  # trailing 5 s >= min → kept
+    ],
+)
+def test_chunk_events_max_trailing(
+    tmp_path: Path,
+    audio_duration: float,
+    expected_durations: list[float],
+    expected_offsets: list[float],
+) -> None:
+    fp = tmp_path / "noise.wav"
+    create_wav(fp, fs=44100, duration=audio_duration)
+    events = pd.DataFrame([dict(type="Audio", start=0, timeline="t", filepath=fp)])
+    events = ns.events.standardize_events(events)
+    out = _transf.ChunkEvents(
+        event_type_to_chunk="Audio",
+        max_duration=10.0,
+        min_duration=3.0,
+        tiling="max",
+    )(events)
+    chunks = out[out.type == "Audio"].sort_values("start")
+    assert list(chunks.duration) == expected_durations
+    assert list(chunks.offset) == expected_offsets
+
+
+def test_chunk_events_chained_time_then_split(tmp_path: Path) -> None:
+    """Chaining time-based then split-based chunking on one Audio event.
+
+    The first pass (``max_duration``) produces multiple target events in
+    the same timeline; the second pass (``event_type_to_split_by``) must then
+    clip sections per event — else a section preceding a later sub-event
+    trips a false leakage guard.
+    """
+    fp = tmp_path / "s.wav"
+    create_wav(fp, fs=44100, duration=18.0)
+    audio = pd.DataFrame([dict(type="Audio", start=1.0, timeline="foo", filepath=fp)])
+    words = _words(
+        *[(s, 1.0, "train" if s < 12 else "test") for s in (0, 1, 2, 6, 11, 14, 17)]
+    )
+    events = ns.events.standardize_events(pd.concat([audio, words], ignore_index=True))
+    events = _transf.ChunkEvents(event_type_to_chunk="Audio", max_duration=9.0)(events)
+    events = _transf.ChunkEvents(
+        event_type_to_chunk="Audio", event_type_to_split_by="Word"
+    )(events)
+    audio = events[events.type == "Audio"].sort_values("start")
+    # Midpoint between last train word stop (12) and first test word start (14).
+    assert list(audio.start) == [1.0, 10.0, 13.0]
+    # Offsets index into the original 18s file (start=1 ⇒ offset = start - 1).
+    assert list(audio.offset) == [0.0, 9.0, 12.0]

--- a/neuralset-repo/neuralset/events/transforms/test_transforms.py
+++ b/neuralset-repo/neuralset/events/transforms/test_transforms.py
@@ -914,53 +914,6 @@ def test_deterministic_splitter() -> None:
     assert splitter("10101001010101") == "train"
 
 
-def test_chunk_events(tmp_path: Path) -> None:
-    fp = tmp_path / "noise.wav"
-    create_wav(fp, fs=44100, duration=10.1)
-    sound = dict(type="Audio", start=0, timeline="foo", filepath=fp)
-    words = [
-        dict(
-            type="Word",
-            text="a",
-            start=i,
-            duration=i + 1,
-            language="english",
-            timeline="foo",
-            split="train" if i % 2 else "test",
-        )
-        for i in range(11)
-    ]
-    events_list = [sound] + words
-    events = pd.DataFrame(events_list)
-    events = ns.events.standardize_events(events)
-
-    events2 = _tutils.chunk_events(
-        events, event_type_to_chunk="Audio", event_type_to_use="Word"
-    )
-    sounds = events2[events2["type"] == "Audio"]
-    assert len(sounds) == 11
-    assert all(sounds.offset.values == list(range(11)))
-
-    events3 = _tutils.chunk_events(
-        events, event_type_to_chunk="Audio", event_type_to_use="Word", min_duration=0.5
-    )
-    sounds = events3[events3["type"] == "Audio"]
-    assert len(sounds) == 10
-
-    events4 = _tutils.chunk_events(events, event_type_to_chunk="Audio", max_duration=2)
-    sounds = events4[events4["type"] == "Audio"]
-    assert len(sounds) == 6
-
-    events5 = _tutils.chunk_events(
-        events,
-        event_type_to_chunk="Audio",
-        max_duration=2,
-        min_duration=0.5,
-    )
-    sounds = events5[events5["type"] == "Audio"]
-    assert len(sounds) == 5
-
-
 def test_cluster_assignment():
     test_cases = [
         {

--- a/neuralset-repo/neuralset/events/transforms/utils.py
+++ b/neuralset-repo/neuralset/events/transforms/utils.py
@@ -15,9 +15,7 @@ from dataclasses import dataclass
 from functools import lru_cache
 
 import numpy as np
-import pandas as pd
 
-from neuralset import segments as _segs
 from neuralset import utils as _ns_utils
 
 from .. import etypes as ev
@@ -273,81 +271,6 @@ def _merge_sentences(
         else:
             out[-1].append(s)
     return out
-
-
-# ---------------------------------------------------------------------------
-# chunking helpers
-# ---------------------------------------------------------------------------
-
-
-def chunk_events(
-    events: pd.DataFrame,
-    event_type_to_chunk: tp.Literal["Audio", "Video"],
-    event_type_to_use: str | None = None,
-    min_duration: float | None = None,
-    max_duration: float = np.inf,
-):
-    """
-    Split events into smaller chunks.
-    If event_type_to_use is None, the events are chunked into chunks of max_duration.
-    If event_type_to_use is not None, the events are chunked based on the train/val/test splits of the event_type_to_use, ensuring that each chunk has duration between min_duration and max_duration.
-    """
-
-    added_events: list[dict] = []
-    dropped_rows: list[int] = []
-    ns_event_type_to_chunk = ev.Event._CLASSES.get(event_type_to_chunk)
-    if ns_event_type_to_chunk is None or not hasattr(ns_event_type_to_chunk, "_split"):
-        raise ValueError(f"Event type {event_type_to_chunk} is not splittable")
-    if event_type_to_use is not None:
-        if "split" not in events.columns:
-            raise RuntimeError("Events must have a split column")
-
-    for _, df in events.groupby("timeline"):
-        to_chunk = df.type == event_type_to_chunk
-        if not any(to_chunk):
-            continue
-        if event_type_to_use is None:  # chunk based on max_duration
-            segments = _segs.list_segments(
-                df,
-                triggers=to_chunk,
-                duration=max_duration,
-                stride=max_duration,
-                stride_drop_incomplete=False,
-            )
-            timepoints = [segment.start for segment in segments]
-        else:  # chunk based on train/test split of the event_type_to_use
-            timepoints = []
-            events_to_use = df.loc[events.type == event_type_to_use].copy()
-            previous = events_to_use.copy().shift(1)
-            split_change = events_to_use.split.astype(str) != previous.split.astype(str)
-            events_to_use["section"] = np.cumsum(split_change.values)  # type: ignore
-            for _, section in events_to_use.groupby("section"):
-                start, end = (
-                    section.iloc[0].start,
-                    section.iloc[-1].start + section.iloc[-1].duration,
-                )
-                timepoints.extend(np.arange(start, end, max_duration))
-
-        events_to_chunk = df.loc[to_chunk]
-        dropped_rows.extend(events_to_chunk.index)
-        for row in events_to_chunk.itertuples(index=False):
-            event_to_chunk = ns_event_type_to_chunk.from_dict(row)
-            new_events = event_to_chunk._split(
-                [t - event_to_chunk.start for t in timepoints], min_duration
-            )  # type: ignore
-            for new_event in new_events:
-                new_event_dict = new_event.to_dict()
-                # add the columns which were removed by event.from_dict() except index
-                for k, v in row._asdict().items():  # type: ignore
-                    if k not in new_event_dict:
-                        new_event_dict[k] = v
-                added_events.append(new_event_dict)
-
-    out_events = events.copy()
-    out_events.drop(dropped_rows, inplace=True)
-    out_events = pd.concat([out_events, pd.DataFrame(added_events)])
-    out_events.reset_index(drop=True, inplace=True)
-    return out_events
 
 
 # ---------------------------------------------------------------------------

--- a/neuralset-repo/neuralset/extractors/neuro.py
+++ b/neuralset-repo/neuralset/extractors/neuro.py
@@ -91,7 +91,7 @@ class MneTimedArray(TimedArray):
             "lowpass": raw.info["lowpass"],
         }
         if start is None:
-            start = raw.first_samp / raw.info["sfreq"]
+            start = float(raw.first_samp / raw.info["sfreq"])
         return cls(
             data=data,
             frequency=raw.info["sfreq"],
@@ -432,16 +432,14 @@ class MneRaw(BaseExtractor):
         freq = ta.frequency
         ch_names = ta.ch_names
 
-        # Relocate cached data to the event's timeline position and extract window
         ta = ta.with_start(event.start)
         tdata = ta.overlap(start=window_start, duration=window_stop - window_start)
-        tdata.data = np.asarray(
-            tdata.data
-        )  # materialize ContiguousMemmap before arithmetic
+        # exca caches return ContiguousMemmap which needs
+        # materializing to operate upon:
+        tdata.data = np.asarray(tdata.data)
         if self.scale_factor is not None:
             tdata.data = tdata.data * self.scale_factor
 
-        # Apply baseline to the data
         if self.baseline is not None:
             baseline_duration = self.baseline[1] - self.baseline[0]
             base = tdata.overlap(start + self.baseline[0], baseline_duration).data
@@ -1728,7 +1726,7 @@ class FmriExtractor(BaseExtractor):
     ) -> tp.Iterable[TimedArray]:
         if self.padding == "auto" and self._padding is None:
             raise RuntimeError("Fmri.prepare needs to be called to compute auto padding")
-        for _event, ta in zip(events, self._get_data(events)):
+        for ta in self._get_data(events):
             data = ta.data
             if self._padding is not None:
                 if data.ndim != 2:


### PR DESCRIPTION
Extends ChunkEvents to Fmri and MneRaw (was audio/video only), with label-safety guarantees when chunking by split, and adds a `tiling` parameter to pick between two partitioning strategies.

Changes
- `etypes.py`: `MneRaw.read` / `Fmri.read` crop to `[offset, offset+duration]` (lazy: `raw.crop` / `img.slicer`); `_split` snaps timepoints to the sample grid so sibling chunks don't drift. Dropped the `offset → raise` guards.
- `transforms/chunking.py`: rewritten `ChunkEvents` + `_Section` helper. `_build_sections` places section boundaries at the midpoint of the silence gap between same-split runs, and raises if the gap is < 1 sample (leakage). Each section is then tiled per `tiling`:
  - `"max"` (default): chunks of exactly `max_duration` + a trailing partial, dropped iff `< min_duration`. Matches main's historical direct-chunking behavior.
  - `"equal"`: uniform tiling, every chunk in `[min_duration, max_duration]`; requires `2 * min_duration <= max_duration`. Lossless — concatenation reconstructs the input event.
