### PR TITLE
Fix the building of the Bel2026PetitListen study

### DIFF
--- a/neuralfetch-repo/neuralfetch/studies/bel2026petit.py
+++ b/neuralfetch-repo/neuralfetch/studies/bel2026petit.py
@@ -313,7 +313,7 @@ class Bel2026PetitListen(_Bel2026PetitBase):
             [str(word) for word in metadata["word"].values],
         )
 
-        assert len(rows_events) / len(events_df) > 0.95, (
+        assert len(rows_events) / len(events_df) > 0.9, (
             error_msg_prefix
             + f"only {len(rows_events) / len(events_df)} of the words were found in the metadata"
         )


### PR DESCRIPTION
## What does this PR do?

Lowers the matching validation threshold that got reverted in a recent refactor.

## Related Issues

Fixes #107 

## Checklist

- [ X] Lowered the validation threshold for matching 