### PR TITLE
docs: clean up landing page footer + equalize package card heights

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1461,14 +1461,14 @@ body[data-theme="dark"] .result-item {
     display: flex;
     flex-wrap: wrap;
     gap: 1rem;
-    align-items: flex-start;
+    align-items: stretch;
     justify-content: center;
     margin: 0 auto;
 }
 
 .package-card-wrapper {
     display: flex;
-    align-items: flex-start;
+    align-items: stretch;
     gap: 1rem;
 }
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -78,10 +78,6 @@
 
    <div class="metadata-panel">
      <p style="font-size: 0.85rem; color: var(--color-foreground-muted); margin: 0;">
-       Copyright © Meta Platforms, Inc. and affiliates |
-       Made with <a href="https://www.sphinx-doc.org/" style="color: inherit; text-decoration: none;">Sphinx</a> and
-       <a href="https://pradyunsg.me" style="color: inherit; text-decoration: none;">@pradyunsg</a>'s
-       <a href="https://github.com/pradyunsg/furo" style="color: inherit; text-decoration: none;">Furo</a> |
        <a href="https://github.com/facebookresearch/neuroai" style="color: inherit; text-decoration: none;"><i class="fab fa-github"></i></a>
      </p>
    </div>


### PR DESCRIPTION
## Summary

Two small landing-page polish fixes:

- **Drop duplicate footer text.** The metadata panel under the package cards repeats the copyright and "Made with Sphinx and @pradyunsg's Furo" line that Furo already renders in the page footer. Removed the text; kept the GitHub icon (it lives closer to the content and is a useful nudge).
- **Equal-height package cards.** `.packages-cards` and `.package-card-wrapper` used `align-items: flex-start`, so each card hugged its own content. The NeuralSet card has a longer tagline that wraps to an extra line, which made it visibly taller than the others. Switching to `align-items: stretch` makes every card in a row match the tallest one.

## Test plan

- [ ] `cd docs && make html` and open `_build/html/index.html`
- [ ] Confirm the "Copyright … Made with Sphinx and @pradyunsg's Furo" line no longer appears under the package cards
- [ ] Confirm Furo's footer still shows the copyright, Sphinx/Furo credit, and GitHub icon
- [ ] Confirm the NeuralSet, NeuralFetch, NeuralTrain, NeuralBench, and Exca cards all render at the same height in a single row
- [ ] Resize to <=1024px and <=768px and confirm the responsive layouts still look right


Made with [Cursor](https://cursor.com)