### PR TITLE
docs: keep theme toggle clickable on subpages

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -78,6 +78,16 @@
     display: none !important;
 }
 
+/* Float-right Furo icon row hosts the visible theme-toggle. Article
+   headings (h1/h2/h3) below use `position: relative`, which makes
+   their full-width boxes paint above the float's stacking layer and
+   swallow clicks on the toggle. Promote this container to its own
+   positioned layer so the toggle stays clickable on every page. */
+.content-icon-container {
+    position: relative;
+    z-index: 1;
+}
+
 /* ===== HERO TAGLINE MAIN (Aggressive Glitch) ===== */
 
 .hero-section-root {


### PR DESCRIPTION
## Summary

The Furo light/dark/auto button was unclickable on every docs page below the root (e.g. `neuralset/index.html`, `neuralfetch/index.html`, …). Only the root `index.html` worked because it has no early `<h1>` to overlay the toggle.

Root cause: `.content-icon-container` (the float-right Furo icon row that hosts the visible `.theme-toggle-content` button) sat in the float stacking layer, while the article headings below it had been promoted to `position: relative` for the gradient underline/bar accents. A positioned element with `z-index: auto` paints **above** floats in the same stacking context, so the full-width `<h1>` box swallowed every click aimed at the toggle.

Fix: lift `.content-icon-container` into its own positioned layer (`position: relative; z-index: 1;`) in `docs/_static/custom.css`. No JS / template changes; the gradient h1 underline is unchanged.

Verified by rebuilding the docs locally, serving them, and using headless Chrome to assert that `document.elementFromPoint(...)` on the toggle's centre lands inside the `.theme-toggle` button (not the H1) and that `btn.click()` cycles `document.body.dataset.theme` on `neuralset/`, `neuralfetch/`, `neuralbench/`, `neuraltrain/` indexes, `neuralset/install.html`, a sphinx-gallery page, and the root `index.html`.

## Test plan

- [ ] CI: `build-docs` succeeds.
- [ ] Manual: open the deployed docs (or a local `make -C docs html` build) and click the moon/sun toggle on the NeuralSet, NeuralFetch, NeuralBench, NeuralTrain landing pages and on a tutorial gallery page. The page theme should cycle auto / light / dark and persist across navigation. The h1 gradient underline should still render exactly as before.

Made with [Cursor](https://cursor.com)