### PR TITLE
Truncate HuggingFaceText context to model positional capacity

### DIFF
--- a/neuralset-repo/neuralset/extractors/test_text.py
+++ b/neuralset-repo/neuralset/extractors/test_text.py
@@ -9,6 +9,7 @@ import typing as tp
 
 import numpy as np
 import pandas as pd
+import pydantic
 import pytest
 import torch
 
@@ -247,6 +248,34 @@ def test_llm_long_context() -> None:
     word.context = " ".join([str(k) for k in range(1024)])
     # should work even though context is larger that 1024=maximum (~1500)
     _ = extractor(word, 0, 1)
+
+
+def test_max_length_real_limit() -> None:
+    extractor = text.HuggingFaceText(model_name="openai-community/gpt2", device="cpu")
+    assert extractor.tokenizer.model_max_length == 1024
+    assert extractor._get_max_length() == 1024
+
+
+@pytest.mark.skipif("IN_GITHUB_ACTION" in os.environ, reason="OPT not in CI cache")
+def test_max_length_sentinel_fallback() -> None:
+    """OPT's tokenizer reports the HF 'infinite' sentinel, so _max_length must
+    fall back to the model's position table and an over-length context must
+    truncate instead of overflowing OPT's learned positions."""
+    word = _make_word()
+    word.context = " ".join(str(k) for k in range(4000))  # >2050 tokens
+    try:
+        extractor = text.HuggingFaceText(
+            model_name="facebook/opt-125m",
+            contextualized=True,
+            device="cpu",
+        )
+        tokenizer = extractor.tokenizer
+        assert tokenizer.model_max_length >= int(1e29)  # sentinel, not a real limit
+        config: tp.Any = extractor.model.config  # type: ignore[union-attr]
+        assert extractor._get_max_length() == config.max_position_embeddings
+        _ = extractor(word, 0, 1)
+    except (OSError, RuntimeError, pydantic.ValidationError):
+        pytest.skip("opt-125m unreachable")
 
 
 @pytest.mark.skipif(

--- a/neuralset-repo/neuralset/extractors/text.py
+++ b/neuralset-repo/neuralset/extractors/text.py
@@ -291,6 +291,7 @@ class HuggingFaceText(BaseStatic, HuggingFaceMixin):
     # initialized later
     _model: nn.Module = pydantic.PrivateAttr()
     _tokenizer: tp.Any = pydantic.PrivateAttr()
+    _max_length: int | None = pydantic.PrivateAttr(None)
 
     def model_post_init(self, log__: tp.Any) -> None:
         super().model_post_init(log__)
@@ -384,6 +385,24 @@ class HuggingFaceText(BaseStatic, HuggingFaceMixin):
         self.model
         return self._tokenizer
 
+    def _get_max_length(self) -> int | None:
+        """Token truncation limit, falling back to the model's positional capacity."""
+        if self._max_length is not None:
+            return self._max_length
+        tok_max = self.tokenizer.model_max_length
+        # HF "infinite" sentinel (~1e30) would disable truncation (overflows OPT)
+        if isinstance(tok_max, int) and tok_max < int(1e29):
+            self._max_length = tok_max
+            return self._max_length
+        # learned-position table is sized capacity + offset, so the offset cancels
+        config = self.model.config
+        for attr in ("max_position_embeddings", "n_positions", "n_ctx"):
+            value = getattr(config, attr, None)
+            if isinstance(value, int) and value > 0:
+                self._max_length = value
+                return self._max_length
+        return None
+
     def _get_timed_arrays(
         self,
         events: list[_ev.etypes.Word | _ev.etypes.Sentence],
@@ -444,6 +463,7 @@ class HuggingFaceText(BaseStatic, HuggingFaceMixin):
                         return_tensors="pt",
                         padding=True,
                         truncation=True,  # beware to have set truncation_side="left" in init
+                        max_length=self._get_max_length(),  # guard tokenizers reporting no real limit (e.g. OPT)
                     ).to(device)
                 outputs = self.model(**inputs, output_hidden_states=True)
                 if "hidden_states" in outputs:


### PR DESCRIPTION
## What does this PR do?

Fixes the OPT contextual-embedding crash in `HuggingFaceText` (`facebook/opt-*` jobs hitting a CUDA `indexSelectLargeIndex` / device-side assert).

`_get_data` tokenized with `truncation=True` but no `max_length`, so it fell back to `tokenizer.model_max_length`. OPT reports the HF "infinite" sentinel (~1e30), disabling truncation; long contexts then overflowed OPT's learned position table. 

The fix derives an explicit `max_length` from the model's real positional capacity (memoized in `_get_max_length`) and passes it to the tokenizer, so truncation always engages.

Behavior:
- Models with a real `model_max_length` (gpt2, Qwen, Llama, BERT, T5, rotary models): unchanged.
- OPT/BART (sentinel + offset position table): truncated to capacity; `truncation_side="left"` keeps the target word at the tail.

Co-authored with @jrapin 