### PR TITLE
Fix digest type for SHA-256 in download.py

### DIFF
--- a/neuralfetch-repo/neuralfetch/download.py
+++ b/neuralfetch-repo/neuralfetch/download.py
@@ -801,8 +801,7 @@ class Dryad(BaseDownload):
                 continue
             print(f"  [{i}/{len(files)}] Downloading {name}...")
             digest_type = f.get("digestType", "")
-            if digest_type == "sha-256":
-                digest_type = "sha256"
+            digest_type = digest_type.replace("-", "") # sha-256 -> sha256
             digest = f.get("digest", "")
             file_hash = f"{digest_type}:{digest}" if digest and digest_type else None
             download_file(

--- a/neuralfetch-repo/neuralfetch/download.py
+++ b/neuralfetch-repo/neuralfetch/download.py
@@ -801,6 +801,8 @@ class Dryad(BaseDownload):
                 continue
             print(f"  [{i}/{len(files)}] Downloading {name}...")
             digest_type = f.get("digestType", "")
+            if digest_type == "sha-256":
+                digest_type = "sha256"
             digest = f.get("digest", "")
             file_hash = f"{digest_type}:{digest}" if digest and digest_type else None
             download_file(

--- a/neuralfetch-repo/neuralfetch/download.py
+++ b/neuralfetch-repo/neuralfetch/download.py
@@ -801,7 +801,8 @@ class Dryad(BaseDownload):
                 continue
             print(f"  [{i}/{len(files)}] Downloading {name}...")
             digest_type = f.get("digestType", "")
-            digest_type = digest_type.replace("-", "") # sha-256 -> sha256
+            # sha-256 -> sha256
+            digest_type = digest_type.replace("-", "")
             digest = f.get("digest", "")
             file_hash = f"{digest_type}:{digest}" if digest and digest_type else None
             download_file(


### PR DESCRIPTION
## What does this PR do?

Small fix when the digest type is incorrect in the files downloaded from Dryad for the conventions of `hashlib`.