### PR TITLE
Support triggerless strided segmentation

### DIFF
--- a/neuralset-repo/neuralset/dataloader.py
+++ b/neuralset-repo/neuralset/dataloader.py
@@ -477,7 +477,8 @@ class Segmenter(base.BaseModel):
         Dataframe query selecting which events act as :term:`triggers <trigger>`
         — segments are time-locked to the matching events
         (see :data:`base.Query`).
-        At least one of ``trigger_query`` or ``stride`` must be provided.
+        If None, ``stride`` must be provided and strided segments are created
+        across each full timeline.
     stride: optional float
         Stride (in seconds) to use to define sliding window segments.
     stride_drop_incomplete: optional bool
@@ -539,13 +540,13 @@ class Segmenter(base.BaseModel):
                     f"the trigger query: {self.trigger_query} led to an empty set."
                 )
         else:
-            trigger_idx = pd.Series(dtype=int)
+            trigger_idx = None
 
         # TODO fixme class typing: self.duration cannot be trigger
         duration = None if self.duration == "trigger" else self.duration
 
         # Drop events not used by extractors or triggers
-        if self.drop_unused_events:
+        if self.drop_unused_events and trigger_idx is not None:
             event_types = []
             for extractor in self.extractors.values():
                 event_types.extend(EventTypesHelper(extractor.event_types).names)

--- a/neuralset-repo/neuralset/dataloader.py
+++ b/neuralset-repo/neuralset/dataloader.py
@@ -91,6 +91,8 @@ class SegmentsMixin:
     @property
     def triggers(self) -> pd.DataFrame:
         triggers = [s.trigger for s in self.segments]
+        if all(t is None for t in triggers):
+            return pd.DataFrame()
         if any(t is None for t in triggers):
             raise RuntimeError(f"Segments did not all have a trigger: {triggers}")
         df = pd.DataFrame([t.to_dict() for t in triggers])  # type: ignore
@@ -530,6 +532,17 @@ class Segmenter(base.BaseModel):
         super().model_post_init(log__)
         if self.trigger_query is None and self.stride is None:
             raise ValueError("trigger_query can only be None when stride is provided")
+        if self.trigger_query is None:
+            trigger_extractors = [
+                name
+                for name, extractor in self.extractors.items()
+                if extractor.aggregation == "trigger"
+            ]
+            if trigger_extractors:
+                raise ValueError(
+                    "trigger_query is required for extractors with "
+                    f"aggregation='trigger': {trigger_extractors}"
+                )
 
     def apply(self, events: pd.DataFrame) -> SegmentDataset:
         # Segment the events based on stride and/or triggers

--- a/neuralset-repo/neuralset/dataloader.py
+++ b/neuralset-repo/neuralset/dataloader.py
@@ -529,7 +529,7 @@ class Segmenter(base.BaseModel):
     def model_post_init(self, log__: tp.Any) -> None:
         super().model_post_init(log__)
         if self.trigger_query is None and self.stride is None:
-            raise ValueError("At least one of trigger_query or stride must be provided.")
+            raise ValueError("trigger_query can only be None when stride is provided")
 
     def apply(self, events: pd.DataFrame) -> SegmentDataset:
         # Segment the events based on stride and/or triggers

--- a/neuralset-repo/neuralset/segments.py
+++ b/neuralset-repo/neuralset/segments.py
@@ -326,7 +326,7 @@ class Segment:
 
 def list_segments(
     events: pd.DataFrame,
-    triggers: pd.Series,
+    triggers: pd.Series | None,
     *,
     start: float = 0.0,
     duration: float | None = None,
@@ -339,8 +339,9 @@ def list_segments(
     ----------
     events : pd.DataFrame
         DataFrame containing events, must be normalized first using :func:`~neuralset.events.standardize_events`.
-    triggers : pd.Series
-        Boolean mask of events to use for defining segments.
+    triggers : pd.Series or None
+        Boolean mask of events to use for defining segments. If None, ``stride``
+        must be provided and windows are created over each full timeline.
     start : float, optional
         Start offset (in seconds) of segments relative to reference events or stride.
         Use negative values to start before the reference. Default is 0.0.
@@ -356,16 +357,19 @@ def list_segments(
     Returns
     -------
     list of Segment
-        List of segments with populated :attr:`ns_events` field and :attr:`trigger` containing the event
-        that triggered the segment.
+        List of segments with populated :attr:`ns_events` field and
+        :attr:`trigger` containing the event that triggered the segment, or
+        None for triggerless windows.
 
     Notes
     -----
-    Two segmentation modes are supported:
+    Three segmentation modes are supported:
 
     1. Single window: each event specified by `triggers` yields a single segment.
     2. Sliding window: for each event specified by `triggers`, create strided
        windows of duration `duration` and step size `stride`.
+    3. Triggerless sliding window: if `triggers` is None, create strided
+       windows from each timeline's first event start to its last event stop.
 
     Examples
     --------
@@ -387,47 +391,66 @@ def list_segments(
 
     if not hasattr(events, "stop"):
         raise ValueError("Run standardize_events on the DataFrame first")
-    if not isinstance(triggers, pd.Series):
+    if triggers is None and stride is None:
+        raise ValueError("triggers can only be None when stride is provided")
+    if triggers is not None and not isinstance(triggers, pd.Series):
         raise TypeError(
             f"triggers must be a boolean pd.Series, got {type(triggers).__name__}"
         )
 
     store = _EventStore.from_dataframe(events)
 
-    trigger_df = events.loc[triggers]
-    if not len(trigger_df):
-        raise ValueError("Empty trigger events")
-
-    df_to_pos = events.index.get_indexer(trigger_df.index)
-
     seg_starts: list[tp.Any] = []
     seg_durations: list[tp.Any] = []
     trigger_positions: list[tp.Any] = []
     trigger_timelines: list[tp.Any] = []
 
-    if stride is None:
-        seg_starts = (trigger_df["start"] + start).tolist()
-        seg_durations = (
-            trigger_df["duration"].tolist()
-            if duration is None
-            else [duration] * len(trigger_df)
-        )
-        trigger_positions = df_to_pos.tolist()
-        trigger_timelines = trigger_df["timeline"].tolist()
-    else:
-        assert duration is not None
-        for i, trig in enumerate(trigger_df.itertuples()):
+    if triggers is None:
+        assert stride is not None and duration is not None
+        if not len(events):
+            raise ValueError("Cannot create triggerless segments from empty events")
+        for timeline, timeline_events in events.groupby("timeline", sort=False):
             s, d = _prepare_strided_windows(
-                float(trig.start) + start,  # type: ignore
-                float(trig.stop),  # type: ignore
+                float(timeline_events["start"].min()) + start,
+                float(timeline_events["stop"].max()),
                 stride,
                 duration,
                 drop_incomplete=stride_drop_incomplete,
             )
             seg_starts.extend(s)
             seg_durations.extend(d)
-            trigger_positions.extend([df_to_pos[i]] * len(s))
-            trigger_timelines.extend([str(trig.timeline)] * len(s))
+            trigger_positions.extend([None] * len(s))
+            trigger_timelines.extend([str(timeline)] * len(s))
+    else:
+        trigger_df = events.loc[triggers]
+        if not len(trigger_df):
+            raise ValueError("Empty trigger events")
+
+        df_to_pos = events.index.get_indexer(trigger_df.index)
+
+        if stride is None:
+            seg_starts = (trigger_df["start"] + start).tolist()
+            seg_durations = (
+                trigger_df["duration"].tolist()
+                if duration is None
+                else [duration] * len(trigger_df)
+            )
+            trigger_positions = df_to_pos.tolist()
+            trigger_timelines = trigger_df["timeline"].tolist()
+        else:
+            assert duration is not None
+            for i, trig in enumerate(trigger_df.itertuples()):
+                s, d = _prepare_strided_windows(
+                    float(trig.start) + start,  # type: ignore
+                    float(trig.stop),  # type: ignore
+                    stride,
+                    duration,
+                    drop_incomplete=stride_drop_incomplete,
+                )
+                seg_starts.extend(s)
+                seg_durations.extend(d)
+                trigger_positions.extend([df_to_pos[i]] * len(s))
+                trigger_timelines.extend([str(trig.timeline)] * len(s))
 
     segments: list[Segment] = []
     for s, d, trig_idx, tl in zip(

--- a/neuralset-repo/neuralset/test_dataloader.py
+++ b/neuralset-repo/neuralset/test_dataloader.py
@@ -318,6 +318,13 @@ def test_repr(tmp_path: Path):
     assert "  'name': '" in string
 
 
+def test_segmenter_requires_stride_without_trigger_query() -> None:
+    with pytest.raises(
+        ValueError, match="trigger_query can only be None when stride is provided"
+    ):
+        dl.Segmenter(extractors={}, trigger_query=None, duration=1.0)
+
+
 def test_segmenter_stride_without_trigger_query() -> None:
     events_df = events.standardize_events(
         pd.DataFrame(

--- a/neuralset-repo/neuralset/test_dataloader.py
+++ b/neuralset-repo/neuralset/test_dataloader.py
@@ -318,40 +318,6 @@ def test_repr(tmp_path: Path):
     assert "  'name': '" in string
 
 
-def test_segmenter_requires_stride_without_trigger_query() -> None:
-    with pytest.raises(
-        ValueError, match="trigger_query can only be None when stride is provided"
-    ):
-        dl.Segmenter(extractors={}, trigger_query=None, duration=1.0)
-
-
-def test_segmenter_stride_without_trigger_query() -> None:
-    events_df = events.standardize_events(
-        pd.DataFrame(
-            [
-                dict(type="Word", start=10, duration=1, text="a", timeline="tl0"),
-                dict(type="Word", start=12, duration=2, text="b", timeline="tl0"),
-                dict(type="Word", start=100, duration=3, text="c", timeline="tl1"),
-            ]
-        )
-    )
-    segmenter = dl.Segmenter(
-        extractors={},
-        trigger_query=None,
-        duration=2.0,
-        stride=2.0,
-    )
-
-    ds = segmenter.apply(events_df)
-
-    assert [(s.timeline, s.start, s.duration) for s in ds.segments] == [
-        ("tl0", 10.0, 2.0),
-        ("tl0", 12.0, 2.0),
-        ("tl1", 100.0, 2.0),
-    ]
-    assert [s.trigger for s in ds.segments] == [None, None, None]
-
-
 def test_repr_segments() -> None:
     segments = _make_segments()
     sd = dl.Batch(data={"meg": torch.randn(1, 3, 100)}, segments=[segments[0]])

--- a/neuralset-repo/neuralset/test_dataloader.py
+++ b/neuralset-repo/neuralset/test_dataloader.py
@@ -318,6 +318,33 @@ def test_repr(tmp_path: Path):
     assert "  'name': '" in string
 
 
+def test_segmenter_stride_without_trigger_query() -> None:
+    events_df = events.standardize_events(
+        pd.DataFrame(
+            [
+                dict(type="Word", start=10, duration=1, text="a", timeline="tl0"),
+                dict(type="Word", start=12, duration=2, text="b", timeline="tl0"),
+                dict(type="Word", start=100, duration=3, text="c", timeline="tl1"),
+            ]
+        )
+    )
+    segmenter = dl.Segmenter(
+        extractors={},
+        trigger_query=None,
+        duration=2.0,
+        stride=2.0,
+    )
+
+    ds = segmenter.apply(events_df)
+
+    assert [(s.timeline, s.start, s.duration) for s in ds.segments] == [
+        ("tl0", 10.0, 2.0),
+        ("tl0", 12.0, 2.0),
+        ("tl1", 100.0, 2.0),
+    ]
+    assert [s.trigger for s in ds.segments] == [None, None, None]
+
+
 def test_repr_segments() -> None:
     segments = _make_segments()
     sd = dl.Batch(data={"meg": torch.randn(1, 3, 100)}, segments=[segments[0]])

--- a/neuralset-repo/neuralset/test_segments.py
+++ b/neuralset-repo/neuralset/test_segments.py
@@ -235,6 +235,21 @@ def test_list_segments_stride_without_triggers() -> None:
         ("tl1", 100.0, 2.0),
     ]
     assert [s.trigger for s in segs] == [None, None, None]
+    assert dl.SegmentDataset(extractors={}, segments=segs).triggers.empty
+
+
+def test_segmenter_rejects_trigger_extractor_without_trigger_query() -> None:
+    with pytest.raises(ValueError, match="trigger_query is required for extractors with"):
+        dl.Segmenter(
+            extractors={
+                "trigger_word": ns.extractors.Pulse(
+                    aggregation="trigger", event_types="Word"
+                )
+            },
+            trigger_query=None,
+            duration=2.0,
+            stride=2.0,
+        )
 
 
 def test_find_incomplete_segments(tmp_path: Path) -> None:

--- a/neuralset-repo/neuralset/test_segments.py
+++ b/neuralset-repo/neuralset/test_segments.py
@@ -220,6 +220,23 @@ def test_list_segments_idx_stride(
     assert all(d == duration for d in durations), f"Got {durations}"
 
 
+def test_list_segments_stride_without_triggers() -> None:
+    data = [
+        dict(type="Word", start=10, duration=1, text="a", timeline="tl0"),
+        dict(type="Word", start=12, duration=2, text="b", timeline="tl0"),
+        dict(type="Word", start=100, duration=3, text="c", timeline="tl1"),
+    ]
+    events = standardize_events(pd.DataFrame(data))
+    segs = list_segments(events=events, triggers=None, duration=2, stride=2)
+
+    assert [(s.timeline, s.start, s.duration) for s in segs] == [
+        ("tl0", 10.0, 2.0),
+        ("tl0", 12.0, 2.0),
+        ("tl1", 100.0, 2.0),
+    ]
+    assert [s.trigger for s in segs] == [None, None, None]
+
+
 def test_find_incomplete_segments(tmp_path: Path) -> None:
     sentence = ("This is a sentence for the unit tests").split(" ")
     words = [


### PR DESCRIPTION
## Summary
- Allows `Segmenter(trigger_query=None, stride=...)` to build strided windows without trigger events.
- Creates triggerless windows over each full timeline, from that timeline's minimum start to maximum stop, while preserving the existing `start` offset and `stride_drop_incomplete` behavior.
- Keeps all events available in triggerless mode so timeline bounds are not narrowed by extractor event-type filtering.

## Example
```python
segmenter = ns.Segmenter(
    extractors={"meg": ns.extractors.MegExtractor(frequency="native")},
    trigger_query=None,
    duration=2.0,
    stride=0.5,
)
dset = segmenter.apply(events)
```

## Test plan
- `./.venv/bin/python -m pytest neuralset-repo/neuralset/test_segments.py::test_list_segments_stride_without_triggers neuralset-repo/neuralset/test_dataloader.py::test_segmenter_stride_without_trigger_query`
- `./.venv/bin/python -m pytest neuralset-repo/neuralset/test_segments.py`

Made with [Cursor](https://cursor.com)