### PR TITLE
Enable NeuralBench local-only execution through config.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 - `neuralfetch`: added `Allen2022MassiveRaw` (BIDS/deepprep NSD variant) and gated NSD downloads behind the `NSD_ACCEPT_LICENCE` env var.
+- `neuralbench`: added a `CLUSTER` key to `~/.neuralbench/config.json` to force fully local execution (`null`) without `--debug`, keep the default SLURM auto-detection (`"auto"`), or always submit to SLURM (`"slurm"`); honored by `--prepare`.
+- `neuralbench`: a blank `WANDB_HOST` now genuinely disables Weights & Biases logging (previously `wandb.login` was still invoked).
 
 ## [0.2.1] - 2026-05-13
 

--- a/docs/neuralbench/install.md
+++ b/docs/neuralbench/install.md
@@ -59,6 +59,34 @@ paths:
 
 The configuration is stored in `~/.neuralbench/config.json` by default.
 
+### Execution backend (SLURM vs. local)
+
+`neuralbench` dispatches preparation and training jobs through the `CLUSTER`
+key in `~/.neuralbench/config.json`:
+
+- **`"auto"`** (default) -- submit to SLURM when it is auto-detected, otherwise
+  run locally. Non-debug SLURM runs additionally require `SLURM_PARTITION` to be
+  set in the config.
+- **`null`** -- force everything (training plus the preprocessing/target caches)
+  to run locally, in-process, even on a SLURM cluster. Unlike `--debug`, this
+  keeps the full config (full epochs and batches). `--prepare` likewise builds
+  caches locally when `CLUSTER` is `null`.
+- **`"slurm"`** -- always submit to SLURM.
+
+For example, to run the full benchmark locally without SLURM, set:
+
+```json
+{
+  "CLUSTER": null
+}
+```
+
+### Disabling Weights & Biases
+
+Leave `WANDB_HOST` blank (`""`) in your config to disable W&B logging entirely;
+results are still written to `SAVE_DIR` and remain accessible via
+`--plot-cached`.
+
 ### Custom config location
 
 Set the `NEURALBENCH_CONFIG` environment variable to point at a different

--- a/neuralbench-repo/README.md
+++ b/neuralbench-repo/README.md
@@ -41,7 +41,7 @@ neuralbench eeg audiovisual_stimulus --prepare    # 2. Prepare cache (preprocess
 neuralbench eeg audiovisual_stimulus              # 3. Run the full grid
 ```
 
-Steps 2 and 3 dispatch to SLURM when it is auto-detected on your machine; step 3 additionally requires `SLURM_PARTITION` to be set in your neuralbench config. Pass `--debug` to either step to force local execution. Step 2 is mostly useful for larger datasets that benefit from parallel preprocessing with SLURM, and is not strictly necessary for `audiovisual_stimulus`. Add `--debug` to any command for a fast local sanity-check run with a subsampled dataset and a limited number of epochs:
+Steps 2 and 3 dispatch to SLURM when it is auto-detected on your machine; step 3 additionally requires `SLURM_PARTITION` to be set in your neuralbench config. Pass `--debug` to either step to force local execution. To run the full config locally (no SLURM, full epochs and batches), set `"CLUSTER": null` in `~/.neuralbench/config.json` (the default `"auto"` uses SLURM when available; `"slurm"` always submits). Step 2 is mostly useful for larger datasets that benefit from parallel preprocessing with SLURM, and is not strictly necessary for `audiovisual_stimulus`. Add `--debug` to any command for a fast local sanity-check run with a subsampled dataset and a limited number of epochs:
 
 ```console
 neuralbench eeg audiovisual_stimulus --debug      # Local validation run

--- a/neuralbench-repo/neuralbench/cli.py
+++ b/neuralbench-repo/neuralbench/cli.py
@@ -130,6 +130,13 @@ def run_benchmark(
     default_config = load_yaml_config(DEFAULTS_DIR / "config.yaml")
     config = ConfDict(default_config)
 
+    # Disable W&B entirely when no host is configured (blank WANDB_HOST), so the
+    # whole pipeline treats logging as off (mirrors the debug-mode overlay).
+    wandb_cfg = config.get("wandb_config")
+    host = wandb_cfg.get("host") if isinstance(wandb_cfg, dict) else None
+    if not host:
+        config["wandb_config"] = None
+
     default_grid = load_yaml_config(DEFAULTS_DIR / "grid.yaml")
     grid_conf = ConfDict(default_grid)
 

--- a/neuralbench-repo/neuralbench/config_manager.py
+++ b/neuralbench-repo/neuralbench/config_manager.py
@@ -93,6 +93,10 @@ def setup_config(config_path: Path | None = None) -> dict[str, Any]:
     config["SLURM_CONSTRAINT"] = ""
     config["N_CPUS"] = 10
 
+    # Execution cluster: "auto" (SLURM if available, else local), null/None
+    # (force local), or "slurm". Can be overridden later in config.json.
+    config["CLUSTER"] = "auto"
+
     # Prompt for paths
     print("\nPlease provide the following paths:")
     print()
@@ -155,6 +159,7 @@ def _default_config() -> dict[str, Any]:
         "SLURM_PARTITION": "",
         "SLURM_CONSTRAINT": "",
         "N_CPUS": 10,
+        "CLUSTER": "auto",
     }
     for key in ["CACHE_DIR", "SAVE_DIR", "DATA_DIR"]:
         Path(str(config[key])).mkdir(parents=True, exist_ok=True)
@@ -215,12 +220,13 @@ if TYPE_CHECKING:
     SLURM_PARTITION: str
     SLURM_CONSTRAINT: str
     N_CPUS: int
+    CLUSTER: str | None
 
 
 def _initialize_module_vars() -> None:
     """Initialize module-level variables from config."""
     global USER, ENTITY_NAME, PROJECT_NAME, DATA_DIR, CACHE_DIR, SAVE_DIR
-    global WANDB_HOST, SLURM_PARTITION, SLURM_CONSTRAINT, N_CPUS
+    global WANDB_HOST, SLURM_PARTITION, SLURM_CONSTRAINT, N_CPUS, CLUSTER
     config = get_config()
     USER = config["USER"]
     ENTITY_NAME = config["ENTITY_NAME"]
@@ -232,6 +238,7 @@ def _initialize_module_vars() -> None:
     SLURM_PARTITION = config.get("SLURM_PARTITION", "")
     SLURM_CONSTRAINT = config.get("SLURM_CONSTRAINT", "")
     N_CPUS = config.get("N_CPUS", 10)
+    CLUSTER = config.get("CLUSTER", "auto")
 
 
 # Lazy module-level config variables for YAML compatibility
@@ -249,6 +256,7 @@ _LAZY_CONFIG_KEYS = {
     "SLURM_PARTITION",
     "SLURM_CONSTRAINT",
     "N_CPUS",
+    "CLUSTER",
 }
 _initialized = False
 

--- a/neuralbench-repo/neuralbench/conftest.py
+++ b/neuralbench-repo/neuralbench/conftest.py
@@ -12,11 +12,32 @@ from pathlib import Path
 
 import pytest
 
+from . import config_manager
 from .data import Data
 
 # Bypass multiprocessing in the test sandbox; ``Test2024Eeg`` is tiny enough
 # that in-process execution is fast.
 _NO_CLUSTER: tp.Any = {"cluster": None}
+
+
+@pytest.fixture
+def patch_config(monkeypatch: pytest.MonkeyPatch) -> Callable[..., None]:
+    """Override resolved neuralbench config values (CLUSTER, WANDB_HOST, ...).
+
+    Returns a callable that installs a synthetic config and forces the lazy
+    module-level variables to re-resolve from it, so YAML ``!!python/name``
+    references pick up the overrides on the next ``config.yaml`` load.
+    """
+
+    def _apply(**overrides: tp.Any) -> None:
+        base = config_manager._default_config()
+        base.update(overrides)
+        monkeypatch.setattr(config_manager, "_config", base)
+        monkeypatch.setattr(config_manager, "_initialized", False)
+        for key in config_manager._LAZY_CONFIG_KEYS:
+            monkeypatch.delattr(config_manager, key, raising=False)
+
+    return _apply
 
 
 @pytest.fixture(scope="session")

--- a/neuralbench-repo/neuralbench/defaults/config.yaml
+++ b/neuralbench-repo/neuralbench/defaults/config.yaml
@@ -13,7 +13,7 @@ wandb_config:
   project: !!python/name:neuralbench.config_manager.PROJECT_NAME
   name: null
 infra:
-  cluster: auto
+  cluster: !!python/name:neuralbench.config_manager.CLUSTER
   folder: !!python/name:neuralbench.config_manager.SAVE_DIR
   slurm_partition: !!python/name:neuralbench.config_manager.SLURM_PARTITION
   timeout_min: 1440
@@ -68,7 +68,7 @@ data:
     scaler: RobustScaler
     clamp: 20.0
     infra:
-      cluster: auto
+      cluster: !!python/name:neuralbench.config_manager.CLUSTER
       folder: !!python/name:neuralbench.config_manager.CACHE_DIR
       keep_in_ram: true
       slurm_partition: !!python/name:neuralbench.config_manager.SLURM_PARTITION
@@ -81,7 +81,7 @@ data:
     include_ref_eeg: false
   target:
     infra:
-      cluster: auto
+      cluster: !!python/name:neuralbench.config_manager.CLUSTER
       slurm_partition: !!python/name:neuralbench.config_manager.SLURM_PARTITION
       folder: !!python/name:neuralbench.config_manager.CACHE_DIR
       cpus_per_task: !!python/name:neuralbench.config_manager.N_CPUS

--- a/neuralbench-repo/neuralbench/experiment_config.py
+++ b/neuralbench-repo/neuralbench/experiment_config.py
@@ -58,18 +58,23 @@ def _apply_debug_overlay(config: ConfDict) -> None:
 
 def _apply_prepare_overlay(config: ConfDict) -> None:
     """Apply prepare-mode overrides: single run to warm the preprocessing cache."""
+    from neuralbench.config_manager import get_config
+
     LOGGER.info("--- RUNNING SINGLE EXPERIMENT TO PREPARE CACHE ---")
-    config["infra.cluster"] = "auto"
+    cluster = get_config().get("CLUSTER", "auto")
+    # When CLUSTER forces local execution (None), keep cache preparation local
+    # too; otherwise use "slurm" (rather than "auto") so prepare_extractors
+    # launches the extractor jobs concurrently.
+    cache_cluster = None if cluster is None else "slurm"
+    config["infra.cluster"] = cluster
     config["infra.gpus_per_node"] = 1
     config["infra.tasks_per_node"] = 1
     config["infra.slurm_use_srun"] = False
-    # Parallel SLURM-based caching for the extractors (use "slurm" rather than
-    # "auto" so that prepare_extractors launches them concurrently)
-    config["data.neuro.infra.cluster"] = "slurm"
+    config["data.neuro.infra.cluster"] = cache_cluster
     config["data.neuro.infra.min_samples_per_job"] = 8
     target_cfg = config.get("data", {}).get("target", {})
     if isinstance(target_cfg, dict) and "infra" in target_cfg:
-        config["data.target.infra.cluster"] = "slurm"
+        config["data.target.infra.cluster"] = cache_cluster
         config["data.target.infra.min_samples_per_job"] = 8
     if "trainer_config" in config:
         config["trainer_config"] = {
@@ -256,8 +261,9 @@ def _warn_slurm_partition(
     """Warn when SLURM is detected but no partition is configured.
 
     Skipped when the run does not actually submit jobs (``debug``,
-    ``prepare``, ``download``).  The warning surfaces the resolved config
-    path, honoring the ``NEURALBENCH_CONFIG`` environment variable.
+    ``prepare``, ``download``, or ``CLUSTER`` forcing local execution).  The
+    warning surfaces the resolved config path, honoring the
+    ``NEURALBENCH_CONFIG`` environment variable.
     """
     import os
     import shutil
@@ -267,6 +273,9 @@ def _warn_slurm_partition(
     if debug or prepare or download:
         return
     config = get_config()
+    # CLUSTER=null forces fully local execution, so no SLURM jobs are submitted.
+    if config.get("CLUSTER", "auto") is None:
+        return
     if not config.get("SLURM_PARTITION") and shutil.which("srun") is not None:
         config_path = os.environ.get("NEURALBENCH_CONFIG") or str(
             get_default_config_path()
@@ -275,5 +284,5 @@ def _warn_slurm_partition(
             "SLURM is available on this machine but SLURM_PARTITION is not set "
             f"in your neuralbench config ({config_path}). Non-debug runs will "
             f"fail when submitting jobs. Either set SLURM_PARTITION in "
-            f"{config_path}, or use --debug to run locally."
+            f'{config_path}, set "CLUSTER": null to run locally, or use --debug.'
         )

--- a/neuralbench-repo/neuralbench/experiment_config.py
+++ b/neuralbench-repo/neuralbench/experiment_config.py
@@ -18,6 +18,7 @@ from warnings import warn
 import yaml
 from exca import ConfDict
 
+from neuralbench.config_manager import get_config
 from neuralbench.registry import (
     DEBUG_STUDY_QUERIES,
     _resolve_model_config_path,
@@ -58,23 +59,21 @@ def _apply_debug_overlay(config: ConfDict) -> None:
 
 def _apply_prepare_overlay(config: ConfDict) -> None:
     """Apply prepare-mode overrides: single run to warm the preprocessing cache."""
-    from neuralbench.config_manager import get_config
-
     LOGGER.info("--- RUNNING SINGLE EXPERIMENT TO PREPARE CACHE ---")
+    # Use the configured CLUSTER for both the run and the extractor/target
+    # caches. "auto" already fans out to SLURM when available (submitit's auto
+    # executor) and falls back to local otherwise, so we avoid hard-coding
+    # "slurm", which would fail on machines without a SLURM cluster.
     cluster = get_config().get("CLUSTER", "auto")
-    # When CLUSTER forces local execution (None), keep cache preparation local
-    # too; otherwise use "slurm" (rather than "auto") so prepare_extractors
-    # launches the extractor jobs concurrently.
-    cache_cluster = None if cluster is None else "slurm"
     config["infra.cluster"] = cluster
     config["infra.gpus_per_node"] = 1
     config["infra.tasks_per_node"] = 1
     config["infra.slurm_use_srun"] = False
-    config["data.neuro.infra.cluster"] = cache_cluster
+    config["data.neuro.infra.cluster"] = cluster
     config["data.neuro.infra.min_samples_per_job"] = 8
     target_cfg = config.get("data", {}).get("target", {})
     if isinstance(target_cfg, dict) and "infra" in target_cfg:
-        config["data.target.infra.cluster"] = cache_cluster
+        config["data.target.infra.cluster"] = cluster
         config["data.target.infra.min_samples_per_job"] = 8
     if "trainer_config" in config:
         config["trainer_config"] = {
@@ -268,7 +267,7 @@ def _warn_slurm_partition(
     import os
     import shutil
 
-    from neuralbench.config_manager import get_config, get_default_config_path
+    from neuralbench.config_manager import get_default_config_path
 
     if debug or prepare or download:
         return

--- a/neuralbench-repo/neuralbench/test_cli.py
+++ b/neuralbench-repo/neuralbench/test_cli.py
@@ -79,21 +79,22 @@ def test_cluster_config_wires_all_infra_clusters(
     assert raw["data"]["target"]["infra"]["cluster"] == cluster
 
 
-@pytest.mark.parametrize(
-    "cluster,expected_cache",
-    [(None, None), ("auto", "slurm"), ("slurm", "slurm")],
-)
+@pytest.mark.parametrize("cluster", [None, "auto", "slurm"])
 def test_prepare_overlay_respects_cluster(
-    patch_config: Callable[..., None], cluster: str | None, expected_cache: str | None
+    patch_config: Callable[..., None], cluster: str | None
 ) -> None:
-    """``--prepare`` runs caches locally when CLUSTER is null, else on slurm."""
+    """``--prepare`` uses the configured CLUSTER for the run and both caches.
+
+    "auto" fans out to SLURM when available and runs locally otherwise, so the
+    cache infra is never hard-coded to "slurm" (which would fail without SLURM).
+    """
     patch_config(CLUSTER=cluster)
     config = ConfDict(load_yaml_config(DEFAULTS_DIR / "config.yaml"))
     _apply_prepare_overlay(config)
     flat = config.flat()
     assert flat["infra.cluster"] == cluster
-    assert flat["data.neuro.infra.cluster"] == expected_cache
-    assert flat["data.target.infra.cluster"] == expected_cache
+    assert flat["data.neuro.infra.cluster"] == cluster
+    assert flat["data.target.infra.cluster"] == cluster
 
 
 def _capture_assembled_experiments(

--- a/neuralbench-repo/neuralbench/test_cli.py
+++ b/neuralbench-repo/neuralbench/test_cli.py
@@ -4,7 +4,10 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
+import shutil
 import typing as tp
+import warnings
+from collections.abc import Callable
 
 import pytest
 from exca import ConfDict
@@ -12,7 +15,12 @@ from exca import ConfDict
 import neuralset as ns
 
 from . import transforms as _transforms  # noqa: F401  — registers Step subclasses
-from .experiment_config import prepare_task_configs
+from .cli import run_benchmark
+from .experiment_config import (
+    _apply_prepare_overlay,
+    _warn_slurm_partition,
+    prepare_task_configs,
+)
 from .main import Data
 from .registry import ALL_DATASETS, ALL_TASKS, DEFAULTS_DIR, load_yaml_config
 
@@ -56,6 +64,97 @@ def test_prepare_task_configs(dataset: str | None) -> None:
     source: tp.Any = steps["source"]
     assert source.path is not None
     assert source.infra is not None
+
+
+@pytest.mark.parametrize("cluster", [None, "auto", "slurm"])
+def test_cluster_config_wires_all_infra_clusters(
+    patch_config: Callable[..., None], cluster: str | None
+) -> None:
+    """The CLUSTER config value drives training + both cache infra.cluster fields."""
+    patch_config(CLUSTER=cluster)
+    raw = load_yaml_config(DEFAULTS_DIR / "config.yaml")
+    assert raw is not None
+    assert raw["infra"]["cluster"] == cluster
+    assert raw["data"]["neuro"]["infra"]["cluster"] == cluster
+    assert raw["data"]["target"]["infra"]["cluster"] == cluster
+
+
+@pytest.mark.parametrize(
+    "cluster,expected_cache",
+    [(None, None), ("auto", "slurm"), ("slurm", "slurm")],
+)
+def test_prepare_overlay_respects_cluster(
+    patch_config: Callable[..., None], cluster: str | None, expected_cache: str | None
+) -> None:
+    """``--prepare`` runs caches locally when CLUSTER is null, else on slurm."""
+    patch_config(CLUSTER=cluster)
+    config = ConfDict(load_yaml_config(DEFAULTS_DIR / "config.yaml"))
+    _apply_prepare_overlay(config)
+    flat = config.flat()
+    assert flat["infra.cluster"] == cluster
+    assert flat["data.neuro.infra.cluster"] == expected_cache
+    assert flat["data.target.infra.cluster"] == expected_cache
+
+
+def _capture_assembled_experiments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[ConfDict]:
+    """Run ``run_benchmark`` with a stubbed aggregator, returning assembled configs."""
+    captured: dict[str, tp.Any] = {}
+
+    class _FakeAggregator:
+        def __init__(self, experiments: list[ConfDict], debug: bool) -> None:
+            captured["experiments"] = experiments
+
+        def prepare(self) -> None:
+            pass
+
+    monkeypatch.setattr("neuralbench.main.BenchmarkAggregator", _FakeAggregator)
+    run_benchmark("eeg", "motor_imagery")
+    return captured["experiments"]
+
+
+def test_run_benchmark_disables_wandb_when_host_blank(
+    monkeypatch: pytest.MonkeyPatch, patch_config: Callable[..., None]
+) -> None:
+    """A blank WANDB_HOST nulls wandb_config across all assembled experiments."""
+    patch_config(WANDB_HOST="", SLURM_PARTITION="dummy")
+    experiments = _capture_assembled_experiments(monkeypatch)
+    assert experiments
+    assert all(cfg.get("wandb_config") is None for cfg in experiments)
+
+
+def test_run_benchmark_keeps_wandb_when_host_set(
+    monkeypatch: pytest.MonkeyPatch, patch_config: Callable[..., None]
+) -> None:
+    """A configured WANDB_HOST is preserved in assembled experiments."""
+    host = "https://wandb.example.com"
+    patch_config(WANDB_HOST=host, SLURM_PARTITION="dummy")
+    experiments = _capture_assembled_experiments(monkeypatch)
+    wandb_cfg = experiments[0].get("wandb_config")
+    assert wandb_cfg is not None
+    assert wandb_cfg["host"] == host
+
+
+def test_warn_slurm_partition_suppressed_when_cluster_local(
+    monkeypatch: pytest.MonkeyPatch, patch_config: Callable[..., None]
+) -> None:
+    """No SLURM warning when CLUSTER forces local execution, even with srun present."""
+    patch_config(CLUSTER=None, SLURM_PARTITION="")
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/srun")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        _warn_slurm_partition(debug=False)
+
+
+def test_warn_slurm_partition_fires_without_partition(
+    monkeypatch: pytest.MonkeyPatch, patch_config: Callable[..., None]
+) -> None:
+    """SLURM warning still fires under CLUSTER='auto' with srun but no partition."""
+    patch_config(CLUSTER="auto", SLURM_PARTITION="")
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/srun")
+    with pytest.warns(UserWarning, match="SLURM is available"):
+        _warn_slurm_partition(debug=False)
 
 
 def test_run_benchmark_cli_help_smoke(

--- a/neuralbench-repo/neuralbench/test_config_manager.py
+++ b/neuralbench-repo/neuralbench/test_config_manager.py
@@ -1,0 +1,31 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+from collections.abc import Callable
+
+from . import config_manager
+
+
+def test_default_config_includes_cluster() -> None:
+    """The non-interactive default config exposes CLUSTER='auto'."""
+    config = config_manager._default_config()
+    assert config["CLUSTER"] == "auto"
+
+
+def test_cluster_resolves_to_none_when_configured_null(
+    patch_config: Callable[..., None],
+) -> None:
+    """A config with ``CLUSTER: null`` resolves the lazy module var to ``None``."""
+    patch_config(CLUSTER=None)
+    assert config_manager.CLUSTER is None
+
+
+def test_cluster_resolves_to_configured_value(
+    patch_config: Callable[..., None],
+) -> None:
+    """A non-null CLUSTER value is surfaced verbatim."""
+    patch_config(CLUSTER="slurm")
+    assert config_manager.CLUSTER == "slurm"


### PR DESCRIPTION
## What does this PR do?

Adds support for running NeuralBench fully locally (no SLURM) and for cleanly disabling Weights & Biases, both controlled via `~/.neuralbench/config.json`.

Verified end-to-end: with `CLUSTER=null` + blank `WANDB_HOST`, `neuralbench eeg audiovisual_stimulus` runs in-process with zero SLURM submissions and zero wandb usage; with the default config it submits to SLURM and logs to W&B on the compute node.

## Related PRs

- #98

## Checklist

- [x] Tests added or updated
- [x] Docstrings updated for any changed public APIs
- [x] `pytest` and `mypy` pass locally