### PR TITLE
Fix duplicate Sentence rows in AddSentenceToWords with multiple Text events

### DIFF
--- a/neuralset-repo/neuralset/events/transforms/test_transforms.py
+++ b/neuralset-repo/neuralset/events/transforms/test_transforms.py
@@ -302,6 +302,23 @@ def test_sentence_to_word_standard() -> None:
     # TODO paragraphs
 
 
+def test_add_sentence_to_words_multiple_text_contexts() -> None:
+    common = dict(timeline="foo", language="english")
+    events = [
+        dict(type="Text", start=-0.1, duration=2, text="he runs.", **common),
+        dict(type="Text", start=2.0, duration=2, text="she eats", **common),
+        dict(type="Word", start=0.0, duration=0.1, text="he", **common),
+        dict(type="Word", start=0.5, duration=0.1, text="runs", **common),
+        dict(type="Word", start=2.5, duration=0.1, text="she", **common),
+        dict(type="Word", start=3.0, duration=0.1, text="eats", **common),
+    ]
+    df = ns.events.standardize_events(pd.DataFrame(events))
+    out = _transf.AddSentenceToWords()(df)
+    sentences = out.loc[out.type == "Sentence", "text"]
+    assert len(sentences) == 2
+    assert set(sentences) == {"he runs.", "she eats"}
+
+
 def test_sentence_to_word_missing_word(caplog: pytest.LogCaptureFixture) -> None:
     text = "le petit prince"
     words = ("le", "pince")

--- a/neuralset-repo/neuralset/events/transforms/text.py
+++ b/neuralset-repo/neuralset/events/transforms/text.py
@@ -181,7 +181,6 @@ class AddSentenceToWords(EventsTransform):
         events["sentence"] = ""
         events["text_char"] = np.nan
 
-        sentences: list[dict[str, tp.Any]] = []
         for context in contexts.itertuples():
             # find words that are enclosed in this context (requires unique timeline)
             encl = _segs.find_enclosed(
@@ -205,9 +204,9 @@ class AddSentenceToWords(EventsTransform):
                 index=sel,
             )
             events.loc[sel, info.columns] = info
-            # create sentence events; standardize_events backfills BIDS/study
-            # from sibling rows in the same timeline.
-            sentences.extend(s.to_dict() for s in _extract_sentences(events))
+        # create sentence events; standardize_events backfills BIDS/study
+        # from sibling rows in the same timeline.
+        sentences = [s.to_dict() for s in _extract_sentences(events)]
         sentences = [s for s in sentences if s["text"] != MISSING_SENTENCE]
         sentence_df = pd.DataFrame(sentences)
         events = pd.concat([events, sentence_df], ignore_index=True)


### PR DESCRIPTION
## What does this PR do?

AddSentenceToWords called `_extract_sentences` inside the loop over `Text` contexts, so each pass re-derived sentences from the full `events` table and appended them again. Timelines with several `Text` rows could end up with duplicate `Sentence` events.
Sentence extraction now runs once after all contexts have been matched to words.

## Checklist

- [x] Tests added or updated
- [x] `pytest` and `mypy` pass locally
