### PR TITLE
Add audio word extraction transform

### DIFF
--- a/neuralset-repo/neuralset/events/transforms/audio.py
+++ b/neuralset-repo/neuralset/events/transforms/audio.py
@@ -181,17 +181,19 @@ class ExtractWordsFromAudio(EventsTransform):
             "offset",
             "stop",
         }
-        for audio_event in audio_events.itertuples(index=False):
-            transcript = transcripts[str(Path(audio_event.filepath))].copy(deep=True)
+        for _, audio_event in audio_events.iterrows():
+            audio_filepath = Path(tp.cast(str, audio_event["filepath"]))
+            transcript = transcripts[str(audio_filepath)].copy(deep=True)
             if transcript.empty:
                 continue
-            for key, value in audio_event._asdict().items():
+            for key, value in audio_event.items():
                 if key not in ignored_fields:
-                    transcript.loc[:, key] = value
+                    transcript[tp.cast(str, key)] = value
             transcript["type"] = "Word"
             transcript["language"] = self.language
-            offset = getattr(audio_event, "offset", 0.0)
-            transcript["start"] += audio_event.start + offset
+            offset = float(audio_event.get("offset", 0.0))
+            audio_start = float(audio_event["start"])
+            transcript["start"] = transcript["start"].astype(float) + audio_start + offset
             all_transcripts.append(transcript)
 
         if not all_transcripts:

--- a/neuralset-repo/neuralset/events/transforms/audio.py
+++ b/neuralset-repo/neuralset/events/transforms/audio.py
@@ -4,6 +4,12 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
+import json
+import logging
+import os
+import subprocess
+import tempfile
+import typing as tp
 from pathlib import Path
 
 import pandas as pd
@@ -11,6 +17,8 @@ from tqdm import tqdm
 
 from .. import etypes as ev
 from ..study import EventsTransform
+
+logger = logging.getLogger(__name__)
 
 
 class ExtractAudioFromVideo(EventsTransform):
@@ -54,3 +62,141 @@ class ExtractAudioFromVideo(EventsTransform):
         events = pd.concat([events, pd.DataFrame(events_to_add)], ignore_index=True)
         events = events.reset_index(drop=True)
         return events
+
+
+class ExtractWordsFromAudio(EventsTransform):
+    """
+    Transcribe Audio events with WhisperX and add the aligned words as Word events.
+
+    Transcripts are cached next to the audio file as ``.tsv`` files. Existing
+    Word events are treated as authoritative and make the transform a no-op.
+    """
+
+    language: str = "english"
+    overwrite: bool = False
+
+    @staticmethod
+    def _get_transcript_from_audio(wav_filename: Path, language: str) -> pd.DataFrame:
+        language_codes = {
+            "english": "en",
+            "french": "fr",
+            "spanish": "es",
+            "dutch": "nl",
+            "chinese": "zh",
+        }
+        if language not in language_codes:
+            raise ValueError(f"Language {language} not supported")
+
+        import torch
+
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        compute_type = "float16" if device == "cuda" else "int8"
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            logger.info("Running whisperx via uvx...")
+            cmd = [
+                "uvx",
+                "whisperx",
+                str(wav_filename),
+                "--model",
+                "large-v3",
+                "--language",
+                language_codes[language],
+                "--device",
+                device,
+                "--compute_type",
+                compute_type,
+                "--batch_size",
+                "16",
+                "--align_model",
+                "WAV2VEC2_ASR_LARGE_LV60K_960H" if language == "english" else "",
+                "--output_dir",
+                output_dir,
+                "--output_format",
+                "json",
+            ]
+            cmd = [c for c in cmd if c]
+            env = {k: v for k, v in os.environ.items() if k != "MPLBACKEND"}
+            result = subprocess.run(cmd, capture_output=True, text=True, env=env)
+            if result.returncode != 0:
+                raise RuntimeError(f"whisperx failed:\n{result.stderr}")
+
+            json_path = Path(output_dir) / f"{wav_filename.stem}.json"
+            transcript = json.loads(json_path.read_text())
+
+        words: list[dict[str, tp.Any]] = []
+        for sequence_id, segment in enumerate(transcript["segments"]):
+            sentence = segment["text"].replace('"', "")
+            for word in segment["words"]:
+                if "start" not in word:
+                    continue
+                words.append(
+                    {
+                        "text": word["word"].replace('"', ""),
+                        "start": word["start"],
+                        "duration": word["end"] - word["start"],
+                        "sequence_id": sequence_id,
+                        "sentence": sentence,
+                    }
+                )
+
+        return pd.DataFrame(words)
+
+    def _run(self, events: pd.DataFrame) -> pd.DataFrame:
+        if "Word" in events.type.unique():
+            logger.warning("Words already present in the events dataframe, skipping")
+            return events
+
+        audio_events = events.loc[events.type == "Audio"]
+        if audio_events.empty:
+            return events
+
+        transcripts: dict[str, pd.DataFrame] = {}
+        audio_filepaths = [Path(filepath) for filepath in audio_events.filepath.unique()]
+        for wav_filename in tqdm(
+            audio_filepaths,
+            total=len(audio_filepaths),
+            desc="Extracting words from audio",
+        ):
+            transcript_filename = wav_filename.with_suffix(".tsv")
+            if transcript_filename.exists() and not self.overwrite:
+                try:
+                    transcript = pd.read_csv(transcript_filename, sep="\t")
+                except pd.errors.EmptyDataError:
+                    transcript = pd.DataFrame()
+                    logger.warning("Empty transcript file %s", transcript_filename)
+            else:
+                transcript = self._get_transcript_from_audio(wav_filename, self.language)
+                transcript.to_csv(transcript_filename, sep="\t", index=False)
+                logger.info("Wrote transcript to %s", transcript_filename)
+            transcripts[str(wav_filename)] = transcript
+
+        all_transcripts = []
+        ignored_fields = {
+            "frequency",
+            "filepath",
+            "type",
+            "start",
+            "duration",
+            "offset",
+            "stop",
+        }
+        for audio_event in audio_events.itertuples(index=False):
+            transcript = transcripts[str(Path(audio_event.filepath))].copy(deep=True)
+            if transcript.empty:
+                continue
+            for key, value in audio_event._asdict().items():
+                if key not in ignored_fields:
+                    transcript.loc[:, key] = value
+            transcript["type"] = "Word"
+            transcript["language"] = self.language
+            offset = getattr(audio_event, "offset", 0.0)
+            transcript["start"] += audio_event.start + offset
+            all_transcripts.append(transcript)
+
+        if not all_transcripts:
+            logger.warning("No transcripts found, skipping")
+            return events
+
+        events = pd.concat([events, pd.concat(all_transcripts)], ignore_index=True)
+        return events.reset_index(drop=True)

--- a/neuralset-repo/neuralset/events/transforms/test_transforms.py
+++ b/neuralset-repo/neuralset/events/transforms/test_transforms.py
@@ -916,6 +916,112 @@ def create_wav(fp: Path, fs: int = 44100, duration: float = 10) -> None:
     scipy.io.wavfile.write(fp, fs, y)
 
 
+def test_extract_words_from_audio(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    wav_filepath = tmp_path / "speech.wav"
+    transcript = pd.DataFrame(
+        [
+            {
+                "text": "hello",
+                "start": 0.5,
+                "duration": 0.4,
+                "sequence_id": 0,
+                "sentence": "hello world",
+            },
+            {
+                "text": "world",
+                "start": 1.0,
+                "duration": 0.5,
+                "sequence_id": 0,
+                "sentence": "hello world",
+            },
+        ]
+    )
+    calls = []
+
+    def fake_transcript(wav_filename: Path, language: str) -> pd.DataFrame:
+        calls.append((wav_filename, language))
+        return transcript
+
+    monkeypatch.setattr(
+        _transf.ExtractWordsFromAudio,
+        "_get_transcript_from_audio",
+        staticmethod(fake_transcript),
+    )
+    events = pd.DataFrame(
+        [
+            {
+                "type": "Audio",
+                "start": 10.0,
+                "duration": 5.0,
+                "offset": 2.0,
+                "timeline": "tl1",
+                "filepath": str(wav_filepath),
+                "subject": "subject1",
+                "task": "listening",
+            }
+        ]
+    )
+
+    out = _transf.ExtractWordsFromAudio(language="english")(events)
+
+    assert calls == [(wav_filepath, "english")]
+    assert wav_filepath.with_suffix(".tsv").exists()
+    words = out.loc[out.type == "Word"].reset_index(drop=True)
+    assert words.text.tolist() == ["hello", "world"]
+    assert words.start.tolist() == pytest.approx([12.5, 13.0])
+    assert words.duration.tolist() == pytest.approx([0.4, 0.5])
+    assert set(words.timeline) == {"tl1"}
+    assert set(words.subject) == {"subject1"}
+    assert set(words.task) == {"listening"}
+    assert set(words.language) == {"english"}
+
+
+def test_extract_words_from_audio_uses_cached_transcript(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    wav_filepath = tmp_path / "speech.wav"
+    pd.DataFrame(
+        [
+            {
+                "text": "bonjour",
+                "start": 0.25,
+                "duration": 0.75,
+                "sequence_id": 0,
+                "sentence": "bonjour",
+            }
+        ]
+    ).to_csv(wav_filepath.with_suffix(".tsv"), sep="\t", index=False)
+
+    def fail_transcript(wav_filename: Path, language: str) -> pd.DataFrame:
+        raise AssertionError("cached transcript should be used")
+
+    monkeypatch.setattr(
+        _transf.ExtractWordsFromAudio,
+        "_get_transcript_from_audio",
+        staticmethod(fail_transcript),
+    )
+    events = pd.DataFrame(
+        [
+            {
+                "type": "Audio",
+                "start": 1.0,
+                "duration": 2.0,
+                "timeline": "tl1",
+                "filepath": str(wav_filepath),
+            }
+        ]
+    )
+
+    out = _transf.ExtractWordsFromAudio(language="french")(events)
+
+    words = out.loc[out.type == "Word"].reset_index(drop=True)
+    assert words.text.tolist() == ["bonjour"]
+    assert words.start.tolist() == pytest.approx([1.25])
+    assert words.language.tolist() == ["french"]
+
+
 def test_deterministic_splitter() -> None:
     with pytest.raises(ValueError):
         splitter = _tutils.DeterministicSplitter(ratios=dict(train=0.5))


### PR DESCRIPTION
## Summary
- Add `ExtractWordsFromAudio`, a WhisperX-backed events transform that turns `Audio` rows into aligned `Word` rows.
- Cache transcripts as sidecar `.tsv` files, reuse existing caches unless `overwrite=True`, and preserve audio-row metadata on generated words.
- Cover fresh transcription and cached-transcript behavior with focused unit tests.

## Test plan
- `.venv/bin/python -m pytest neuralset-repo/neuralset/events/transforms/test_transforms.py -k 'extract_words_from_audio'`
- `.venv/bin/python -m ruff check neuralset-repo/neuralset/events/transforms/audio.py neuralset-repo/neuralset/events/transforms/test_transforms.py`
- Full `test_transforms.py` run: 86 passed, 1 environment failure due missing `deepmultilingualpunctuation` for `test_ensure_texts_fullstop`.


Made with [Cursor](https://cursor.com)