### PR TITLE
Support full local neuralbench runs via --local

### DIFF
--- a/neuralbench-repo/neuralbench/cli.py
+++ b/neuralbench-repo/neuralbench/cli.py
@@ -86,7 +86,7 @@ def run_benchmark(
     debug : bool
         Run locally with a reduced config (2 epochs, 5 batches).
     local : bool
-        Run locally without applying the reduced debug-mode config.
+        Run locally using the full config; unlike --debug, do not reduce epochs or batches.
     force : bool
         Force re-running experiments.
     retry : bool

--- a/neuralbench-repo/neuralbench/cli.py
+++ b/neuralbench-repo/neuralbench/cli.py
@@ -52,6 +52,7 @@ def run_benchmark(
     downstream_wrapper: str | list[str] | None = None,
     grid: bool = False,
     debug: bool = False,
+    local: bool = False,
     force: bool = False,
     retry: bool = False,
     prepare: bool = False,
@@ -84,6 +85,8 @@ def run_benchmark(
         Expand the task-specific hyperparameter grid.
     debug : bool
         Run locally with a reduced config (2 epochs, 5 batches).
+    local : bool
+        Run locally without applying the reduced debug-mode config.
     force : bool
         Force re-running experiments.
     retry : bool
@@ -124,7 +127,7 @@ def run_benchmark(
 
     _ensure_initialized()
     _validate_inputs(device, task, model, downstream_wrapper)
-    _warn_slurm_partition(debug, prepare=prepare, download=download)
+    _warn_slurm_partition(debug or local, prepare=prepare, download=download)
 
     # --- base config & grid ---
     default_config = load_yaml_config(DEFAULTS_DIR / "config.yaml")
@@ -183,6 +186,14 @@ def run_benchmark(
             quiet=plot_cached,
             retry=retry,
         )
+        if local:
+            for task_config in task_configs:
+                task_config["infra.cluster"] = None
+                if "data" in task_config:
+                    task_config["data.neuro.infra.cluster"] = None
+                    target_cfg = task_config.get("data", {}).get("target", {})
+                    if isinstance(target_cfg, dict) and "infra" in target_cfg:
+                        task_config["data.target.infra.cluster"] = None
         configs.extend(task_configs)
 
     if download:
@@ -197,7 +208,7 @@ def run_benchmark(
 
     agg = BenchmarkAggregator(
         experiments=configs,
-        debug=debug,
+        debug=debug or local,
     )
 
     if not plot_cached:
@@ -246,6 +257,11 @@ def run_benchmark_cli() -> None:
         "--debug",
         action="store_true",
         help="Run in debug mode (locally and smaller config, with infra.mode='force').",
+    )
+    parser.add_argument(
+        "--local",
+        action="store_true",
+        help="Run locally using the full config; unlike --debug, do not reduce epochs or batches.",
     )
     mode_group = parser.add_mutually_exclusive_group()
     mode_group.add_argument(
@@ -326,6 +342,7 @@ def run_benchmark_cli() -> None:
             downstream_wrapper=args.downstream_wrapper,
             grid=args.grid,
             debug=args.debug,
+            local=args.local,
             force=args.force,
             retry=args.retry,
             prepare=args.prepare,

--- a/neuralbench-repo/neuralbench/main.py
+++ b/neuralbench-repo/neuralbench/main.py
@@ -246,7 +246,7 @@ class Experiment(BaseExperiment):
             with open(savedir / "config.yaml", "w") as outfile:
                 yaml.dump(self.model_dump(), outfile, indent=4, default_flow_style=False)
 
-        if self.wandb_config is not None:
+        if self.wandb_config is not None and self.wandb_config.host not in (None, ""):
             self._wandb_logger = self.setup_wandb_logger(self.wandb_config, str(savedir))
         if self.csv_config is not None:
             self._csv_logger = self.csv_config.build(save_dir=savedir)

--- a/neuralbench-repo/neuralbench/test_cli.py
+++ b/neuralbench-repo/neuralbench/test_cli.py
@@ -75,3 +75,101 @@ def test_run_benchmark_cli_help_smoke(
     out = capsys.readouterr().out
     assert "available datasets per task:" in out
     assert "eeg" in out
+
+def test_run_benchmark_cli_local_flag_forwards_to_run_benchmark(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from . import cli
+
+    called: dict[str, tp.Any] = {}
+
+    def fake_run_benchmark(**kwargs: tp.Any) -> list[dict[str, tp.Any]]:
+        called.update(kwargs)
+        return []
+
+    monkeypatch.setattr(cli, "run_benchmark", fake_run_benchmark)
+    monkeypatch.setattr(
+        "sys.argv",
+        ["neuralbench", "eeg", "audiovisual_stimulus", "--local"],
+    )
+
+    cli.run_benchmark_cli()
+
+    assert called["local"] is True
+    assert called["debug"] is False
+
+
+def test_run_benchmark_local_preserves_official_config_and_runs_locally(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from . import cli
+
+    prepare_debug_flags: list[bool] = []
+    aggregator_calls: dict[str, tp.Any] = {}
+
+    def fake_load_yaml_config(path: tp.Any) -> dict[str, tp.Any]:
+        if str(path).endswith("grid.yaml"):
+            return {"seed": [1, 2, 3]}
+        return {
+            "infra": {"cluster": "slurm"},
+            "data": {
+                "neuro": {"infra": {"cluster": "slurm"}},
+                "target": {"infra": {"cluster": "slurm"}},
+            },
+        }
+
+    def fake_prepare_task_configs(
+        config: ConfDict,
+        grid: ConfDict,
+        device: str,
+        task_name: str,
+        use_task_grid: bool,
+        debug: bool,
+        force: bool,
+        prepare: bool,
+        download: bool,
+        models: list[str | None],
+        datasets: list[str | None] | None,
+        quiet: bool = False,
+        retry: bool = False,
+    ) -> list[ConfDict]:
+        prepare_debug_flags.append(debug)
+        return [config]
+
+    class DummyAggregator:
+        def __init__(self, experiments: list[ConfDict], debug: bool) -> None:
+            aggregator_calls["experiments"] = experiments
+            aggregator_calls["debug"] = debug
+
+        def prepare(self) -> None:
+            aggregator_calls["prepared"] = True
+
+        def run(self, cached_only: bool = False) -> list[dict[str, tp.Any]]:
+            aggregator_calls["cached_only"] = cached_only
+            return []
+
+    monkeypatch.setattr(cli, "load_yaml_config", fake_load_yaml_config)
+    monkeypatch.setattr(cli, "_validate_inputs", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli, "_warn_slurm_partition", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli, "_resolve_tasks", lambda device, task: ["task_a"])
+    monkeypatch.setattr(
+        cli, "_expand_models", lambda model, device, task_name: [None]
+    )
+    monkeypatch.setattr(
+        cli, "_resolve_datasets", lambda device, task_name, dataset: None
+    )
+    monkeypatch.setattr(cli, "prepare_task_configs", fake_prepare_task_configs)
+    monkeypatch.setattr(
+        "neuralbench.config_manager._ensure_initialized", lambda: None
+    )
+    monkeypatch.setattr("neuralbench.main.BenchmarkAggregator", DummyAggregator)
+
+    cli.run_benchmark("eeg", "audiovisual_stimulus", local=True)
+
+    assert prepare_debug_flags == [False]
+    assert aggregator_calls["debug"] is True
+    assert aggregator_calls["prepared"] is True
+    experiment = aggregator_calls["experiments"][0]
+    assert experiment["infra.cluster"] is None
+    assert experiment["data.neuro.infra.cluster"] is None
+    assert experiment["data.target.infra.cluster"] is None

--- a/neuralbench-repo/neuralbench/test_cli.py
+++ b/neuralbench-repo/neuralbench/test_cli.py
@@ -76,6 +76,7 @@ def test_run_benchmark_cli_help_smoke(
     assert "available datasets per task:" in out
     assert "eeg" in out
 
+
 def test_run_benchmark_cli_local_flag_forwards_to_run_benchmark(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -152,16 +153,10 @@ def test_run_benchmark_local_preserves_official_config_and_runs_locally(
     monkeypatch.setattr(cli, "_validate_inputs", lambda *args, **kwargs: None)
     monkeypatch.setattr(cli, "_warn_slurm_partition", lambda *args, **kwargs: None)
     monkeypatch.setattr(cli, "_resolve_tasks", lambda device, task: ["task_a"])
-    monkeypatch.setattr(
-        cli, "_expand_models", lambda model, device, task_name: [None]
-    )
-    monkeypatch.setattr(
-        cli, "_resolve_datasets", lambda device, task_name, dataset: None
-    )
+    monkeypatch.setattr(cli, "_expand_models", lambda model, device, task_name: [None])
+    monkeypatch.setattr(cli, "_resolve_datasets", lambda device, task_name, dataset: None)
     monkeypatch.setattr(cli, "prepare_task_configs", fake_prepare_task_configs)
-    monkeypatch.setattr(
-        "neuralbench.config_manager._ensure_initialized", lambda: None
-    )
+    monkeypatch.setattr("neuralbench.config_manager._ensure_initialized", lambda: None)
     monkeypatch.setattr("neuralbench.main.BenchmarkAggregator", DummyAggregator)
 
     cli.run_benchmark("eeg", "audiovisual_stimulus", local=True)

--- a/neuralbench-repo/neuralbench/test_main.py
+++ b/neuralbench-repo/neuralbench/test_main.py
@@ -178,9 +178,7 @@ def test_run_seeds_before_preparing_dataloaders(monkeypatch) -> None:
     assert result["n_trainable_params"] is None
 
 
-def test_setup_run_skips_wandb_when_host_blank(
-    monkeypatch, tmp_path: Path
-) -> None:
+def test_setup_run_skips_wandb_when_host_blank(monkeypatch, tmp_path: Path) -> None:
     """Blank ``WANDB_HOST`` should disable W&B setup entirely.
 
     The README documents that leaving ``WANDB_HOST=""`` disables W&B logging.

--- a/neuralbench-repo/neuralbench/test_main.py
+++ b/neuralbench-repo/neuralbench/test_main.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import typing as tp
+from pathlib import Path
 from types import SimpleNamespace
 
 import lightning.pytorch as pl
@@ -16,6 +17,7 @@ from torch.utils.data import DataLoader
 from neuraltrain.losses import BaseLoss
 from neuraltrain.models.base import BaseModelConfig
 from neuraltrain.optimizers import LightningOptimizer
+from neuraltrain.utils import WandbLoggerConfig
 
 from .data import Data
 from .main import Experiment
@@ -174,3 +176,43 @@ def test_run_seeds_before_preparing_dataloaders(monkeypatch) -> None:
     assert events[-2:] == ["prepare_pl_module", "cleanup"]
     assert result["n_total_params"] is None
     assert result["n_trainable_params"] is None
+
+
+def test_setup_run_skips_wandb_when_host_blank(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Blank ``WANDB_HOST`` should disable W&B setup entirely.
+
+    The README documents that leaving ``WANDB_HOST=""`` disables W&B logging.
+    This test locks in that ``setup_run`` honors that contract instead of
+    calling ``wandb.login(host="")``.
+    """
+    calls: list[tuple[WandbLoggerConfig, str]] = []
+
+    def fake_setup_wandb_logger(
+        self, wandb_config: WandbLoggerConfig, savedir: str
+    ) -> object:
+        del self
+        calls.append((wandb_config, savedir))
+        return object()
+
+    monkeypatch.setattr(Experiment, "setup_wandb_logger", fake_setup_wandb_logger)
+
+    experiment = Experiment.model_construct(
+        data=tp.cast(Data, object()),
+        brain_model_config=tp.cast(BaseModelConfig, object()),
+        trainer_config=tp.cast(TrainerConfig, object()),
+        loss=tp.cast(BaseLoss, _DummyLoss()),
+        lightning_optimizer_config=tp.cast(LightningOptimizer, object()),
+        metrics=[],
+        infra=TaskInfra(version="1", folder=tmp_path),
+        wandb_config=WandbLoggerConfig(group="eeg/audiovisual_stimulus", host=""),
+    )
+    run_dir = tmp_path / "run"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(TaskInfra, "uid_folder", lambda self: run_dir)
+
+    experiment.setup_run()
+
+    assert calls == []
+    assert experiment._wandb_logger is None


### PR DESCRIPTION
## What does this PR do?

Adds a `--local` mode to `neuralbench` so canonical runs can execute on the current machine without switching to the reduced debug config.

This is useful when the default non-debug path would otherwise rely on cluster execution. With `--local`, the benchmark and extractor/target infra are forced to run locally, while epochs, batch limits, and the rest of the task config stay unchanged.

Example:

```bash
neuralbench eeg audiovisual_stimulus --local
```

This branch also keeps W&B disabled when `WANDB_HOST` is blank, which matters for local runs that should not try to initialize W&B.


## Related Issues

N/A

## Checklist

- [x] Tests added or updated
- [x] Docstrings updated for any changed public APIs
- [ ] `pytest` and `mypy` pass locally