### PR TITLE
feat(segments): add on_trigger_overlap guard to list_segments

### DIFF
--- a/neuralset-repo/neuralset/segments.py
+++ b/neuralset-repo/neuralset/segments.py
@@ -475,10 +475,6 @@ def _check_trigger_overlap(
     """
     if mode == "allow":
         return
-    if mode not in ("raise", "warn"):
-        raise ValueError(
-            f"on_trigger_overlap must be 'raise', 'warn' or 'allow', got {mode!r}"
-        )
 
     keys = ["type", "timeline", "start"]
     if not all(k in trigger_df.columns for k in keys):

--- a/neuralset-repo/neuralset/segments.py
+++ b/neuralset-repo/neuralset/segments.py
@@ -332,7 +332,6 @@ def list_segments(
     duration: float | None = None,
     stride: float | None = None,
     stride_drop_incomplete: bool = True,
-    on_trigger_overlap: tp.Literal["raise", "warn", "allow"] = "raise",
 ) -> list[Segment]:
     """Create a list of segments based on events, sliding windows, or both.
 
@@ -353,9 +352,6 @@ def list_segments(
     stride_drop_incomplete : bool, optional
         If True and stride is not None, drop segments not fully contained within
         the valid time range. Default is True.
-    on_trigger_overlap : {"raise", "warn", "allow"}, optional
-        Behavior when several triggers of the same ``type`` start at the same
-        time on the same ``timeline`` (ambiguous segments). Default is "raise".
 
     Returns
     -------
@@ -404,20 +400,14 @@ def list_segments(
 
     # Two triggers of the same type starting at the same time on the same
     # timeline (e.g. two Fmri events differing only by metadata) define
-    # ambiguous/duplicate segments and can corrupt train/test splits. See
-    # https://github.com/fairinternal/brainai/pull/2531#issuecomment-4073936157
-    if on_trigger_overlap != "allow":
-        keys = ["type", "timeline", "start"]
-        collisions = trigger_df[trigger_df.duplicated(subset=keys, keep=False)]
-        if len(collisions):
-            msg = (
-                f"{len(collisions)} triggers of the same type start at the same time "
-                f"on the same timeline:\n{collisions[keys]}\nNarrow the `triggers` "
-                "mask, or pass on_trigger_overlap='allow' to bypass."
-            )
-            if on_trigger_overlap == "raise":
-                raise ValueError(msg)
-            logger.warning(msg)
+    # ambiguous/duplicate segments and can corrupt train/test splits.
+    keys = ["type", "timeline", "start"]
+    collisions = trigger_df[trigger_df.duplicated(subset=keys, keep=False)]
+    if len(collisions):
+        raise ValueError(
+            f"{len(collisions)} triggers of the same type start at the same time "
+            f"on the same timeline:\n{collisions[keys]}\nNarrow the `triggers` mask."
+        )
 
     df_to_pos = events.index.get_indexer(trigger_df.index)
 

--- a/neuralset-repo/neuralset/segments.py
+++ b/neuralset-repo/neuralset/segments.py
@@ -354,13 +354,8 @@ def list_segments(
         If True and stride is not None, drop segments not fully contained within
         the valid time range. Default is True.
     on_trigger_overlap : {"raise", "warn", "allow"}, optional
-        How to handle two or more trigger events of the same ``type`` starting at
-        the same time on the same ``timeline`` (e.g. two ``Fmri`` events at the
-        same timestamp differing only by metadata). Such simultaneous,
-        similarly-typed triggers are almost always a mistake: they silently
-        create duplicate/ambiguous segments and can corrupt train/test splits.
-        ``"raise"`` (default) errors out, ``"warn"`` logs a warning and keeps
-        going, ``"allow"`` disables the check. Default is ``"raise"``.
+        Behavior when several triggers of the same ``type`` start at the same
+        time on the same ``timeline`` (ambiguous segments). Default is "raise".
 
     Returns
     -------
@@ -407,7 +402,28 @@ def list_segments(
     if not len(trigger_df):
         raise ValueError("Empty trigger events")
 
-    _check_trigger_overlap(trigger_df, on_trigger_overlap)
+    # Two triggers of the same type starting at the same time on the same
+    # timeline (e.g. two Fmri events differing only by metadata) define
+    # ambiguous/duplicate segments and can corrupt train/test splits. See
+    # https://github.com/fairinternal/brainai/pull/2531#issuecomment-4073936157
+    if on_trigger_overlap != "allow":
+        keys = ["type", "timeline", "start"]
+        collisions = trigger_df[trigger_df.duplicated(subset=keys, keep=False)]
+        if len(collisions):
+            groups = collisions.groupby(keys, observed=True).size()
+            examples = "; ".join(
+                f"{int(n)}x type={typ!r} on timeline={tl!r} at start={st}"
+                for (typ, tl, st), n in groups.items()
+            )
+            msg = (
+                f"Found {len(collisions)} trigger events of the same type starting "
+                f"at the same time on the same timeline ({examples}). Narrow the "
+                "`triggers` mask so each segment has a single trigger, or pass "
+                "on_trigger_overlap='allow' to bypass this check."
+            )
+            if on_trigger_overlap == "raise":
+                raise ValueError(msg)
+            logger.warning(msg)
 
     df_to_pos = events.index.get_indexer(trigger_df.index)
 
@@ -460,45 +476,6 @@ def list_segments(
 # ---------------------------------------------------------------------------
 # Utilities
 # ---------------------------------------------------------------------------
-
-
-def _check_trigger_overlap(
-    trigger_df: pd.DataFrame, mode: tp.Literal["raise", "warn", "allow"]
-) -> None:
-    """Detect same-type trigger events starting simultaneously on a timeline.
-
-    Two triggers of the same ``type`` with the same ``start`` on the same
-    ``timeline`` define overlapping/duplicate segments, which is almost always
-    an upstream data-modeling mistake (e.g. several ``Fmri`` events that only
-    differ by metadata such as ``space``/``preproc``). See discussion in
-    https://github.com/fairinternal/brainai/pull/2531#issuecomment-4073936157.
-    """
-    if mode == "allow":
-        return
-
-    keys = ["type", "timeline", "start"]
-    if not all(k in trigger_df.columns for k in keys):
-        return
-    collisions = trigger_df[trigger_df.duplicated(subset=keys, keep=False)]
-    if not len(collisions):
-        return
-
-    groups = collisions.groupby(keys, observed=True).size()
-    examples = "; ".join(
-        f"{int(n)}x type={typ!r} on timeline={tl!r} at start={st}"
-        for (typ, tl, st), n in groups.items()
-    )
-    msg = (
-        f"Found {len(collisions)} trigger events of the same type starting at "
-        f"the same time on the same timeline ({examples}). Such simultaneous, "
-        "similarly-typed triggers create duplicate/ambiguous segments and can "
-        "corrupt train/test splits. Narrow the `triggers` mask (e.g. filter by "
-        "metadata) so each segment has a single unambiguous trigger, or pass "
-        "on_trigger_overlap='allow' to bypass this check."
-    )
-    if mode == "raise":
-        raise ValueError(msg)
-    logger.warning(msg)
 
 
 def _prepare_strided_windows(

--- a/neuralset-repo/neuralset/segments.py
+++ b/neuralset-repo/neuralset/segments.py
@@ -332,6 +332,7 @@ def list_segments(
     duration: float | None = None,
     stride: float | None = None,
     stride_drop_incomplete: bool = True,
+    on_trigger_overlap: tp.Literal["raise", "warn", "allow"] = "raise",
 ) -> list[Segment]:
     """Create a list of segments based on events, sliding windows, or both.
 
@@ -352,6 +353,14 @@ def list_segments(
     stride_drop_incomplete : bool, optional
         If True and stride is not None, drop segments not fully contained within
         the valid time range. Default is True.
+    on_trigger_overlap : {"raise", "warn", "allow"}, optional
+        How to handle two or more trigger events of the same ``type`` starting at
+        the same time on the same ``timeline`` (e.g. two ``Fmri`` events at the
+        same timestamp differing only by metadata). Such simultaneous,
+        similarly-typed triggers are almost always a mistake: they silently
+        create duplicate/ambiguous segments and can corrupt train/test splits.
+        ``"raise"`` (default) errors out, ``"warn"`` logs a warning and keeps
+        going, ``"allow"`` disables the check. Default is ``"raise"``.
 
     Returns
     -------
@@ -397,6 +406,8 @@ def list_segments(
     trigger_df = events.loc[triggers]
     if not len(trigger_df):
         raise ValueError("Empty trigger events")
+
+    _check_trigger_overlap(trigger_df, on_trigger_overlap)
 
     df_to_pos = events.index.get_indexer(trigger_df.index)
 
@@ -449,6 +460,49 @@ def list_segments(
 # ---------------------------------------------------------------------------
 # Utilities
 # ---------------------------------------------------------------------------
+
+
+def _check_trigger_overlap(
+    trigger_df: pd.DataFrame, mode: tp.Literal["raise", "warn", "allow"]
+) -> None:
+    """Detect same-type trigger events starting simultaneously on a timeline.
+
+    Two triggers of the same ``type`` with the same ``start`` on the same
+    ``timeline`` define overlapping/duplicate segments, which is almost always
+    an upstream data-modeling mistake (e.g. several ``Fmri`` events that only
+    differ by metadata such as ``space``/``preproc``). See discussion in
+    https://github.com/fairinternal/brainai/pull/2531#issuecomment-4073936157.
+    """
+    if mode == "allow":
+        return
+    if mode not in ("raise", "warn"):
+        raise ValueError(
+            f"on_trigger_overlap must be 'raise', 'warn' or 'allow', got {mode!r}"
+        )
+
+    keys = ["type", "timeline", "start"]
+    if not all(k in trigger_df.columns for k in keys):
+        return
+    collisions = trigger_df[trigger_df.duplicated(subset=keys, keep=False)]
+    if not len(collisions):
+        return
+
+    groups = collisions.groupby(keys, observed=True).size()
+    examples = "; ".join(
+        f"{int(n)}x type={typ!r} on timeline={tl!r} at start={st}"
+        for (typ, tl, st), n in groups.items()
+    )
+    msg = (
+        f"Found {len(collisions)} trigger events of the same type starting at "
+        f"the same time on the same timeline ({examples}). Such simultaneous, "
+        "similarly-typed triggers create duplicate/ambiguous segments and can "
+        "corrupt train/test splits. Narrow the `triggers` mask (e.g. filter by "
+        "metadata) so each segment has a single unambiguous trigger, or pass "
+        "on_trigger_overlap='allow' to bypass this check."
+    )
+    if mode == "raise":
+        raise ValueError(msg)
+    logger.warning(msg)
 
 
 def _prepare_strided_windows(

--- a/neuralset-repo/neuralset/segments.py
+++ b/neuralset-repo/neuralset/segments.py
@@ -410,16 +410,10 @@ def list_segments(
         keys = ["type", "timeline", "start"]
         collisions = trigger_df[trigger_df.duplicated(subset=keys, keep=False)]
         if len(collisions):
-            groups = collisions.groupby(keys, observed=True).size()
-            examples = "; ".join(
-                f"{int(n)}x type={typ!r} on timeline={tl!r} at start={st}"
-                for (typ, tl, st), n in groups.items()
-            )
             msg = (
-                f"Found {len(collisions)} trigger events of the same type starting "
-                f"at the same time on the same timeline ({examples}). Narrow the "
-                "`triggers` mask so each segment has a single trigger, or pass "
-                "on_trigger_overlap='allow' to bypass this check."
+                f"{len(collisions)} triggers of the same type start at the same time "
+                f"on the same timeline:\n{collisions[keys]}\nNarrow the `triggers` "
+                "mask, or pass on_trigger_overlap='allow' to bypass."
             )
             if on_trigger_overlap == "raise":
                 raise ValueError(msg)

--- a/neuralset-repo/neuralset/test_segments.py
+++ b/neuralset-repo/neuralset/test_segments.py
@@ -55,6 +55,52 @@ def test_segment() -> None:
     assert set(s._to_extractor()) == {"events", "start", "duration", "trigger"}
 
 
+def test_on_trigger_overlap(caplog: pytest.LogCaptureFixture) -> None:
+    # Two same-type triggers starting at the same time on the same timeline
+    # (e.g. two Fmri events differing only by metadata).
+    events = standardize_events(
+        pd.DataFrame(
+            [
+                dict(type="Word", start=10.0, duration=0.5, text="Hello", timeline="x"),
+                dict(type="Word", start=10.0, duration=0.5, text="world", timeline="x"),
+            ]
+        )
+    )
+    triggers = events.type == "Word"
+
+    # default is "raise"
+    with pytest.raises(ValueError, match="same time"):
+        list_segments(events, triggers=triggers, duration=1.0)
+    with pytest.raises(ValueError, match="same time"):
+        list_segments(events, triggers=triggers, duration=1.0, on_trigger_overlap="raise")
+
+    # "warn" logs but still builds the (duplicate) segments
+    with caplog.at_level("WARNING"):
+        segments = list_segments(
+            events, triggers=triggers, duration=1.0, on_trigger_overlap="warn"
+        )
+    assert len(segments) == 2
+    assert "same time" in caplog.text
+
+    # "allow" silently builds the segments
+    segments = list_segments(
+        events, triggers=triggers, duration=1.0, on_trigger_overlap="allow"
+    )
+    assert len(segments) == 2
+
+    # distinct start times never collide, even with the default
+    events2 = standardize_events(
+        pd.DataFrame(
+            [
+                dict(type="Word", start=10.0, duration=0.5, text="Hello", timeline="x"),
+                dict(type="Word", start=12.0, duration=0.5, text="world", timeline="x"),
+            ]
+        )
+    )
+    segments = list_segments(events2, triggers=events2.type == "Word", duration=1.0)
+    assert len(segments) == 2
+
+
 @pytest.mark.parametrize("reloaded", (True, False))
 def test_find_intersect(reloaded: bool, tmp_path: Path, validated: bool = True) -> None:
     #  |-----A----|

--- a/neuralset-repo/neuralset/test_segments.py
+++ b/neuralset-repo/neuralset/test_segments.py
@@ -55,9 +55,9 @@ def test_segment() -> None:
     assert set(s._to_extractor()) == {"events", "start", "duration", "trigger"}
 
 
-def test_on_trigger_overlap(caplog: pytest.LogCaptureFixture) -> None:
+def test_trigger_overlap() -> None:
     # Two same-type triggers starting at the same time on the same timeline
-    # (e.g. two Fmri events differing only by metadata).
+    # (e.g. two Fmri events differing only by metadata) are ambiguous and raise.
     events = standardize_events(
         pd.DataFrame(
             [
@@ -68,25 +68,8 @@ def test_on_trigger_overlap(caplog: pytest.LogCaptureFixture) -> None:
     )
     triggers = events.type == "Word"
 
-    # default is "raise"
     with pytest.raises(ValueError, match="same time"):
         list_segments(events, triggers=triggers, duration=1.0)
-    with pytest.raises(ValueError, match="same time"):
-        list_segments(events, triggers=triggers, duration=1.0, on_trigger_overlap="raise")
-
-    # "warn" logs but still builds the (duplicate) segments
-    with caplog.at_level("WARNING"):
-        segments = list_segments(
-            events, triggers=triggers, duration=1.0, on_trigger_overlap="warn"
-        )
-    assert len(segments) == 2
-    assert "same time" in caplog.text
-
-    # "allow" silently builds the segments
-    segments = list_segments(
-        events, triggers=triggers, duration=1.0, on_trigger_overlap="allow"
-    )
-    assert len(segments) == 2
 
 
 @pytest.mark.parametrize("reloaded", (True, False))
@@ -162,13 +145,13 @@ def test_find_intersect(reloaded: bool, tmp_path: Path, validated: bool = True) 
         actual = seg.find_overlap(events, events.text == "f")
         assert "".join(events.loc[actual].text) == "f"
 
-        expected_list = "d", "da", "dacb", "dacb", "e", "f"
-        # triggering on every event includes two Words at the same start/timeline
+        expected_list = "d", "da", "dacb", "e", "f"
+        # exclude "c": it shares start/timeline with "b" and would be an
+        # ambiguous trigger overlap (same type, time and timeline).
         actual_segments = seg.list_segments(
             events,
-            pd.Series(True, index=events.index),
+            events.text != "c",
             duration=0.1,
-            on_trigger_overlap="allow",
         )
         for act, exp in zip(actual_segments, expected_list):
             sub = events.loc[[e._index for e in act.ns_events]]

--- a/neuralset-repo/neuralset/test_segments.py
+++ b/neuralset-repo/neuralset/test_segments.py
@@ -163,8 +163,12 @@ def test_find_intersect(reloaded: bool, tmp_path: Path, validated: bool = True) 
         assert "".join(events.loc[actual].text) == "f"
 
         expected_list = "d", "da", "dacb", "dacb", "e", "f"
+        # triggering on every event includes two Words at the same start/timeline
         actual_segments = seg.list_segments(
-            events, pd.Series(True, index=events.index), duration=0.1
+            events,
+            pd.Series(True, index=events.index),
+            duration=0.1,
+            on_trigger_overlap="allow",
         )
         for act, exp in zip(actual_segments, expected_list):
             sub = events.loc[[e._index for e in act.ns_events]]

--- a/neuralset-repo/neuralset/test_segments.py
+++ b/neuralset-repo/neuralset/test_segments.py
@@ -88,18 +88,6 @@ def test_on_trigger_overlap(caplog: pytest.LogCaptureFixture) -> None:
     )
     assert len(segments) == 2
 
-    # distinct start times never collide, even with the default
-    events2 = standardize_events(
-        pd.DataFrame(
-            [
-                dict(type="Word", start=10.0, duration=0.5, text="Hello", timeline="x"),
-                dict(type="Word", start=12.0, duration=0.5, text="world", timeline="x"),
-            ]
-        )
-    )
-    segments = list_segments(events2, triggers=events2.type == "Word", duration=1.0)
-    assert len(segments) == 2
-
 
 @pytest.mark.parametrize("reloaded", (True, False))
 def test_find_intersect(reloaded: bool, tmp_path: Path, validated: bool = True) -> None:


### PR DESCRIPTION
## Summary

Adds an `on_trigger_overlap` parameter to `list_segments` that, **by default, raises** when two or more trigger events of the **same `type`** start at the **same time** on the **same `timeline`** (e.g. two `Fmri` events differing only by metadata such as `space`/`preproc`).

Such simultaneous, similarly-typed triggers silently produce duplicate/ambiguous segments and can corrupt train/test splits — the failure mode discussed in fairinternal/brainai#2531 (comment: https://github.com/fairinternal/brainai/pull/2531#issuecomment-4073936157):

> 1. `list_segments(on_trigger_overlap='raise')` to ensure a single trigger, avoid bug with stride

The guard inspects only the **trigger** events (`events.loc[triggers]`), so legitimately overlapping *context* events are unaffected. It runs *before* the strided/non-strided branch, so it covers both modes (catching the "avoid bug with stride" case where colliding triggers would each expand into the same set of windows).

## API

```python
list_segments(events, triggers, *, on_trigger_overlap="raise" | "warn" | "allow")
```

- `"raise"` (default): error, printing the colliding `(type, timeline, start)` rows.
- `"warn"`: log a warning and still build the (duplicate) segments.
- `"allow"`: disable the check (previous behavior).

## Note on the default

Defaulting to `"raise"` is a deliberate behavior change matching the "(by default)" intent in the linked comment. It surfaces pipelines that build segments from simultaneous same-type triggers (e.g. multi-space `Fmri`); those should narrow the `triggers` mask or pass `on_trigger_overlap="allow"`. Happy to flip to `"warn"` if we'd rather phase it in.

Open question (flagged in review): should the collision key drop `type` and use only `(timeline, start)`? For the common single-type trigger this is equivalent; keeping `type` avoids false positives on intentional multi-type triggering where the trigger event carries meaning (e.g. `aggregation="trigger"`).

## Test plan

- [x] New unit test `test_on_trigger_overlap` in `test_segments.py`: covers `raise` (default + explicit), `warn` (logs + builds), `allow`.
- [x] ruff / codespell clean; mypy clean on `segments.py`.
- [ ] CI (lint, mypy, pytest neuralset).

Made-with: Cursor

Made with [Cursor](https://cursor.com)