### PR TITLE
Accept mne raw input for spikes extractor when not NWB

### DIFF
--- a/neuralset-repo/neuralset/events/etypes.py
+++ b/neuralset-repo/neuralset/events/etypes.py
@@ -979,16 +979,19 @@ class Ieeg(MneRaw):
 
 
 class Spikes(BaseDataEvent):
-    """Spikes recording event saved as HDF5 object.
+    """Spikes recording event (NWB/HDF5 or pre-binned MNE data).
 
-    Base class for spikes recordings that can be loaded using HDF5.
+    By default, :meth:`read` opens an NWB-style HDF5 file (``h5py.File``).
+    With a :class:`~neuralset.events.study.SpecialLoader`, it may return an
+    ``mne.io.RawArray`` of pre-binned spike counts for use with
+    :class:`~neuralset.extractors.SpikesExtractor`.
 
     Parameters
     ----------
     subject : str
         Subject identifier (required, cannot be empty)
     filepath: str
-        Path to the HDF5 file (required, cannot be empty)
+        Path to the HDF5 file, or a SpecialLoader JSON URI (required)
 
     Notes
     -----
@@ -999,8 +1002,8 @@ class Spikes(BaseDataEvent):
     .. code-block:: python
 
         spikes = Spikes(start=0, timeline="scan1", filepath="data_raw.nwb",
-                 subject="sub-01")
-        h5py_file = spikes.read()  # Returns h5py.File object
+                 subject="sub-01", frequency=1000.0, duration=10.0)
+        h5py_file = spikes.read()  # NWB/HDF5: returns h5py.File
     """
 
     subject: StrCast = ""

--- a/neuralset-repo/neuralset/extractors/neuro.py
+++ b/neuralset-repo/neuralset/extractors/neuro.py
@@ -688,13 +688,17 @@ class IeegExtractor(MneRaw):
 
 
 class SpikesExtractor(BaseExtractor):
-    """Feature extractor for spike data stored in HDF5/NWB files.
+    """Feature extractor for spike data in HDF5/NWB or pre-binned MNE format.
 
-    Reads spike times from HDF5 files and creates a dense binned array
-    of shape (n_units, n_time_bins) at the specified frequency.
+    Supports two input formats returned by :meth:`~neuralset.events.etypes.Spikes.read`:
+
+    - **NWB/HDF5** (``h5py.File``): spike times are binned into a dense array
+      of shape ``(n_units, n_time_bins)`` at the target frequency.
+    - **MNE** (``mne.io.RawArray``): pre-binned continuous data; resampled with
+      :meth:`mne.io.Raw.resample` when ``raw.info["sfreq"]`` differs from ``frequency``.
 
     The preprocessing steps, if specified, are ordered as follows:
-    1. Spike binning at target frequency
+    1. Spike binning or resampling to target frequency
     2. Scaling
     3. Baseline correction (applied on segments)
     4. Clamp (applied on segments)
@@ -702,8 +706,8 @@ class SpikesExtractor(BaseExtractor):
     Parameters
     ----------
     frequency : "native" or float, default="native"
-        Target sampling frequency for spike binning. If ``"native"``, uses the
-        frequency declared in the Spikes event.
+        Target sampling frequency (Hz). If ``"native"``, uses the frequency
+        declared in the Spikes event (NWB) or ``raw.info["sfreq"]`` (MNE).
     offset : float, default=0.0
         Time offset (in seconds) applied to the segment window.
     baseline : tuple of float, optional
@@ -813,34 +817,6 @@ class SpikesExtractor(BaseExtractor):
 
         return data, [str(n) for n in ch_names]
 
-    @staticmethod
-    def _resample_spike_data(
-        data: np.ndarray, orig_sfreq: float, new_sfreq: float
-    ) -> np.ndarray:
-        n_timestamps = data.shape[-1]
-        timestamps = np.arange(n_timestamps) / orig_sfreq
-        new_timestamps = np.arange(
-            0, timestamps[-1] + (1 / orig_sfreq) - (1 / new_sfreq), 1 / new_sfreq
-        )
-        resamp_data = np.stack(
-            [
-                np.interp(new_timestamps, timestamps, unit, right=unit[-1])
-                for unit in data
-            ],
-            axis=0,
-        )
-        # Evaluate how many timestamps were dropped at the end because of no extrapolation
-        n_new_timestamps_without_extrapolation = int(timestamps[-1] * new_sfreq) + 1
-        dropped_timestamps = len(new_timestamps) - n_new_timestamps_without_extrapolation
-        if dropped_timestamps > 0:
-            msg = (
-                f"{dropped_timestamps} invalid timestamps at the end of the timeline due to resampling without"
-                f" interpolation from f={orig_sfreq:0.2f}Hz to f={new_sfreq:0.2f}Hz. These invalid timestamps "
-                "have been filled with NaNs."
-            )
-            logger.warning(msg)
-        return resamp_data
-
     def _preprocess_spikes(self, event: etypes.Spikes) -> TimedArray:
         import h5py  # type: ignore[import-untyped]
 
@@ -856,11 +832,15 @@ class SpikesExtractor(BaseExtractor):
             h5py_or_raw.close()
         elif isinstance(h5py_or_raw, mne.io.RawArray):
             raw = h5py_or_raw
-            data = raw.get_data()
             loaded_sfreq = float(raw.info["sfreq"])
             ch_names = raw.ch_names
             if loaded_sfreq != sfreq:
-                data = self._resample_spike_data(data, loaded_sfreq, sfreq)
+                # copy first — ``crop`` mutates in place, and ``super().read()``
+                # could return a cached/shared Raw (e.g. via ``_special_loader``).
+                raw = raw.copy()
+                raw.load_data()
+                raw = raw.resample(sfreq, verbose=False)
+            data = raw.get_data()
         else:
             raise ValueError(f"Unsupported spike data type: {type(h5py_or_raw)}")
 

--- a/neuralset-repo/neuralset/extractors/neuro.py
+++ b/neuralset-repo/neuralset/extractors/neuro.py
@@ -813,6 +813,34 @@ class SpikesExtractor(BaseExtractor):
 
         return data, [str(n) for n in ch_names]
 
+    @staticmethod
+    def _resample_spike_data(
+        data: np.ndarray, orig_sfreq: float, new_sfreq: float
+    ) -> np.ndarray:
+        n_timestamps = data.shape[-1]
+        timestamps = np.arange(n_timestamps) / orig_sfreq
+        new_timestamps = np.arange(
+            0, timestamps[-1] + (1 / orig_sfreq) - (1 / new_sfreq), 1 / new_sfreq
+        )
+        resamp_data = np.stack(
+            [
+                np.interp(new_timestamps, timestamps, unit, right=unit[-1])
+                for unit in data
+            ],
+            axis=0,
+        )
+        # Evaluate how many timestamps were dropped at the end because of no extrapolation
+        n_new_timestamps_without_extrapolation = int(timestamps[-1] * new_sfreq) + 1
+        dropped_timestamps = len(new_timestamps) - n_new_timestamps_without_extrapolation
+        if dropped_timestamps > 0:
+            msg = (
+                f"{dropped_timestamps} invalid timestamps at the end of the timeline due to resampling without"
+                f" interpolation from f={orig_sfreq:0.2f}Hz to f={new_sfreq:0.2f}Hz. These invalid timestamps "
+                "have been filled with NaNs."
+            )
+            logger.warning(msg)
+        return resamp_data
+
     def _preprocess_spikes(self, event: etypes.Spikes) -> TimedArray:
         import h5py  # type: ignore[import-untyped]
 
@@ -822,12 +850,19 @@ class SpikesExtractor(BaseExtractor):
             else float(self.frequency)
         )
 
-        nwb_file = event.read()
-        try:
-            data, ch_names = self._bin_spikes(nwb_file, sfreq)
-        finally:
-            if isinstance(nwb_file, h5py.File):
-                nwb_file.close()
+        h5py_or_raw = event.read()
+        if isinstance(h5py_or_raw, h5py.File):
+            data, ch_names = self._bin_spikes(h5py_or_raw, sfreq)
+            h5py_or_raw.close()
+        elif isinstance(h5py_or_raw, mne.io.RawArray):
+            raw = h5py_or_raw
+            data = raw.get_data()
+            loaded_sfreq = float(raw.info["sfreq"])
+            ch_names = raw.ch_names
+            if loaded_sfreq != sfreq:
+                data = self._resample_spike_data(data, loaded_sfreq, sfreq)
+        else:
+            raise ValueError(f"Unsupported spike data type: {type(h5py_or_raw)}")
 
         if self.scaler is not None:
             scaler_cls = getattr(sklearn.preprocessing, self.scaler)()

--- a/neuralset-repo/neuralset/extractors/neuro.py
+++ b/neuralset-repo/neuralset/extractors/neuro.py
@@ -835,9 +835,6 @@ class SpikesExtractor(BaseExtractor):
             loaded_sfreq = float(raw.info["sfreq"])
             ch_names = raw.ch_names
             if loaded_sfreq != sfreq:
-                # copy first — ``crop`` mutates in place, and ``super().read()``
-                # could return a cached/shared Raw (e.g. via ``_special_loader``).
-                raw = raw.copy()
                 raw.load_data()
                 raw = raw.resample(sfreq, verbose=False)
             data = raw.get_data()


### PR DESCRIPTION
## What does this PR do?

Extends SpikesExtractor so spike data can come from an mne.io.RawArray (pre-binned continuous data), not only from NWB/HDF5 files.

NWB/HDF5 path (unchanged): event.read() returns h5py.File → spike times are binned via _bin_spikes.
MNE path (new): event.read() returns mne.io.RawArray → data is taken with raw.get_data(), channel names from raw.ch_names, and resampled to the target frequency when raw.info["sfreq"] differs from the extractor’s frequency.

This supports datasets where spikes are already represented as binned continuous data (e.g. via SpecialLoader), while keeping the existing NWB binning workflow.