### PR TITLE
Add support for new datasets in NeuralBench

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -376,6 +376,7 @@ sphinx_gallery_conf = {
         "neuralbench/tutorials/04_adding_model",
         "neuralbench/tutorials/05_advanced",
         "neuralbench/tutorials/06_eeg_challenge",
+        "neuralbench/tutorials/07_biosignal_challenge_2026",
     ],
     "gallery_dirs": [
         # neuralset
@@ -395,6 +396,7 @@ sphinx_gallery_conf = {
         "neuralbench/auto_examples/adding_model",
         "neuralbench/auto_examples/advanced",
         "neuralbench/auto_examples/eeg_challenge",
+        "neuralbench/auto_examples/biosignal_challenge_2026",
     ],
     "filename_pattern": r"/.+\.py$",
     "backreferences_dir": "gen_modules/backreferences",

--- a/docs/neuralbench/dataset_table.csv
+++ b/docs/neuralbench/dataset_table.csv
@@ -8,7 +8,7 @@ Dementia diagnosis,:bdg-danger:`subject`,EEG,:py:class:`~neuralset.studies.Milti
 Depression diagnosis,:bdg-danger:`subject`,EEG,:py:class:`~neuralset.studies.Mumtaz2018Machine`,5.0,19,Classification,2,14683,8756,69,2760,64,
 Emotion,:bdg-success:`event`,EEG,:py:class:`~neuralset.studies.Chen2023Large`,5.0,32,Classification,9,20664,12264,96,3840,123,
 Error-related negativity,:bdg-success:`event`,EEG,:py:class:`~neuralset.studies.Kappenman2021ErpErn`,1.0,30,Classification,2,15972,9591,75,3000,40,Chavarriaga2010Learning; Kueper2024Eeg
-Image,:bdg-success:`event`,EEG,:py:class:`~neuralset.studies.Gifford2022Large`,1.0,63,Retrieval,1536,830640,534720,4178,167120,10,
+Image,:bdg-success:`event`,EEG,:py:class:`~neuralset.studies.Gifford2022Large`,1.0,63,Retrieval,1536,830640,534720,4178,167120,10,Xu2024Alljoined; Xu2025Alljoined
 Lrp,:bdg-success:`event`,EEG,:py:class:`~neuralset.studies.Kappenman2021ErpLrp`,1.0,30,Classification,2,15972,9591,75,3000,40,
 Mental arithmetic,:bdg-success:`event`,EEG,:py:class:`~neuralset.studies.Zyma2019Eeg`,5.0,20,Classification,2,1659,986,8,320,35,Shin2017OpenB
 Mental imagery,:bdg-success:`event`,EEG,:py:class:`~neuralset.studies.Scherer2015Individually`,4.0,30,Classification,5,3550,1620,13,520,9,
@@ -29,7 +29,7 @@ Seizure,:bdg-success:`event`,EEG,:py:class:`~neuralset.studies.Dan2023Bids`,5.0,
 Sentence,:bdg-success:`event`,EEG,:py:class:`~neuralset.studies.Hollenstein2018Zuco`,3.0,128,Retrieval,768,25819,17181,135,5400,12,
 Sex,:bdg-danger:`subject`,EEG,:py:class:`~neuralset.studies.Shirazi2024Hbn`,2.0,129,Classification,2,171480,123120,962,38480,2858,
 Sleep arousal,:bdg-success:`event`,EEG,:py:class:`~neuralset.studies.Ghassemi2018You`,15.0,6,Classification,2,1838941,1106687,8646,345840,994,
-Sleep stage,:bdg-success:`event`,EEG,:py:class:`~neuralset.studies.Kemp2000Analysis`,30.0,2,Classification,5,196220,116493,911,36440,78,
+Sleep stage,:bdg-success:`event`,EEG,:py:class:`~neuralset.studies.Kemp2000Analysis`,30.0,2,Classification,5,196220,116493,911,36440,78,Ghassemi2018You; Alvarez2022Haaglanden
 Speech,:bdg-success:`event`,EEG,:py:class:`~neuralset.studies.Brennan2019Hierarchical`,3.0,60,Retrieval,4096,70257,46827,366,14640,33,
 Ssvep,:bdg-success:`event`,EEG,:py:class:`~neuralset.studies.Wang2017Benchmark`,4.0,64,Classification,40,8160,4800,38,1520,34,Kalunga2016Online; Lee2019EegSsvep; Nakanishi2015Comparison; Oikonomou2016ComparativeA; Oikonomou2016ComparativeB; Oikonomou2016ComparativeC; Wang2017Benchmark
 Typing,:bdg-success:`event`,EEG,:py:class:`~neuralset.studies.Levy2025BrainEeg`,1.0,61,Classification,29,146551,87650,685,27400,20,
@@ -37,4 +37,4 @@ Video,:bdg-success:`event`,EEG,:py:class:`~neuralset.studies.Liu2024Eeg2video`,2
 Word,:bdg-success:`event`,EEG,:py:class:`~neuralset.studies.Nieuwland2018Large`,3.0,74,Retrieval,1024,529730,425399,3324,132960,222,
 Image,:bdg-success:`event`,MEG,:py:class:`~neuralset.studies.Hebart2023ThingsMeg`,1.0,300,Retrieval,1536,98592,71201,557,22280,4,
 Typing,:bdg-success:`event`,MEG,:py:class:`~neuralset.studies.Levy2025BrainMeg`,1.0,306,Classification,29,193051,119479,934,37360,23,
-Image,:bdg-success:`event`,fMRI,:py:class:`~neuralset.studies.Allen2022Nsd`,7.0,,Retrieval,1536,213000,153559,1200,48000,8,
+Image,:bdg-success:`event`,fMRI,:py:class:`~neuralset.studies.Allen2022Nsd`,7.0,,Retrieval,1536,213000,153559,1200,48000,8,Chang2019Bold5000; Hebart2023ThingsBold

--- a/docs/neuralbench/index.rst
+++ b/docs/neuralbench/index.rst
@@ -117,6 +117,15 @@ comparison figures and tables from the stored results (no retraining):
       Reproduce the NeurIPS 2025 challenge tasks (cross-task reaction
       time and externalizing-factor prediction) with NeuralBench.
 
+   .. grid-item-card:: :fas:`trophy` EEG/EMG Foundation Challenge 2026
+      :link: auto_examples/biosignal_challenge_2026/plot_overview
+      :link-type: doc
+      :class-card: sd-shadow-sm
+
+      Starter kit for the proposed 2026 multi-track challenge:
+      EEG-to-Image, BCI, sleep onset, EMG-to-Text, and Foundation
+      Transfer.
+
 ----
 
 Running the full EEG benchmark
@@ -202,6 +211,7 @@ If you use NeuralBench in your research, please cite the
    auto_examples/adding_model/index
    auto_examples/advanced/index
    auto_examples/eeg_challenge/index
+   auto_examples/biosignal_challenge_2026/index
 
 .. toctree::
     :maxdepth: 3

--- a/docs/neuralbench/tasks/eeg/image.rst
+++ b/docs/neuralbench/tasks/eeg/image.rst
@@ -30,9 +30,27 @@ Dataset Notes
 
 * We use [Gifford2022Large]_ for evaluation because test images were recorded in separate runs, limiting the potential impact of temporal correlations on decoding performance.
 
+Additional Datasets
+~~~~~~~~~~~~~~~~~~~
+
+The following additional EEG image-decoding datasets can also be used with this task:
+
+* ``Xu2024Alljoined`` (Alljoined1) -- 8 participants, 64-channel EEG at 512 Hz, viewing static images from the Natural Scenes Dataset (NSD) [Xu2024Alljoined]_.
+* ``Xu2025Alljoined`` (Alljoined-1.6M) -- 20 participants viewing static images in EEG [Xu2025Alljoined]_. Source: `Hugging Face <https://huggingface.co/datasets/Alljoined/Alljoined-1.6M>`_.
+* ``Grootswagers2022Human`` (THINGS-EEG1) -- 50 participants, 64-channel EEG at 1000 Hz, viewing rapid serial visual presentation (RSVP) streams covering all 1,854 THINGS object concepts; uses the dataset's predefined train/test split [Grootswagers2022]_.
+
+To run with an alternate dataset:
+
+.. code-block:: bash
+
+   neuralbench eeg image --dataset xu2024alljoined
+
 References
 ~~~~~~~~~~
 
 .. [Benchetrit2023] Benchetrit, Yohann, Hubert Banville, and Jean-Rémi King. "Brain decoding: toward real-time reconstruction of visual perception." arXiv preprint arXiv:2310.19812 (2023).
 .. [Gifford2022Large] Gifford, Alessandro T., et al. "A large and rich EEG dataset for modeling human visual object recognition." NeuroImage 264 (2022): 119754.
 .. [Hebart2019] Hebart, Martin N., et al. "THINGS: A database of 1,854 object concepts and more than 26,000 naturalistic object images." PloS one 14.10 (2019): e0223792.
+.. [Xu2024Alljoined] Xu, Jonathan, et al. "Alljoined -- A dataset for EEG-to-Image decoding." arXiv preprint arXiv:2404.05553 (2024).
+.. [Xu2025Alljoined] Xu, Jonathan, et al. "Alljoined-1.6M: A Million-Trial EEG-Image Dataset for Evaluating Affordable Brain-Computer Interfaces." arXiv preprint arXiv:2508.18571 (2025).
+.. [Grootswagers2022] Grootswagers, Tijl, et al. "Human EEG recordings for 1,854 concepts presented in rapid serial visual presentation streams." Scientific Data 9.1 (2022): 3.

--- a/docs/neuralbench/tasks/eeg/sleep_onset.rst
+++ b/docs/neuralbench/tasks/eeg/sleep_onset.rst
@@ -55,8 +55,26 @@ regimes that demand fundamentally different algorithmic capabilities.
 Standard regression metrics (MAE, RMSE, Pearson r, R^2, normalized RMSE) are
 also logged alongside the headline ``bmae``.
 
+Additional Datasets
+~~~~~~~~~~~~~~~~~~~
+
+The following additional polysomnography datasets can also be used with this
+task. Both expose annotated sleep stages, so ``AddSleepOnsetTargets`` derives
+the N2-onset target the same way as on Sleep-EDF.
+
+* ``Alvarez2022Haaglanden`` (HMC-Sleep-Staging) -- 151 whole-night PSG recordings (6-channel EEG, 256 Hz) from clinical sleep-center patients [Alvarez2022]_.
+* ``Ghassemi2018You`` (PhysioNet/CinC Challenge 2018) -- clinical PSG recordings; only the labeled training split (N=994) is used [Ghassemi2018]_.
+
+To run with an alternate dataset:
+
+.. code-block:: bash
+
+   neuralbench eeg sleep_onset --dataset alvarez2022haaglanden
+
 References
 ~~~~~~~~~~
 
 .. [Kemp2000] B Kemp, AH Zwinderman, B Tuk, HAC Kamphuisen, JJL Oberyé. Analysis of a sleep-dependent neuronal feedback loop: the slow-wave microcontinuity of the EEG. IEEE-BME 47(9):1185-1194 (2000).
 .. [Rechtschaffen1968] A Rechtschaffen, AE Kales. A manual of standardized terminology, techniques and scoring systems for sleep stages of human subjects. Los Angeles, CA: UCLA Brain Information Service. Brain Research Institute 10 (1968).
+.. [Alvarez2022] D Alvarez-Estevez, R Rijsman. Haaglanden Medisch Centrum Sleep Staging Database (version 1.1). PhysioNet (2022). doi:10.13026/T79Q-FR32.
+.. [Ghassemi2018] MM Ghassemi, BE Moody, L-w H Lehman, C Song, Q Li, H Sun, RG Mark, MB Westover, GD Clifford. You Snooze, You Win: The PhysioNet/Computing in Cardiology Challenge 2018. Computing in Cardiology 45 (2018).

--- a/docs/neuralbench/tasks/eeg/sleep_stage.rst
+++ b/docs/neuralbench/tasks/eeg/sleep_stage.rst
@@ -32,8 +32,24 @@ Dataset Notes
 
 * Recordings are cropped to start 30 minutes before the first occurrence of a sleep stage and end 30 minutes after the last occurrence of a sleep stage to avoid imbalances due to long periods of wakefulness at the beginning and end of the recordings.
 
+Additional Datasets
+~~~~~~~~~~~~~~~~~~~
+
+The following additional polysomnography datasets can also be used with this task:
+
+* ``Ghassemi2018You`` (PhysioNet/CinC Challenge 2018) -- 1,985 whole-night recordings annotated for sleep stage and arousal; only the labelled training split is used here [Ghassemi2018You]_.
+* ``Alvarez2022Haaglanden`` (HMC) -- 151 whole-night polysomnographic recordings from clinical sleep-center patients [Alvarez2022Haaglanden]_.
+
+To run with an alternate dataset:
+
+.. code-block:: bash
+
+   neuralbench eeg sleep_stage --dataset alvarez2022haaglanden
+
 References
 ~~~~~~~~~~
 
 .. [Rechtschaffen1968] A Rechtschaffen, AE Kales. A manual of standardized terminology, techniques and scoring systems for sleep stages of human subjects. Los Angeles, CA: UCLA Brain Information Service. Brain Research Institute 10 (1968).
 .. [Kemp2000] B Kemp, AH Zwinderman, B Tuk, HAC Kamphuisen, JJL Oberyé. Analysis of a sleep-dependent neuronal feedback loop: the slow-wave microcontinuity of the EEG. IEEE-BME 47(9):1185-1194 (2000).
+.. [Ghassemi2018You] Ghassemi, Mohammad M., et al. "You Snooze, You Win: The PhysioNet/Computing in Cardiology Challenge 2018." Computing in Cardiology 45 (2018).
+.. [Alvarez2022Haaglanden] Alvarez-Estevez, Diego, and Roselyne Rijsman. "Haaglanden Medisch Centrum Sleep Staging Database." PhysioNet (2022).

--- a/docs/neuralbench/tasks/fmri/image.rst
+++ b/docs/neuralbench/tasks/fmri/image.rst
@@ -3,7 +3,7 @@ Image decoding
 
 | **Name**: image
 | **Category**: cognitive decoding
-| **Dataset**: :py:class:`~neuralfetch.studies.allen2022massive.Allen2022MassiveRaw` (NSD, BIDS/deepprep variant)
+| **Dataset**: :py:class:`~neuralfetch.studies.chang2019bold5000.Chang2019Bold5000` (BOLD5000)
 | **Objective**: :bdg-dark:`Retrieval`
 | **Split**: Predefined
 
@@ -23,19 +23,34 @@ Usage
 Description
 ~~~~~~~~~~~
 
-The fMRI image decoding task involves retrieving the visual stimulus presented to a subject from their BOLD fMRI response. We use the Natural Scenes Dataset (NSD) [Allen2022]_, a large-scale 7T fMRI dataset in which 8 subjects each viewed up to 10,000 distinct natural scene images over 30--40 scanning sessions (~73,000 image presentations total).
+The fMRI image decoding task involves retrieving the visual stimulus presented to a subject from their BOLD fMRI response. We use BOLD5000 [Chang2019]_, a 3T fMRI dataset in which 4 subjects each viewed ~5,000 natural images drawn from the SUN, COCO, and ImageNet collections over 9--15 scanning sessions.
 
 BOLD responses are extracted from a 7-second window starting 2 seconds after image onset to account for the hemodynamic delay. Surface-projected activations (fsaverage5 mesh) are used as model input. Target embeddings are DINOv2-giant representations of the presented images (1536-dimensional).
 
-The train/test split follows the dataset-native partition: NSD reserves a set of 1,000 images seen by all 8 subjects as a shared test set.
+The train/test split follows the dataset-native partition based on the 113 images repeated across sessions for test-retest reliability.
 
 Dataset Notes
 ~~~~~~~~~~~~~
 
-* The NSD is a very large dataset (several TB). Downloading requires AWS credentials and agreeing to the NSD terms of use.
-* Only the ``betas_fithrf_GLMdenoise_RR`` single-trial beta maps and the stimulus images are needed.
+* BOLD5000 is distributed via OpenNeuro (``ds001499``) under a CC0 licence; the preprocessed beta maps (MNI152NLin2009aSym space) and the stimulus images are needed.
+
+Additional Datasets
+~~~~~~~~~~~~~~~~~~~
+
+The following additional fMRI image-decoding datasets can also be used with this task:
+
+* ``Allen2022MassiveRaw`` (NSD) -- 8 participants each viewing up to 10,000 distinct natural scene images over 30--40 7T scanning sessions (~73,000 presentations total) [Allen2022]_.
+* ``Hebart2023ThingsBold`` (THINGS-fMRI) -- 3 participants viewing 1,854 diverse object images from the THINGS database [Hebart2023]_.
+
+To run with an alternate dataset:
+
+.. code-block:: bash
+
+   neuralbench fmri image --dataset Allen2022MassiveRaw
 
 References
 ~~~~~~~~~~
 
 .. [Allen2022] Allen, Emily J., et al. "A massive 7T fMRI dataset to bridge cognitive neuroscience and artificial intelligence." Nature Neuroscience 25.1 (2022): 116-126.
+.. [Chang2019] Chang, Nadine, et al. "BOLD5000, a public fMRI dataset while viewing 5000 visual images." Scientific Data 6.1 (2019): 49.
+.. [Hebart2023] Hebart, Martin N., et al. "THINGS-data, a multimodal collection of large-scale datasets for investigating object representations in human brain and behavior." eLife 12 (2023): e82580.

--- a/docs/neuralbench/tutorials/07_biosignal_challenge_2026/GALLERY_HEADER.rst
+++ b/docs/neuralbench/tutorials/07_biosignal_challenge_2026/GALLERY_HEADER.rst
@@ -1,0 +1,14 @@
+EEG/EMG Foundation Challenge 2026
+=================================
+
+Starter kit for the proposed 2026 EEG/EMG Foundation Challenge.
+
+Each page below walks through one competition track and shows how to
+reproduce its NeuralBench baseline. Start with the overview, then jump
+to the track(s) you plan to submit to.
+
+.. note::
+   These pages assume ``neuralbench`` is already installed and
+   configured. See :doc:`/neuralbench/install` and the
+   :doc:`quickstart </neuralbench/auto_examples/quickstart/01_run_first_task>`
+   if you have not run a task yet.

--- a/docs/neuralbench/tutorials/07_biosignal_challenge_2026/plot_overview.py
+++ b/docs/neuralbench/tutorials/07_biosignal_challenge_2026/plot_overview.py
@@ -1,0 +1,189 @@
+"""
+Overview: EEG/EMG Foundation Challenge 2026
+============================================
+
+The EEG/EMG Foundation Challenge 2026 is a proposed multi-track
+competition on shift-robust representation learning for biosignals,
+and the multi-modal successor to the 2025 EEG Foundation Challenge.
+
+.. note::
+
+   The competition is currently at the proposal stage and has not
+   yet been accepted. This starter kit is shared so the community
+   can experiment with the planned tracks while the proposal is
+   under review.
+
+The competition is organised as **4 + 1 tracks**:
+
+1. **Track 1 -- EEG-to-Image** (cross-stimulus): retrieve a viewed image
+   from EEG. Headline metric: **Top-5 retrieval accuracy** (higher is
+   better).
+2. **Track 2 -- EEG-to-BCI** (cross-session, within-user): decode one of
+   three cued mental tasks (motor imagery, mental calculation, word
+   association). Headline metric: **balanced accuracy** averaged over
+   subject-session-context cells (higher is better).
+3. **Track 3 -- Sleep onset** (cross-subject): estimate sleep-onset
+   latency from wearable EEG. Headline metric: **recording-level mean
+   absolute error in seconds** (lower is better).
+4. **Track 4 -- EMG-to-Text** (cross-subject): decode keystroke
+   sequences from surface EMG. Headline metric: **character error
+   rate** (lower is better).
+5. **Track 5 -- Foundation Transfer** (cross-task, EEG only): submit a
+   *single* EEG encoder; organisers fit linear probes for Tracks 1-3.
+   Headline metric: **mean rank** across the three EEG leaderboards
+   (lower is better).
+
+Tracks 1-4 accept both task-specific models and foundation models.
+Track 5 is restricted to a single shared encoder.
+
+This starter kit shows how to reproduce a baseline for each track with
+NeuralBench, using the closest publicly available dataset when the
+official competition data is not yet released.
+"""
+
+# %%
+# Starter kit pages
+# -----------------
+#
+# - :doc:`Track 1 -- EEG-to-Image <plot_track1_eeg_to_image>`
+# - :doc:`Track 2 -- EEG-to-BCI <plot_track2_eeg_to_bci>`
+# - :doc:`Track 3 -- Sleep onset <plot_track3_sleep_onset>`
+# - :doc:`Track 4 -- EMG-to-Text <plot_track4_emg_to_text>`
+# - :doc:`Track 5 -- Foundation Transfer <plot_track5_foundation_transfer>`
+# - :doc:`How to Submit a Model <plot_submission_guide>`
+#
+# Each page follows the same shape:
+#
+# 1. What the track measures (data, shift, headline metric).
+# 2. The matching ``neuralbench`` task and CLI commands.
+# 3. Where the official competition data diverges from the default.
+
+# %%
+# Representative results
+# ----------------------
+#
+# The table below summarises NeuralBench results on **publicly
+# available datasets that are similar in paradigm and modality** to
+# the ones the competition will use. These numbers are *not* the
+# competition leaderboard -- the official tracks will use distinct
+# datasets, hidden evaluation sets, and rerun protocols. They are
+# useful as a sanity check that your training pipeline behaves like
+# the published baselines on the closest open data.
+#
+# .. list-table::
+#    :header-rows: 1
+#    :widths: 22 18 18 18 18
+#
+#    * - Model
+#      - Image (Top-5 %, higher)
+#      - BCI (Bal. acc %, higher)
+#      - Sleep (Onset MAE s, lower)
+#      - EMG (CER %, lower)
+#    * - Chance
+#      - 2.22 +/- 0.31
+#      - 24.81 +/- 1.03
+#      - 205.42 +/- 0.01
+#      - 96.71 +/- 0.00
+#    * - Dummy
+#      - 2.50 +/- 0.00
+#      - 25.00 +/- 0.00
+#      - 299.90 +/- 0.00
+#      - 100.00 +/- 0.00
+#    * - EEGNet
+#      - 28.13 +/- 0.14
+#      - 58.58 +/- 0.34
+#      - 143.30 +/- 0.40
+#      - --
+#    * - REVE (FM)
+#      - 84.75 +/- 0.38
+#      - 68.04 +/- 0.73
+#      - 134.89 +/- 2.02
+#      - --
+#    * - EMG2QwertyNet
+#      - --
+#      - --
+#      - --
+#      - 25.14 +/- 2.30
+#
+# REVE is also the reference **Track 5** baseline: its three EEG-track
+# numbers come from a single set of encoder weights, so its mean rank
+# on the Tracks 1-3 leaderboards is also its Track 5 score.
+
+# %%
+# Collecting and plotting your results
+# -------------------------------------
+#
+# Every NeuralBench run caches its test-metric dictionary on disk.
+# After the experiments you care about have finished, re-invoke the
+# same CLI command with ``--plot-cached`` to aggregate results into
+# comparison plots and CSV tables without retraining:
+#
+# .. code-block:: bash
+#
+#    # 1. Run experiments (cached automatically)
+#    neuralbench eeg image motor_imagery sleep_onset -m eegnet reve
+#
+#    # 2. Aggregate cached results -- no retraining
+#    neuralbench eeg image motor_imagery sleep_onset -m eegnet reve --plot-cached
+#
+# ``--plot-cached`` produces, under ``<SAVE_DIR>/outputs/``:
+#
+# - ``core/core_bar_chart.png`` -- bar chart per task and model.
+# - ``core/core_results_table.csv`` -- raw per-task metrics.
+# - ``core/core_rank_table.csv`` -- ranks per task (the input to the
+#   Track 5 mean-rank score).
+#
+# For programmatic access to the same data, instantiate
+# :class:`~neuralbench.main.BenchmarkAggregator` directly. The
+# :doc:`/neuralbench/auto_examples/results/plot_visualize_results`
+# tutorial walks through the full Python API, including how to
+# customise the loss-to-metric mapping and the output directory.
+
+# %%
+# Resources and dependencies
+# ---------------------------
+#
+# This starter kit relies on the following organiser-maintained
+# open-source libraries:
+#
+# - `NeuralBench <https://facebookresearch.github.io/neuroai/>`_
+#   (this package): unified benchmark suite.
+# - `NeuralSet <https://kingjr.github.io/files/neuralset.pdf>`_: data
+#   loading, study registry, event system.
+# - `Braindecode <https://github.com/braindecode/braindecode>`_ and
+#   `MOABB <https://github.com/NeuroTechX/moabb>`_: deep-learning EEG
+#   architectures and BCI benchmarks.
+# - `MNE-Python <https://mne.tools/>`_ and
+#   `EEG-Dash <https://eegdash.org/>`_: signal-processing primitives.
+#
+# If ``neuralbench`` is not yet installed, follow the
+# :doc:`installation guide </neuralbench/install>` and the
+# :doc:`quickstart </neuralbench/auto_examples/quickstart/01_run_first_task>`
+# before continuing.
+
+# %%
+# Known gaps in this starter kit
+# -------------------------------
+#
+# Some pieces of the planned competition pipeline are not yet shipped
+# with NeuralBench at the time of writing. The following items are
+# being worked on and will be folded back into the relevant track
+# page once they land:
+#
+# 1. **Official Track 2 dataset (MI / Calc / Word, 20 subjects, 6
+#    sessions, Graz + BrainHero).** The corresponding study is not
+#    public yet. Track 2 currently uses ``Stieger2021Continuous`` (4
+#    motor-imagery classes, cross-subject) as the closest analog.
+# 2. **Muse sleep-onset training set (~1000 subjects).** The Track 3
+#    page currently runs on ``Kemp2000Analysis`` (Sleep-EDF) -- and the
+#    additional ``Ghassemi2018You`` / ``Alvarez2022Haaglanden`` PSG
+#    datasets -- with the same ``SleepOnsetTargetExtractor`` + ``bmae``
+#    metric the competition will use.
+# 3. **Hidden evaluation sets.** Every track is scored against a hidden
+#    test set (Alljoined Emotiv for Track 1, later Graz/BrainHero
+#    sessions for Track 2, the Muse cohort for Track 3, 100 new users
+#    for Track 4). Only the closest public training data ships here, so
+#    the numbers above are sanity checks, not leaderboard scores.
+#
+# Updates and corrections to this page are tracked on the GitHub
+# repository linked from the (future) competition website.

--- a/docs/neuralbench/tutorials/07_biosignal_challenge_2026/plot_submission_guide.py
+++ b/docs/neuralbench/tutorials/07_biosignal_challenge_2026/plot_submission_guide.py
@@ -1,0 +1,61 @@
+"""
+How to Submit a Model
+======================
+
+This page describes how to package and submit a model to the
+EEG/EMG Foundation Challenge 2026.
+
+.. warning::
+   The submission portal is **not yet open**. This page is a
+   placeholder that documents the expected submission workflow.
+   It will be updated with concrete instructions and URLs once
+   the competition is officially launched.
+"""
+
+# %%
+# Overview
+# --------
+#
+# Each track accepts a trained model (or, for Track 5, a frozen
+# encoder). The submission workflow follows three steps:
+#
+# 1. **Train** your model locally using NeuralBench or your own
+#    pipeline.
+# 2. **Package** the model weights and a minimal inference script
+#    into the required format.
+# 3. **Upload** the package to the competition portal, where
+#    organisers run evaluation on the hidden test set.
+#
+# Tracks 1--4 accept both task-specific models and foundation
+# models. Track 5 accepts only a single frozen EEG encoder (see
+# :doc:`plot_track5_foundation_transfer`).
+
+# %%
+# Important dates (TBD)
+# ---------------------
+#
+# .. list-table::
+#    :widths: 40 60
+#
+#    * - Competition launch
+#      - TBD
+#    * - Submission portal opens
+#      - TBD
+#    * - Submission deadline
+#      - TBD
+#    * - Winners announced
+#      - NeurIPS 2026 competition track
+
+# %%
+# Next steps
+# ----------
+#
+# While the portal is not yet open, you can already:
+#
+# - Run the track baselines from the starter kit to familiarise
+#   yourself with the tasks and metrics.
+# - Register a new model in NeuralBench and iterate on your
+#   architecture (see
+#   :doc:`/neuralbench/auto_examples/adding_model/create_new_model`).
+# - Watch the competition repository for announcements on portal
+#   availability and dataset releases.

--- a/docs/neuralbench/tutorials/07_biosignal_challenge_2026/plot_track1_eeg_to_image.py
+++ b/docs/neuralbench/tutorials/07_biosignal_challenge_2026/plot_track1_eeg_to_image.py
@@ -1,0 +1,78 @@
+"""
+Track 1 -- EEG-to-Image (cross-stimulus retrieval)
+====================================================
+
+Given EEG recorded while a participant views a natural image, decode
+the image identity. The competition tests **cross-stimulus**
+generalisation: training images and test images do not overlap.
+
+- **Shift**: seen images -> unseen images.
+- **Headline metric**: Top-5 retrieval accuracy in a frozen DINOv2
+  embedding space (higher is better).
+- **Data**: THINGS-EEG1 + THINGS-EEG2 + Alljoined-1 + Alljoined-1.6M
+  (88 subjects, research- and consumer-grade hardware). The hidden
+  evaluation set is provided by Alljoined and uses Emotiv hardware.
+"""
+
+# %%
+# NeuralBench mapping
+# -------------------
+#
+# The closest task in NeuralBench is :doc:`/neuralbench/tasks/eeg/image`.
+#
+# - **CLI**: ``neuralbench eeg image``
+# - **Default dataset**: ``Gifford2022Large`` (THINGS-EEG2,
+#   10 subjects, 63 channels). This is one of the four datasets the
+#   competition uses.
+# - **Target**: frozen ``facebook/dinov2-giant`` image embeddings
+#   (1536-d), aligned with a CLIP contrastive loss -- the same
+#   embedding space the competition scorer uses.
+# - **Headline metric key**: ``test/batch_top5_acc`` (Top-5 retrieval).
+#
+# .. dropdown:: Show ``tasks/eeg/image/config.yaml``
+#
+#    .. literalinclude:: ../../../../neuralbench-repo/neuralbench/tasks/eeg/image/config.yaml
+#       :language: yaml
+
+# %%
+# Reproducing the baseline
+# ------------------------
+#
+# .. code-block:: bash
+#
+#    # 1. Download THINGS-EEG2
+#    neuralbench eeg image --download
+#
+#    # 2. Build the preprocessing + DINOv2 target cache
+#    neuralbench eeg image --prepare
+#
+#    # 3. Quick local sanity check (2 epochs, subsampled)
+#    neuralbench eeg image --debug
+#
+#    # 4. Full baseline -- task-specific model (EEGNet)
+#    neuralbench eeg image -m eegnet
+#
+# Step 2 is the most expensive: it computes one DINOv2 embedding per
+# unique stimulus and caches it under ``CACHE_DIR``.
+
+# %%
+# Where the competition data diverges
+# ------------------------------------
+#
+# The starter kit ships four relevant datasets you can use to develop
+# and evaluate your model, while the competition itself evaluates on a
+# *hidden* Alljoined Emotiv test set. The four available training
+# sources are ``Gifford2022Large`` (THINGS-EEG2, the default),
+# ``Grootswagers2022Human`` (THINGS-EEG1), ``Xu2024Alljoined``
+# (Alljoined-1) and ``Xu2025Alljoined`` (Alljoined-1.6M). They give
+# directionally correct baselines but not the exact competition numbers
+# (the hidden Emotiv test set is not public).
+#
+# The three non-default sources are registered under
+# ``tasks/eeg/image/datasets/`` and can be selected with ``--dataset``:
+#
+# .. code-block:: bash
+#
+#    neuralbench eeg image --dataset grootswagers2022human
+#    neuralbench eeg image --dataset xu2024alljoined
+#    neuralbench eeg image --dataset xu2025alljoined

--- a/docs/neuralbench/tutorials/07_biosignal_challenge_2026/plot_track2_eeg_to_bci.py
+++ b/docs/neuralbench/tutorials/07_biosignal_challenge_2026/plot_track2_eeg_to_bci.py
@@ -1,0 +1,88 @@
+"""
+Track 2 -- EEG-to-BCI (cross-session command decoding)
+========================================================
+
+Given EEG recorded while a user performs one of three cued mental
+tasks (kinesthetic motor imagery, mental calculation, or
+letter/word association), decode the active command after the user
+has already provided labelled calibration data. The competition tests
+**within-user, cross-session** generalisation.
+
+- **Shift**: early sessions -> later sessions (Graz + BrainHero
+  contexts).
+- **Headline metric**: balanced accuracy averaged over
+  subject-session-context cells (higher is better).
+- **Data**: 20 subjects, 6 sessions each, BrainAmp/actiCAP. Sessions
+  1-3 of the 10 evaluation subjects are released as labelled
+  calibration; sessions 4-6 are the hidden test set. The 10 training
+  subjects have all 6 sessions released.
+
+.. note::
+   At the time of writing the official Track 2 dataset
+   (Dreyer / Kojima / Lotte, 3 classes: MI / Calc / Word) is not
+   publicly released. NeuralBench's :doc:`motor_imagery
+   </neuralbench/tasks/eeg/motor_imagery>` task is the closest
+   analog and is used here as the starter-kit baseline.
+"""
+
+# %%
+# NeuralBench mapping (starter-kit analog)
+# -----------------------------------------
+#
+# - **CLI**: ``neuralbench eeg motor_imagery``
+# - **Default dataset**: ``Stieger2021Continuous`` (62 subjects,
+#   60-channel EEG, 4-class motor imagery -- LH / RH / Both / Rest).
+# - **Shift**: cross-subject (NeuralBench's default split), *not* the
+#   cross-session shift of the competition. Use it to validate the
+#   training pipeline and architecture choice.
+# - **Headline metric key**: ``test/bal_acc``.
+#
+# .. dropdown:: Show ``tasks/eeg/motor_imagery/config.yaml``
+#
+#    .. literalinclude:: ../../../../neuralbench-repo/neuralbench/tasks/eeg/motor_imagery/config.yaml
+#       :language: yaml
+
+# %%
+# Reproducing the baseline
+# ------------------------
+#
+# .. code-block:: bash
+#
+#    # 1. Download Stieger2021Continuous
+#    neuralbench eeg motor_imagery --download
+#
+#    # 2. Prepare the preprocessing cache
+#    neuralbench eeg motor_imagery --prepare
+#
+#    # 3. Quick local sanity check
+#    neuralbench eeg motor_imagery --debug
+#
+#    # 4. Full baseline -- task-specific model (EEGNet)
+#    neuralbench eeg motor_imagery -m eegnet
+#
+# Other MI datasets registered in
+# :doc:`/neuralbench/tasks/eeg/motor_imagery` (MOABB, Dreyer2023,
+# BCI Competition IV, ...) can also be selected with ``--dataset
+# <name>`` and are useful for stress-testing cross-subject behaviour.
+
+# %%
+# Adapting to the competition setup
+# ----------------------------------
+#
+# To match the official Track 2 evaluation regime, two pieces need to
+# change once the official dataset is released:
+#
+# 1. **Dataset source**: register the new MI / Calc / Word study and
+#    set ``data.study.source.name`` to it, with
+#    ``brain_model_output_size: 3``.
+# 2. **Split**: replace the default ``SklearnSplit`` with a
+#    predefined per-subject split where sessions 1-3 are train and
+#    sessions 4-6 are test. The
+#    ``neuralset.events.transforms.PredefinedSplit`` already used by
+#    ``reaction_time`` and ``psychopathology`` is the right primitive
+#    -- the ``test_split_query`` becomes
+#    ``"subject in evaluation_subjects and session in [4, 5, 6]"``.
+#
+# Submissions may dispatch internally to per-subject sub-models using
+# the per-example metadata dictionary ``m`` (subject, session, run,
+# paradigm). Re-training on the hidden later sessions is forbidden.

--- a/docs/neuralbench/tutorials/07_biosignal_challenge_2026/plot_track3_sleep_onset.py
+++ b/docs/neuralbench/tutorials/07_biosignal_challenge_2026/plot_track3_sleep_onset.py
@@ -1,0 +1,99 @@
+"""
+Track 3 -- Sleep onset (cross-subject latency prediction)
+===========================================================
+
+Given a continuous wearable EEG recording, predict the latency
+(in seconds, from recording start) at which the participant
+transitions into stable sleep. The competition tests **cross-subject**
+generalisation: train sleepers and test sleepers are disjoint.
+
+- **Shift**: seen sleepers -> unseen sleepers.
+- **Headline metric**: recording-level mean absolute error in seconds
+  (lower is better). Tolerance rates within 30 / 60 / 300 s are
+  reported as diagnostics.
+- **Data**: continuous Muse wearable EEG, ~1000 training subjects,
+  hidden evaluation set of the same order of magnitude. The reference
+  onset is the first annotated N2 event (or equivalently the first
+  non-Wake epoch satisfying a fixed persistence rule).
+
+.. note::
+   The Muse training set will be released by InteraXon for the
+   competition. Until then, this starter kit runs on the Sleep-EDF
+   dataset (``Kemp2000Analysis``) -- the data format and target
+   extractor are identical, only the recording hardware differs.
+"""
+
+# %%
+# NeuralBench mapping
+# -------------------
+#
+# - **CLI**: ``neuralbench eeg sleep_onset``
+# - **Default dataset**: ``Kemp2000Analysis`` (Sleep-EDF Expanded,
+#   78 nights, 2 EEG channels, full polysomnography).
+# - **Target**: latency from recording start to the first N2 epoch,
+#   extracted by ``AddSleepOnsetTargets`` + ``SleepOnsetTargetExtractor``
+#   and capped at 600 s. This matches the competition's reference
+#   definition.
+# - **Headline metric key**: ``test/bmae`` (binned MAE in seconds).
+#
+# .. dropdown:: Show ``tasks/eeg/sleep_onset/config.yaml``
+#
+#    .. literalinclude:: ../../../../neuralbench-repo/neuralbench/tasks/eeg/sleep_onset/config.yaml
+#       :language: yaml
+
+# %%
+# Reproducing the baseline
+# ------------------------
+#
+# .. code-block:: bash
+#
+#    # 1. Download Sleep-EDF
+#    neuralbench eeg sleep_onset --download
+#
+#    # 2. Prepare the preprocessing cache
+#    neuralbench eeg sleep_onset --prepare
+#
+#    # 3. Quick local sanity check
+#    neuralbench eeg sleep_onset --debug
+#
+#    # 4. Full baseline -- task-specific model (EEGNet)
+#    neuralbench eeg sleep_onset -m eegnet
+
+# %%
+# Where the competition data diverges
+# ------------------------------------
+#
+# Sleep-EDF and the Muse competition data differ on three axes that
+# matter at training time:
+#
+# 1. **Hardware**: research-grade PSG (Sleep-EDF) vs consumer-grade
+#    Muse headband (4-channel frontal EEG, +/- accelerometer, no EOG).
+#    Expect to drop or re-map channels in the dataloader.
+# 2. **Cohort and recording context**: laboratory monitored sleep vs
+#    home recordings with movement artifacts and impedance changes.
+# 3. **Annotations**: full hypnograms vs ``n2_onset`` events only on
+#    the training set. NeuralBench already trains on
+#    ``SleepOnsetMarker`` events, so the model interface does not
+#    change.
+#
+# Two additional polysomnography datasets are already registered under
+# ``tasks/eeg/sleep_onset/datasets/`` and use the same
+# ``AddSleepOnsetTargets`` + ``bmae`` pipeline as the default. They are
+# useful for stress-testing cross-subject behaviour on more sleepers:
+#
+# .. code-block:: bash
+#
+#    neuralbench eeg sleep_onset --dataset ghassemi2018you
+#    neuralbench eeg sleep_onset --dataset alvarez2022haaglanden
+#
+# Once the Muse study is registered, switching is a single
+# ``data.study.source.name: Interaxon2026Muse`` override (or
+# ``--dataset interaxon2026muse`` if a ``datasets/`` YAML ships).
+#
+# Submission outputs (per the competition):
+#
+# - a direct onset estimate ``tau_hat`` in seconds, **or**
+# - per-window time-to-onset predictions, **or**
+# - per-window sleep probabilities.
+#
+# The current NeuralBench head produces the first format directly.

--- a/docs/neuralbench/tutorials/07_biosignal_challenge_2026/plot_track4_emg_to_text.py
+++ b/docs/neuralbench/tutorials/07_biosignal_challenge_2026/plot_track4_emg_to_text.py
@@ -1,0 +1,65 @@
+"""
+Track 4 -- EMG-to-Text (cross-subject keystroke decoding)
+===========================================================
+
+Given surface EMG (sEMG) recorded from two wristbands while a user
+types prompted text on a physical QWERTY keyboard, decode the
+keystroke sequence. The competition tests **cross-subject**
+generalisation: train users and test users are disjoint.
+
+- **Shift**: seen users -> unseen users.
+- **Headline metric**: corpus-level character error rate (CER), with
+  insertion / deletion / substitution rates and rendered-text CER as
+  diagnostics. Lower is better.
+- **Data**: ``emg2qwerty`` for training and local validation (108
+  users, two differential dry-electrode sEMG wristbands, 2 kHz). The
+  hidden evaluation set contains 100 new users with the same hardware
+  and paradigm.
+
+.. note::
+   The official Track 4 evaluation set (100 new users on the same
+   hardware) is not public yet, so this page runs on the released
+   ``emg2qwerty`` training data as the closest open analog.
+"""
+
+# %%
+# NeuralBench mapping
+# -------------------
+#
+# The entry point is:
+#
+# - **CLI**: ``neuralbench emg typing``
+# - **Default dataset**: ``Sivakumar2024Emg2qwerty`` (108 users,
+#   32-channel EMG, 2 kHz, ~1135 sessions, BIDS-converted from the
+#   original HDF5 release).
+# - **Target**: keystroke token sequence over an alphabet of keyboard
+#   symbols (space, punctuation, backspace).
+# - **Headline metric key**: ``test/cer`` (character error rate).
+#
+# The study itself is already documented:
+# :py:class:`~neuralset.studies.Sivakumar2024Emg2qwerty`. It exposes
+# three event types: ``Emg`` (raw signal), ``Sentence`` (prompt), and
+# ``Keystroke`` (token + timestamp).
+
+# %%
+# Reproducing the baseline
+# ------------------------
+#
+# .. code-block:: bash
+#
+#    # 1. Download emg2qwerty / NM000104 (~239 GB, via eegdash/NEMAR)
+#    neuralbench emg typing --download
+#
+#    # 2. Prepare the preprocessing cache
+#    neuralbench emg typing --prepare
+#
+#    # 3. Quick local sanity check
+#    neuralbench emg typing --debug
+#
+#    # 4. Full baseline -- task-specific model (EMG2QwertyNet)
+#    neuralbench emg typing -m emg2qwertynet
+#
+# Unlike the EEG tracks, the headline metric is sequence-level: the
+# model must output a *sequence* of keystrokes, not a per-window
+# label. Any sequence-supervised objective is permitted (CTC, RNN-T,
+# alignment-supervised, LM-assisted, ...).

--- a/docs/neuralbench/tutorials/07_biosignal_challenge_2026/plot_track5_foundation_transfer.py
+++ b/docs/neuralbench/tutorials/07_biosignal_challenge_2026/plot_track5_foundation_transfer.py
@@ -1,0 +1,130 @@
+"""
+Track 5 -- Foundation Transfer (one EEG encoder, three tasks)
+==============================================================
+
+Track 5 evaluates the central foundation-model claim: does a *single*
+EEG encoder transfer across heterogeneous EEG tasks without
+task-specific re-training? Participants submit one encoder
+:math:`g_{\\phi}`; the organisers freeze it and **linear-probe** it
+for each of the three EEG tracks (Image, BCI, Sleep), then auto-enrol
+the submission on those leaderboards under the foundation-model
+label.
+
+- **Shift**: cross-task, cross-device, cross-montage.
+- **Headline metric**: mean rank of the submission across the three
+  EEG leaderboards (lower is better),
+  :math:`S_{\\mathrm{FM}}(a) = \\frac{1}{3} \\sum_{t} r_{a,t}`.
+- **Rule**: the encoder must be a single set of weights. It may read
+  the per-example metadata :math:`m` (subject, session, track,
+  channel layout) and may be channel-aware, but bundling separately
+  trained sub-encoders is not allowed.
+"""
+
+# %%
+# How Track 5 is scored
+# ---------------------
+#
+# Submitting an encoder to Track 5 *automatically* produces three
+# leaderboard entries. For each EEG track, the organisers freeze the
+# encoder weights and fit a **linear probe** on top of the encoder
+# features:
+#
+# 1. Track 1 (EEG-to-Image) -- linear probe on
+#    :math:`g_{\phi}(X, m)`, plugged into the same Top-5 retrieval
+#    scorer as Track 1.
+# 2. Track 2 (EEG-to-BCI) -- linear probe on the same encoder
+#    features, scored with balanced accuracy.
+# 3. Track 3 (Sleep onset) -- linear probe on the same encoder
+#    features, scored with onset MAE.
+#
+# The submission's Track 5 score is the mean of its ranks on those
+# three leaderboards. Ties are broken by jointly bootstrapping the
+# three leaderboards (see the competition proposal for details).
+#
+# Practically: a strong Track 5 submission needs to be competitive on
+# **all three** EEG tracks at the same time, with frozen encoder
+# weights and a single channel-handling mechanism. No track-specific
+# fine-tuning of the encoder is allowed.
+#
+# .. note::
+#    The official Track 5 protocol freezes the encoder and fits a
+#    **linear probe** per track. NeuralBench currently runs foundation
+#    models with **full fine-tuning** (the encoder is trained jointly
+#    with the head), so the baselines below approximate Track 5 rather
+#    than reproduce its exact frozen-encoder protocol. Frozen-encoder
+#    linear probing is coming soon; until it lands, treat these numbers
+#    as an upper-bound proxy for the transfer signal.
+
+# %%
+# Reproducing the reference baseline (REVE)
+# ------------------------------------------
+#
+# REVE is the reference Track 5 baseline: a single set of weights
+# evaluated across Tracks 1-3. To reproduce its three leaderboard
+# entries with NeuralBench:
+#
+# .. code-block:: bash
+#
+#    # Image: Top-5 accuracy
+#    neuralbench eeg image -m reve
+#
+#    # BCI: balanced accuracy (starter-kit dataset, see Track 2)
+#    neuralbench eeg motor_imagery -m reve
+#
+#    # Sleep onset: recording-level MAE
+#    neuralbench eeg sleep_onset -m reve
+#
+# Each command produces a ``test/<metric>`` value (``batch_top5_acc``,
+# ``bal_acc``, ``bmae``). REVE's three values are reported in
+# :doc:`plot_overview`.
+#
+# To compare against task-specific models on the same three tracks:
+#
+# .. code-block:: bash
+#
+#    neuralbench eeg image           -m all_classic all_fm
+#    neuralbench eeg motor_imagery   -m all_classic all_fm
+#    neuralbench eeg sleep_onset     -m all_classic all_fm
+#
+# Then use the
+# :doc:`results tutorial </neuralbench/auto_examples/results/plot_visualize_results>`
+# (or the ``--plot-cached`` workflow described in
+# :doc:`plot_overview`) to aggregate ranks across the three tracks.
+
+# %%
+# Submitting your own foundation model
+# -------------------------------------
+#
+# Track 5 submissions are evaluated by the organisers; the encoder
+# itself runs locally during preparation and is then packaged for
+# submission. From NeuralBench's perspective, the encoder is a
+# foundation model registered under ``models/<your_model>.yaml`` with
+# a ``downstream_model_wrapper`` (the same wiring used by
+# ``reve.yaml``, ``labram.yaml``, ``bendr.yaml``, ``biot.yaml``,
+# ``cbramod.yaml``, ``luna.yaml``). With NeuralBench's current support,
+# the encoder is fine-tuned end-to-end with the downstream head;
+# frozen-encoder linear probing (the official Track 5 protocol) is
+# coming soon.
+#
+# See :doc:`/neuralbench/auto_examples/adding_model/create_new_model`
+# for the model-registration walkthrough. The same encoder config can
+# then be passed to all three EEG tracks via ``-m <your_model>``.
+
+# %%
+# Rules cheat-sheet (from the competition proposal)
+# --------------------------------------------------
+#
+# - One set of weights. No separately trained sub-encoders, no
+#   metadata-conditional routing among separately trained components.
+# - The encoder is frozen at submission time; only the organisers'
+#   linear probes adapt to each track.
+# - Channel handling (e.g., padding to a canonical montage, learned
+#   channel embeddings from electrode positions) is a single shared
+#   component.
+# - Pre-training data is unrestricted but must be disclosed in the
+#   methods report.
+# - A Track 5 team may **not** also submit specialised models to
+#   Tracks 1-3 in their own name; the organisers handle those entries
+#   on the Track 5 encoder's behalf.
+# - Track 4 (EMG) is excluded from Track 5 -- EMG and EEG differ in
+#   sampling rate, substrate, and montage.

--- a/neuralbench-repo/neuralbench/defaults/debug_study.yaml
+++ b/neuralbench-repo/neuralbench/defaults/debug_study.yaml
@@ -11,14 +11,22 @@ Accou2024Sparrkulee: "subject == 'Accou2024Sparrkulee/001'"
 Albrecht2019Increased: "subject in ['Albrecht2019Increased/CC_EEG_s128_P', 'Albrecht2019Increased/CC_EEG_s130_P', 'Albrecht2019Increased/CC_EEG_s132_P', 'Albrecht2019Increased/CC_EEG_s134_P', 'Albrecht2019Increased/CC_EEG_s136_P', 'Albrecht2019Increased/CC_EEG_s149_N', 'Albrecht2019Increased/CC_EEG_s151_N', 'Albrecht2019Increased/CC_EEG_s153_N', 'Albrecht2019Increased/CC_EEG_s155_N', 'Albrecht2019Increased/CC_EEG_s157_N']"
 Allen2022Massive: "timeline_index < 4"
 Allen2022MassiveRaw: "timeline_index < 4"
+Alvarez2022Haaglanden: "subject_index < 5"
 Brennan2019Hierarchical: "subject_index == 0"
 Broderick2018Electrophysiological: "subject_index == 0"
+Chang2019Bold5000: "timeline_index < 6"
 Chen2023Large: "subject_index < 5"
+Hebart2023ThingsBold: "timeline_index < 6"
 Hebart2023ThingsMeg: "timeline_index < 6"
 Dan2023Bids: "subject_index < 5"
 Fuglsang2017Noise: "subject_index == 0"
+# All Ghassemi-backed tasks (sleep_stage, sleep_arousal, sleep_onset) filter to
+# the labeled "train" split. Test-split record IDs sort before training-split IDs
+# alphabetically, so the labeled training subjects are at the high indices -- hence
+# selecting subject_index > 1978 keeps the debug subset within the train split.
 Ghassemi2018You: "subject_index > 1978"
 Gifford2022Large: "timeline_index < 6"
+Grootswagers2022Human: "subject_index < 5"
 Grootswagers2024Mapping: "subject_index < 5"
 Hamid2020Tuar: "subject_index < 10"
 # Designed to contain all 6 labels and timelines from both splits
@@ -48,6 +56,9 @@ Singh2021Timing: "subject in ['Singh2021Timing/PD1025', 'Singh2021Timing/PD1795'
 Levy2025BrainMeg: "subject_index == 0"
 Levy2025BrainEeg: "subject_index == 0"
 Sivakumar2024Emg2qwerty: "subject_index < 5"
+Sivakumar2024Emg2qwerty: "subject_index < 5"
+Xu2024Alljoined: "subject_index < 5"
+Xu2025Alljoined: "subject_index < 5"
 Zhang2024Chisco: "timeline_index < 8"
 Zyma2019Electroencephalograms: "subject_index < 10"
 

--- a/neuralbench-repo/neuralbench/tasks/eeg/image/datasets/grootswagers2022human.yaml
+++ b/neuralbench-repo/neuralbench/tasks/eeg/image/datasets/grootswagers2022human.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Grootswagers2022Human (THINGS-EEG1) ships a predefined train/test partition in
+# its ``split`` column (test = the repeated validation images), so we reuse the
+# base image-decoding design with ``PredefinedSplit`` on that column.
+data:
+  study:
+    =replace=: true
+    source:
+      name: Grootswagers2022Human
+    split:
+      name: PredefinedSplit
+      test_split_query: null
+      col_name: split
+      valid_split_by: timeline
+      valid_split_ratio: 0.2
+      valid_random_state: 33
+  summary_columns: [category, filepath]

--- a/neuralbench-repo/neuralbench/tasks/eeg/image/datasets/xu2024alljoined.yaml
+++ b/neuralbench-repo/neuralbench/tasks/eeg/image/datasets/xu2024alljoined.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Splitting: Xu2024Alljoined has no predefined train/test partition. We replicate
+# the base image-decoding design (leave-concept-out, within-subject) by splitting
+# on the stimulus image.
+data:
+  study:
+    =replace=: true
+    source:
+      name: Xu2024Alljoined
+    split:
+      name: SklearnSplit
+      split_by: filepath
+      valid_split_ratio: 0.2
+      test_split_ratio: 0.2
+      valid_random_state: 33
+      test_random_state: 33
+  summary_columns: [filepath]

--- a/neuralbench-repo/neuralbench/tasks/eeg/image/datasets/xu2025alljoined.yaml
+++ b/neuralbench-repo/neuralbench/tasks/eeg/image/datasets/xu2025alljoined.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+data:
+  study:
+    =replace=: true
+    source:
+      name: Xu2025Alljoined
+    filter_stimuli:
+      name: QueryEvents
+      query: "type != 'Image' or label in ['stim_train', 'stim_test']"
+    split:
+      name: PredefinedSplit
+      test_split_query: "label == 'stim_test'"
+      col_name: split
+      valid_split_by: timeline
+      valid_split_ratio: 0.2
+      valid_random_state: 33
+  summary_columns: [filepath]

--- a/neuralbench-repo/neuralbench/tasks/eeg/sleep_onset/datasets/alvarez2022haaglanden.yaml
+++ b/neuralbench-repo/neuralbench/tasks/eeg/sleep_onset/datasets/alvarez2022haaglanden.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+data:
+  study:
+    =replace=: true
+    source:
+      name: Alvarez2022Haaglanden
+    annotate_sleep_onset:
+      name: AddSleepOnsetTargets
+      max_pre_n2_s: 1200.0
+    split:
+      name: SklearnSplit
+      split_by: subject
+      valid_split_ratio: 0.2
+      test_split_ratio: 0.2
+      valid_random_state: 33
+      test_random_state: 33

--- a/neuralbench-repo/neuralbench/tasks/eeg/sleep_onset/datasets/ghassemi2018you.yaml
+++ b/neuralbench-repo/neuralbench/tasks/eeg/sleep_onset/datasets/ghassemi2018you.yaml
@@ -1,0 +1,25 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+data:
+  study:
+    =replace=: true
+    source:
+      name: Ghassemi2018You
+    filter_train_split:
+      name: QueryEvents
+      query: "split == 'train'"
+    annotate_sleep_onset:
+      name: AddSleepOnsetTargets
+      max_pre_n2_s: 1200.0
+    split:
+      name: SklearnSplit
+      split_by: subject
+      valid_split_ratio: 0.2
+      test_split_ratio: 0.2
+      valid_random_state: 33
+      test_random_state: 33
+  channel_positions.layout_or_montage_name: standard_1005

--- a/neuralbench-repo/neuralbench/tasks/eeg/sleep_stage/config.yaml
+++ b/neuralbench-repo/neuralbench/tasks/eeg/sleep_stage/config.yaml
@@ -25,6 +25,11 @@ data:
   # fallback resolves Fpz-Cz -> Fpz and Pz-Oz -> Pz to real 3D coordinates.
   channel_positions:
     layout_or_montage_name: standard_1020
+  # Force serial MNE resample/filter for the whole task so everything is
+  # in-process (no worker, no re-import, no lock); plenty fast for the
+  # cached per-timeline extraction.
+  neuro:
+    mne_cpus: 1
   target:
     =replace=: true
     name: LabelEncoder

--- a/neuralbench-repo/neuralbench/tasks/eeg/sleep_stage/datasets/alvarez2022haaglanden.yaml
+++ b/neuralbench-repo/neuralbench/tasks/eeg/sleep_stage/datasets/alvarez2022haaglanden.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+data:
+  study:
+    =replace=: true
+    source:
+      name: Alvarez2022Haaglanden
+    crop_sleep_recordings:
+      name: CropSleepRecordings
+      max_wake_duration_min: 30.0
+    split:
+      name: SklearnSplit
+      split_by: subject
+      valid_split_ratio: 0.2
+      test_split_ratio: 0.2
+      valid_random_state: 33
+      test_random_state: 33

--- a/neuralbench-repo/neuralbench/tasks/eeg/sleep_stage/datasets/ghassemi2018you.yaml
+++ b/neuralbench-repo/neuralbench/tasks/eeg/sleep_stage/datasets/ghassemi2018you.yaml
@@ -1,0 +1,27 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+data:
+  study:
+    =replace=: true
+    source:
+      name: Ghassemi2018You
+    filter_train_split:
+      name: QueryEvents
+      query: "split == 'train'"
+    crop_sleep_recordings:
+      name: CropSleepRecordings
+      max_wake_duration_min: 30.0
+    split:
+      name: SklearnSplit
+      split_by: subject
+      valid_split_ratio: 0.2
+      test_split_ratio: 0.2
+      valid_random_state: 33
+      test_random_state: 33
+  channel_positions.layout_or_montage_name: standard_1005
+  target:
+    aggregation: trigger

--- a/neuralbench-repo/neuralbench/tasks/fmri/image/config.yaml
+++ b/neuralbench-repo/neuralbench/tasks/fmri/image/config.yaml
@@ -7,16 +7,7 @@
 data:
   study:
     source:
-      name: Allen2022MassiveRaw
-    # Keep a single preprocessed fMRI space per timeline. Allen2022MassiveRaw
-    # (and other deepprep studies) emit one Fmri event per
-    # {T1w, MNI152NLin2009cAsym, fsnative, fsaverage}; extractors like the
-    # subject-id LabelEncoder have no from_space filter, so we narrow to
-    # fsaverage (matching the SurfaceProjector(mesh=fsaverage5) below) upstream
-    # of segmentation.
-    filter_fmri_space:
-      name: QueryEvents
-      query: 'type != "Fmri" or space == "fsaverage"'
+      name: Chang2019Bold5000
     split:
       name: PredefinedSplit
       test_split_query: null

--- a/neuralbench-repo/neuralbench/tasks/fmri/image/datasets/Allen2022MassiveRaw.yaml
+++ b/neuralbench-repo/neuralbench/tasks/fmri/image/datasets/Allen2022MassiveRaw.yaml
@@ -1,0 +1,26 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+data:
+  study:
+    =replace=: true
+    source:
+      name: Allen2022MassiveRaw
+    # Keep a single preprocessed fMRI space per timeline (see above). The
+    # subject-id LabelEncoder and other downstream extractors have no
+    # from_space filter, so we narrow to fsaverage upstream of segmentation.
+    filter_fmri_space:
+      name: QueryEvents
+      query: 'type != "Fmri" or space == "fsaverage"'
+    split:
+      name: PredefinedSplit
+      test_split_query: null
+      col_name: split
+      valid_split_by: timeline
+      valid_split_ratio: 0.2
+      valid_random_state: 33
+  neuro:
+    from_space: auto

--- a/neuralbench-repo/neuralbench/tasks/fmri/image/datasets/Chang2019Bold5000.yaml
+++ b/neuralbench-repo/neuralbench/tasks/fmri/image/datasets/Chang2019Bold5000.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+data:
+  study:
+    =replace=: true
+    source:
+      name: Chang2019Bold5000
+    split:
+      name: PredefinedSplit
+      test_split_query: null
+      col_name: split
+      valid_split_by: timeline
+      valid_split_ratio: 0.2
+      valid_random_state: 33
+  neuro:
+    from_space: auto

--- a/neuralbench-repo/neuralbench/tasks/fmri/image/datasets/Hebart2023ThingsBold.yaml
+++ b/neuralbench-repo/neuralbench/tasks/fmri/image/datasets/Hebart2023ThingsBold.yaml
@@ -1,0 +1,23 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+data:
+  study:
+    =replace=: true
+    source:
+      name: Hebart2023ThingsBold
+    split:
+      name: PredefinedSplit
+      test_split_query: null
+      col_name: split
+      valid_split_by: timeline
+      valid_split_ratio: 0.2
+      valid_random_state: 33
+  neuro:
+    from_space: auto
+  # TR = 1.5 s: a 5.7 s window yields exactly 4 TRs to match fmri_mlp's fixed
+  # n_repetition_times (the default 7.0 s window gives 5 and crashes the model).
+  duration: 5.7

--- a/neuralfetch-repo/neuralfetch/studies/alvarez2022haaglanden.py
+++ b/neuralfetch-repo/neuralfetch/studies/alvarez2022haaglanden.py
@@ -1,0 +1,163 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+import typing as tp
+
+import mne
+import pandas as pd
+
+from neuralfetch import download
+from neuralset.events import study
+
+logger = logging.getLogger(__name__)
+
+
+class Alvarez2022Haaglanden(study.Study):
+    url: tp.ClassVar[str] = "https://physionet.org/content/hmc-sleep-staging/1.1/"
+    """Haaglanden Medisch Centrum Sleep Staging Database (HMC-Sleep-Staging): EEG recordings during whole-night polysomnographic sleep monitoring.
+
+    A collection of 151 whole-night polysomnographic sleep recordings collected at the Haaglanden
+    Medisch Centrum sleep center in The Netherlands. Each recording includes 6-channel EEG with
+    sleep stage annotations (W, N1, N2, N3, R). The population consists of clinical sleep center
+    patients (85 male, 66 female, mean age 53.9 ± 15.4).
+
+    Experimental Design:
+        - EEG recordings (6-channel, 256 Hz)
+        - 151 participants (clinical sleep center patients)
+        - 1 session per participant (whole-night recording)
+        - Paradigm: whole-night sleep staging with annotated sleep stages (W, N1, N2, N3, R)
+    """
+
+    aliases: tp.ClassVar[tuple[str, ...]] = (
+        "Haaglanden Medisch Centrum Sleep Staging Database",
+        "HMC-Sleep-Staging",
+    )
+
+    bibtex: tp.ClassVar[str] = """
+    @misc{alvarez2022haaglanden,
+        title={Haaglanden {{Medisch Centrum}} Sleep Staging Database},
+        author={{Alvarez-Estevez}, Diego and Rijsman, Roselyne},
+        year=2022,
+        month=mar,
+        publisher={PhysioNet},
+        doi={10.13026/T79Q-FR32},
+        url={https://physionet.org/content/hmc-sleep-staging/1.1/}
+    }
+    """
+    licence: tp.ClassVar[str] = "CC-BY-4.0"
+    description: tp.ClassVar[str] = """
+    EEG sleep recordings from 151 whole-night polysomnographic (PSG) sessions (85 male, 66 female, mean age of 53.9 ± 15.4)
+    collected during 2018 at the Haaglanden Medisch Centrum (HMC, The Netherlands) sleep center.
+    """
+    _MISSING: list[int] = [14, 64, 135]
+    _info: tp.ClassVar[study.StudyInfo] = study.StudyInfo(
+        num_timelines=151,
+        num_subjects=151,
+        event_types_in_query={"Eeg", "SleepStage", "CategoricalEvent"},
+        num_events_in_query=103,
+        data_shape=(6, 6566400),
+        frequency=256,
+    )
+
+    def _download(self, overwrite=False) -> None:
+        self.path.mkdir(exist_ok=True, parents=True)
+        physionet = download.Physionet(
+            study="hmc-sleep-staging",
+            dset_dir=self.path,
+            bucket="physionet-open",
+            version="1.1",
+        )
+        if physionet.get_success_file().exists() and not overwrite:
+            return
+        physionet.download(overwrite=overwrite)
+
+    @staticmethod
+    def _fix_channels(raw: mne.io.Raw) -> mne.io.Raw:
+        """
+        Rename bipolar EEG channels to monopolar names and add EEG montage.
+        """
+        rename_map = {
+            "EEG F4-M1": "F4",
+            "EEG C4-M1": "C4",
+            "EEG O2-M1": "O2",
+            "EEG C3-M2": "C3",
+            "EMG chin": "EMG",
+            "EOG E1-M2": "EOG1",
+            "EOG E2-M2": "EOG2",
+        }
+        raw.rename_channels(rename_map)
+        raw.set_channel_types({"EOG1": "eog", "EOG2": "eog"})
+
+        montage = mne.channels.make_standard_montage("standard_1005")
+        raw.set_montage(montage, on_missing="ignore")
+
+        return raw
+
+    def iter_timelines(self) -> tp.Iterator[dict[str, tp.Any]]:
+        subjects = set(range(1, 155)).difference(self._MISSING)
+        for subject in subjects:
+            sub_id = f"SN{subject:03d}"
+            yield dict(subject=sub_id)
+
+    def _load_timeline_events(self, timeline: dict[str, tp.Any]) -> pd.DataFrame:
+        sub_dir = self.path / "download" / "recordings"
+        fname_events = sub_dir / f"{timeline['subject']}_sleepscoring.edf"
+        annots_df = mne.read_annotations(fname_events).to_data_frame(time_format=None)
+        annots_df.rename(columns={"onset": "start"}, inplace=True)
+
+        annots_df["stage"] = annots_df["description"].replace(
+            {
+                "Sleep stage W": "W",
+                "Sleep stage N1": "N1",
+                "Sleep stage N2": "N2",
+                "Sleep stage N3": "N3",
+                "Sleep stage N4": "N3",
+                "Sleep stage R": "R",
+                "Sleep stage ?": pd.NA,
+                "Movement time": pd.NA,
+            }
+        )
+
+        annots_df = annots_df.dropna(subset=["stage"], how="all", axis=0)
+        annots_df.insert(0, "type", "")
+        annots_df.loc[annots_df.stage.isin(["W", "N1", "N2", "N3", "R"]), "type"] = (
+            "SleepStage"
+        )
+        idx = annots_df.stage.str.contains("Lights")
+        annots_df.loc[idx, "type"] = "CategoricalEvent"
+        annots_df.loc[idx, "duration"] = 1e-3
+
+        grouping = annots_df["stage"].ne(annots_df["stage"].shift()).cumsum()
+        grouped = (
+            annots_df.groupby(grouping)
+            .agg(
+                {
+                    "start": "first",
+                    "duration": "sum",
+                    "type": "first",
+                    "description": "first",
+                    "stage": "first",
+                }
+            )
+            .reset_index(drop=True)
+        )
+
+        info = study.SpecialLoader(method=self._load_raw, timeline=timeline).to_json()
+        eeg = dict(type="Eeg", filepath=info, start=0)
+        eeg_events = pd.concat([pd.DataFrame([eeg]), grouped])
+
+        return eeg_events
+
+    def _load_raw(self, timeline: dict[str, tp.Any]) -> mne.io.BaseRaw:
+        sub_dir = self.path / "download" / "recordings"
+        fname_eeg = sub_dir / f"{timeline['subject']}.edf"
+
+        raw = mne.io.read_raw_edf(fname_eeg)
+        # Fix channel names, types, and add montage
+        raw = self._fix_channels(raw)
+
+        return raw

--- a/neuralfetch-repo/neuralfetch/studies/chang2019bold5000.py
+++ b/neuralfetch-repo/neuralfetch/studies/chang2019bold5000.py
@@ -1,0 +1,278 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import re
+import typing as tp
+from pathlib import Path
+
+import nibabel
+import pandas as pd
+
+from neuralfetch import download
+from neuralset.events import study
+from neuralset.utils import get_bids_filepath, get_masked_bold_image, read_bids_events
+
+
+class Chang2019Bold5000(study.Study):
+    """BOLD5000: 3T fMRI responses to diverse image categories.
+
+    This study provides 3T BOLD fMRI data from 4 participants viewing ~5,000
+    images from three major computer vision datasets: scene images (SUN),
+    ImageNet, and Microsoft COCO. The dataset is designed to study visual
+    representation across diverse stimulus types.
+
+    Experimental Design:
+        - 3T fMRI recordings (TR = 2.0 seconds)
+        - 4 participants (CSI1-4)
+        - 9-15 scanning sessions per participant
+        - 9-10 runs per session (varies by session)
+        - Paradigm: passive viewing of still images
+            * ~37 image presentations per run (2s duration each)
+            * Three image categories: Scene (SUN), ImageNet, MS COCO
+            * 113 images repeated across sessions for test-retest reliability
+
+    Data Format:
+        - BIDS-compliant dataset structure (OpenNeuro ds001499)
+        - Preprocessed in MNI152NLin2009aSym space
+        - 510 total timelines
+        - Event types: Fmri, Image
+        - ImageNet class labels and scene categories provided
+        - Train/test split based on repeated stimuli
+
+    """
+
+    aliases: tp.ClassVar[tuple[str, ...]] = ("BOLD5000",)
+    url: tp.ClassVar[str] = "https://openneuro.org/datasets/ds001499"
+    bibtex: tp.ClassVar[str] = """
+    @article{chang2019bold5000,
+        title={{{BOLD5000}}, a Public {{fMRI}} Dataset While Viewing 5000 Visual Images},
+        author={Chang, Nadine and Pyles, John A. and Marcus, Austin and Gupta, Abhinav and Tarr, Michael J. and Aminoff, Elissa M.},
+        year=2019,
+        month=may,
+        journal={Scientific Data},
+        volume={6},
+        number={1},
+        pages={49},
+        publisher={Nature Publishing Group},
+        issn={2052-4463},
+        doi={10.1038/s41597-019-0052-3},
+        copyright={2019 The Author(s)},
+        langid={english},
+    }
+
+    @misc{chang2020bold5000,
+        url = {https://openneuro.org/datasets/ds001499/versions/1.3.1},
+        title={{{BOLD5000}}},
+        author={Chang, Nadine and Pyles, John A. and Marcus, Austin and {Abhinav Gupta} and Tarr, Michael J. and Aminoff, Elissa M.},
+        year=2020,
+        publisher={Openneuro},
+        doi={10.18112/OPENNEURO.DS001499.V1.3.1},
+        url={https://openneuro.org/datasets/ds001499/versions/1.3.1},
+    }
+    """
+    licence: tp.ClassVar[str] = "CC0-1.0"
+    description: tp.ClassVar[str] = (
+        "Preprocessed BOLD data (in MNI152NLin2009aSym) for"
+        "4 participants watching still images in 3T fMRI"
+    )
+    requirements: tp.ClassVar[tuple[str, ...]] = ("openneuro-py>=2025.2.0",)
+
+    _info: tp.ClassVar[study.StudyInfo] = study.StudyInfo(
+        num_timelines=510,
+        num_subjects=4,
+        num_events_in_query=38,
+        event_types_in_query={"Fmri", "Image"},
+        data_shape=(77, 94, 80, 194),
+        frequency=0.5,
+        fmri_spaces=("custom",),
+    )
+
+    STIMULUS_URL: str = (
+        "https://www.dropbox.com/s/5ie18t4rjjvsl47/BOLD5000_Stimuli.zip?dl=1"
+    )
+
+    SESSIONS_PER_SUBJECT: tp.ClassVar[dict[int, int]] = {1: 15, 2: 15, 3: 15, 4: 9}
+
+    # Each session has 9 or 10 runs
+    SESSIONS_WITH_10_RUNS: tp.ClassVar[dict[int, tuple[int, ...]]] = {
+        1: (1, 2, 3, 5, 7, 10, 15),
+        2: (1, 3, 4, 5, 11, 12, 14),
+        3: (1, 3, 5, 6, 7, 11, 15),
+        4: (1, 4, 9),
+    }
+
+    BIDS_FOLDER: tp.ClassVar[str] = "download"
+    DERIVATIVES_FOLDER: tp.ClassVar[str] = "derivatives_in_standard_space"
+    BOLD_SPACE: tp.ClassVar[str] = "MNI152NLin2009aSym"
+    TASK: tp.ClassVar[str] = "5000scenes"
+    TR_FMRI_S: tp.ClassVar[float] = 2.0
+    STIMULI_FOLDER: tp.ClassVar[str] = "BOLD5000_Stimuli/"
+    SUBJ_PADDING: tp.ClassVar[str] = "01"
+    SUBJ_SUFFIX: tp.ClassVar[str] = "CSI"
+
+    def _download(self) -> None:
+        with download.success_writer(self.path / "download_all") as already_done:
+            if already_done:
+                return
+            # Download fMRI data from OpenNeuro
+            from neuralfetch.download import Openneuro
+
+            Openneuro(study="ds001499", dset_dir=self.path).download()
+
+            # Download stimuli data
+            stimuli_zip = self.path / "BOLD5000_Stimuli.zip"
+            print(f"Downloading stimuli to {stimuli_zip}...")
+            download.download_file(self.STIMULUS_URL, stimuli_zip, show_progress=True)
+
+            # Extract BOLD5000_Stimuli folder
+            print(f"Extracting stimuli to {self.path}...")
+            download.extract_zip(stimuli_zip, destination=self.path, remove_after=True)
+
+    def iter_timelines(self) -> tp.Iterator[dict[str, tp.Any]]:
+        for subject, sessions in self.SESSIONS_PER_SUBJECT.items():
+            for session in range(1, sessions + 1):
+                n_runs = 10 if session in self.SESSIONS_WITH_10_RUNS[subject] else 9
+                for run in range(1, n_runs + 1):
+                    yield dict(
+                        subject=str(subject), session=session, task=self.TASK, run=run
+                    )
+
+    def _load_timeline_events(self, timeline: dict[str, tp.Any]) -> pd.DataFrame:
+        info = study.SpecialLoader(method=self._load_raw, timeline=timeline).to_json()
+        fmri = {
+            "filepath": info,
+            "type": "Fmri",
+            "start": 0.0,
+            "frequency": self._get_fmri_frequency(),
+            "duration": self._get_bold_image(timeline).shape[-1] * self.TR_FMRI_S,
+        }
+        bids_events_df_fp = get_bids_filepath(
+            root_path=self.path / self.BIDS_FOLDER,
+            filetype="events",
+            data_type="Fmri",
+            subj_padding=self.SUBJ_PADDING,
+            subj_suffix=self.SUBJ_SUFFIX,
+            **timeline,
+        )
+        bids_events_df = read_bids_events(bids_events_df_fp)
+        repeated_stimuli = self.get_repeated_stimuli()
+        image_net_classes = self._get_imagenet_classes()
+        ns_events_df = self._get_ns_img_events_df(
+            bids_events_df,
+            self._get_fmri_frequency(),
+            image_net_classes,
+            repeated_stimuli,
+        )
+        return pd.concat([pd.DataFrame([fmri]), ns_events_df], axis=0)
+
+    def _load_raw(self, timeline: dict[str, tp.Any]) -> nibabel.Nifti1Image:
+        return get_masked_bold_image(
+            self._get_bold_image(timeline), self._get_bold_mask(timeline)
+        )
+
+    def _get_ns_img_events_df(
+        self,
+        bids_events_df: pd.DataFrame,
+        frequency: float,
+        image_net_classes: dict[str, str],
+        repeated_stimuli: list[str],
+    ) -> pd.DataFrame:
+        bids_events = bids_events_df.to_dict("records")
+        ns_events = []
+        for bids_event in bids_events:
+            stimulus_path = self._get_stimulus_path(
+                bids_event["stim_file"], bids_event["ImgType"]
+            )
+            fp = self.path / self.STIMULI_FOLDER / "Scene_Stimuli" / stimulus_path
+            ns_event = dict(
+                type="Image",
+                start=bids_event["onset"],
+                duration=bids_event["duration"],
+                frequency=frequency,
+                filepath=str(fp),
+                split="test" if bids_event["stim_file"] in repeated_stimuli else "train",
+                annotation=self._get_image_annotation(
+                    bids_event["stim_file"], bids_event["ImgType"], image_net_classes
+                ),
+            )
+            ns_events.append(ns_event)
+        return pd.DataFrame(ns_events)
+
+    def _get_stimulus_path(self, stim_file: str, img_type: str) -> Path:
+        if img_type.endswith("scenes"):
+            foldername = "Scene"
+        elif img_type.endswith("coco"):
+            foldername = "COCO"
+        elif img_type.endswith("imagenet"):
+            foldername = "ImageNet"
+        else:
+            raise ValueError(f"Unknown image type {img_type}")
+        return Path("Presented_Stimuli") / foldername / stim_file
+
+    def _get_bold_mask(self, timeline: dict[str, tp.Any]):
+        fp = get_bids_filepath(
+            root_path=self.path / self.DERIVATIVES_FOLDER,
+            filetype="bold_mask",
+            data_type="Fmri",
+            space=self.BOLD_SPACE,
+            subj_padding=self.SUBJ_PADDING,
+            subj_suffix=self.SUBJ_SUFFIX,
+            **timeline,
+        )
+        return nibabel.load(fp, mmap=True)
+
+    def _get_bold_image(self, timeline: dict[str, tp.Any]):
+        fp = get_bids_filepath(
+            root_path=self.path / self.DERIVATIVES_FOLDER,
+            filetype="bold",
+            data_type="Fmri",
+            space=self.BOLD_SPACE,
+            subj_padding=self.SUBJ_PADDING,
+            subj_suffix=self.SUBJ_SUFFIX,
+            **timeline,
+        )
+        return nibabel.load(fp, mmap=True)
+
+    def _get_fmri_frequency(self) -> float:
+        return 1.0 / self.TR_FMRI_S
+
+    def get_repeated_stimuli(self) -> list[str]:
+        filepath = (
+            self.path
+            / self.STIMULI_FOLDER
+            / "Scene_Stimuli"
+            / "repeated_stimuli_113_list.txt"
+        )
+        return [line.strip() for line in filepath.read_text("utf8").splitlines()]
+
+    def _get_imagenet_classes(self) -> dict[str, str]:
+        image_to_annotations = {}
+        filepath = (
+            self.path / self.STIMULI_FOLDER / "Image_Labels" / "imagenet_final_labels.txt"
+        )
+        with filepath.open("r", encoding="utf8") as file:
+            for line in file:
+                identifier, string_list = line.split(" ", 1)
+                string = " ".join([s.strip() for s in string_list.split(",")])
+                image_to_annotations[identifier] = string
+        return image_to_annotations
+
+    def _get_image_annotation(
+        self, stim_file: str, img_type: str, image_net_classes: dict[str, str]
+    ) -> str:
+        if img_type in ["scenes", "rep_scenes"]:
+            match = re.match(r"([a-zA-Z_]+)(\d|[.])", stim_file)
+            if match is not None:
+                return match.group(1)
+            else:
+                raise ValueError(f"'{stim_file}' has an unexpected pattern")
+        elif img_type in ["imagenet", "rep_imagenet"]:
+            return image_net_classes[stim_file.split("_")[0]]
+        elif img_type in ["coco", "rep_coco"]:
+            return "none"
+        else:
+            msg = f"{img_type} should be one of 'scenes', 'imagenet', or 'coco'"
+            raise ValueError(msg)

--- a/neuralfetch-repo/neuralfetch/studies/hebart2023thingsbold.py
+++ b/neuralfetch-repo/neuralfetch/studies/hebart2023thingsbold.py
@@ -1,0 +1,269 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import re
+import typing as tp
+from pathlib import Path
+
+import nibabel
+import pandas as pd
+
+import neuralset.utils as nutils
+from neuralfetch import download, utils
+from neuralset.events import study
+
+
+class Hebart2023ThingsBold(study.Study):
+    """THINGS-fMRI1: 3T fMRI responses to a large-scale object image database.
+
+    This study is part of the THINGS initiative, a multimodal collection
+    investigating object representations during 3T fMRI scanning. The large
+    number of unique object concepts and multiple split strategies make it
+    valuable for both within-domain and zero-shot generalization studies.
+
+    Experimental Design:
+        - 3T fMRI recordings (TR = 1.5 seconds)
+        - 3 participants
+        - 12 scanning sessions per participant
+        - Paradigm: passive viewing of object images
+            * 10 runs per session (except sub-02/ses-03/run-07 is missing)
+            * ~82 image presentations per run
+            * Images from THINGS database cover 1,854 object concepts
+            * Catch trials included to ensure attention
+
+    Data Format:
+        - BIDS-compliant dataset structure (OpenNeuro ds004192)
+        - Preprocessed in MNI152NLin2009aSym space
+        - 359 total timelines (3 participants x 12 sessions x ~10 runs)
+        - Event types: Fmri, Image
+        - Multiple train/test split strategies:
+            * Original paper split (test trials vs. train trials)
+            * Zero-shot split (held-out object categories)
+            * Large split (includes held-out categories in test set)
+
+    Download Requirements:
+        - datalad (for dataset download from OpenNeuro ds004192)
+        - THINGS-images database (shared across THINGS studies): checked for in
+          ../THINGS-images/ and downloaded automatically if missing
+    """
+
+    aliases: tp.ClassVar[tuple[str, ...]] = ("THINGS-fMRI1",)
+
+    bibtex: tp.ClassVar[str] = """
+    @article{hebart2023things,
+        title={THINGS-data, a multimodal collection of large-scale datasets for
+        investigating object representations in human brain and behavior},
+        author={Hebart, Martin N and Contier, Oliver and Teichmann, Lina and Rockter,
+        Adam H and Zheng, Charles Y and Kidder, Alexis and Corriveau, Anna
+        and Vaziri-Pashkam, Maryam and Baker, Chris I},
+        journal={Elife},
+        volume={12},
+        pages={e82580},
+        year={2023},
+        publisher={eLife Sciences Publications Limited},
+        doi={10.7554/eLife.82580},
+        url={https://elifesciences.org/articles/82580}
+    }
+
+    @misc{hebart2022things,
+        url = {https://openneuro.org/datasets/ds004192/versions/1.0.5}
+        author={Martin N. Hebart AND Oliver Contier AND Lina Teichmann AND Adam H. Rockter AND Charles Zheng AND Alexis Kidder AND Anna Corriveau AND Maryam Vaziri-Pashkam AND Chris I. Baker},
+        title={"THINGS-fMRI"},
+        year={2022},
+        doi={10.18112/openneuro.ds004192.v1.0.5},
+        publisher={OpenNeuro},
+        url={https://openneuro.org/datasets/ds004192/versions/1.0.5}
+    }
+    """
+    licence: tp.ClassVar[str] = "CC0-1.0"
+    description: tp.ClassVar[str] = (
+        "THINGS-data: 3T BOLD fMRI from 3 participants viewing 1,854 diverse "
+        "object concepts."
+    )
+    requirements: tp.ClassVar[tuple[str, ...]] = ("datalad>=0.19.5",)
+
+    _info: tp.ClassVar[study.StudyInfo] = study.StudyInfo(
+        num_timelines=359,
+        num_subjects=3,
+        num_events_in_query=83,
+        event_types_in_query={"Fmri", "Image"},
+        data_shape=(77, 94, 80, 284),
+        frequency=0.667,
+        fmri_spaces=("custom",),
+    )
+
+    SUBJECTS: tp.ClassVar[tuple[int, ...]] = (1, 2, 3)
+    SESSIONS_PER_SUBJECT: tp.ClassVar[int] = 12
+    RUNS_PER_SESSION: tp.ClassVar[int] = 10
+    BIDS_FOLDER: tp.ClassVar[str] = "download/ds004192"
+    DERIVATIVES_FOLDER: tp.ClassVar[str] = "derivatives"
+    BOLD_SPACE: tp.ClassVar[str] = "MNI152NLin2009aSym"
+    TASK: tp.ClassVar[str] = "things"
+    SESSION_SUFFIX: tp.ClassVar[str] = "things"
+    TR_FMRI_S: tp.ClassVar[float] = 1.5
+
+    def _download(self) -> None:
+        with download.success_writer(self.path / "download_all") as already_done:
+            if already_done:
+                return
+            # Gate on the THINGS licence and fetch the shared image database before
+            # the large Datalad download (used across multiple THINGS studies).
+            utils.download_things_images(self.path)
+            download.Datalad(
+                study="hebart2023bold",
+                dset_dir=self.path,
+                repo_url="https://github.com/OpenNeuroDatasets/ds004192.git",
+                threads=4,
+                folders=[download.Wildcard(folder="sub-*")],
+            ).download()
+            self._write_test_categories()
+
+    def _write_test_categories(self) -> None:
+        event_dfs = []
+        for tl in self.iter_timelines():
+            bids_events_df_fp = nutils.get_bids_filepath(
+                root_path=self.path / self.BIDS_FOLDER,
+                filetype="events",
+                data_type="Fmri",
+                ses_suffix=self.SESSION_SUFFIX,
+                **tl,
+            )
+            event_dfs.append(nutils.read_bids_events(bids_events_df_fp))
+        event_df = pd.concat(event_dfs, axis=0)
+        test_trials = event_df[event_df.trial_type == "test"]
+        test_categories = test_trials.file_path.map(self._get_category).unique()
+        with open(self.path / "test_categories.txt", mode="w", encoding="utf8") as f:
+            f.writelines([f"{category}\n" for category in test_categories])
+
+    def _get_test_categories(self) -> tp.Set[str]:
+        with (self.path / "test_categories.txt").open(encoding="utf8") as f:
+            return set(line.strip() for line in f)
+
+    def iter_timelines(self) -> tp.Iterator[dict[str, tp.Any]]:
+        for subject in self.SUBJECTS:
+            for session in range(1, self.SESSIONS_PER_SUBJECT + 1):
+                for run in range(1, self.RUNS_PER_SESSION + 1):
+                    if subject == 2 and session == 3 and run == 7:
+                        continue  # Missing data, see hebart2023bold/download/ds004192/sub-02/ses-things03/func/
+                    yield dict(subject=subject, session=session, task=self.TASK, run=run)
+
+    def _load_timeline_events(self, timeline: dict[str, tp.Any]) -> pd.DataFrame:
+        info = study.SpecialLoader(method=self._load_raw, timeline=timeline).to_json()
+        fmri = {
+            "filepath": info,
+            "type": "Fmri",
+            "start": 0.0,
+            "frequency": self._get_fmri_frequency(),
+            "duration": self._get_bold_image(timeline).shape[-1] * self.TR_FMRI_S,
+        }
+        bids_events_df_fp = nutils.get_bids_filepath(
+            root_path=self.path / self.BIDS_FOLDER,
+            filetype="events",
+            data_type="Fmri",
+            ses_suffix=self.SESSION_SUFFIX,
+            **timeline,
+        )
+        bids_events_df = nutils.read_bids_events(bids_events_df_fp)
+        path_to_stimuli = (self.path / ".." / "THINGS-images").resolve(strict=False)
+        test_cats = self._get_test_categories()
+        ns_events_df = self._get_ns_img_events_df(
+            bids_events_df, path_to_stimuli, self._get_fmri_frequency(), test_cats
+        )
+
+        # Add indicator column for events of test categories
+        ns_events_df["stem"] = ns_events_df.filepath.apply(lambda x: Path(x).stem)
+        ns_events_df["is_test_category"] = ns_events_df.category.isin(test_cats)
+        # For consistency with other THINGS-derived studies, redefine categories and split
+        ns_events_df["category"] = ns_events_df.stem.apply(
+            lambda x: "_".join(x.split("_")[:-1])
+        )
+        ns_events_df["split"] = ns_events_df.hebart2023_paper_split
+
+        # Add shared filepath
+        shared_things_path = (self.path / ".." / "THINGS-images").resolve(strict=False)
+        if shared_things_path.exists():
+            base = str(shared_things_path)
+            ns_events_df["shared_filepath"] = (
+                base + "/" + ns_events_df.category + "/" + ns_events_df.stem + ".jpg"
+            )
+        return pd.concat([pd.DataFrame([fmri]), ns_events_df], axis=0)
+
+    def _load_raw(self, timeline: dict[str, tp.Any]) -> nibabel.Nifti1Image:
+        return nutils.get_masked_bold_image(
+            self._get_bold_image(timeline), self._get_bold_mask(timeline)
+        )
+
+    @classmethod
+    def _get_category(cls, file_path: str) -> str:
+        return re.sub(r"\d", "", " ".join(Path(file_path).stem.split("_")[:-1]))
+
+    def _get_ns_img_events_df(
+        self,
+        bids_events_df: pd.DataFrame,
+        stimuli_path: str | Path,
+        frequency: float,
+        test_cats: tp.Set[str],
+    ) -> pd.DataFrame:
+        # Leave out 'catch' trials (used for making sure subject is focused)
+        bids_events_df = bids_events_df[bids_events_df.trial_type != "catch"]
+        bids_events = bids_events_df.to_dict("records")
+        ns_events = []
+        for bids_event in bids_events:
+            parent = "_".join(Path(bids_event["file_path"]).stem.split("_")[:-1])
+            fp = Path(stimuli_path) / parent / Path(bids_event["file_path"]).name
+            split = "test" if bids_event["trial_type"] == "test" else "train"
+            ns_event = dict(
+                type="Image",
+                start=bids_event["onset"],
+                duration=bids_event["duration"],
+                frequency=frequency,
+                filepath=str(fp),
+                hebart2023_paper_split=split,
+                category=self._get_category(bids_event["file_path"]),
+            )
+            ns_events.append(ns_event)
+
+        ns_events_df = pd.DataFrame(ns_events)
+
+        # Add zero-shot split, that is:
+        # Remove images from train-set whose category is in test
+        ns_events_df["zero_shot_split"] = ns_events_df.hebart2023_paper_split
+        sel = (ns_events_df.hebart2023_paper_split == "train") & (
+            ns_events_df.category.isin(test_cats)
+        )
+        ns_events_df.loc[sel, "zero_shot_split"] = "trash"
+
+        # Add large split, that is:
+        # from zero-shot split, add 'trash' images to 'test'
+        ns_events_df["large_split"] = ns_events_df.zero_shot_split
+        sel = ns_events_df.zero_shot_split == "trash"
+        ns_events_df.loc[sel, "large_split"] = "test"
+        return ns_events_df
+
+    def _get_bold_mask(self, timeline: dict[str, tp.Any]):
+        fp = nutils.get_bids_filepath(
+            root_path=self.path / self.DERIVATIVES_FOLDER,
+            filetype="bold_mask",
+            data_type="Fmri",
+            space=self.BOLD_SPACE,
+            ses_suffix=self.SESSION_SUFFIX,
+            **timeline,
+        )
+        return nibabel.load(fp, mmap=True)
+
+    def _get_bold_image(self, timeline: dict[str, tp.Any]):
+        fp = nutils.get_bids_filepath(
+            root_path=self.path / self.DERIVATIVES_FOLDER,
+            filetype="bold",
+            data_type="Fmri",
+            space=self.BOLD_SPACE,
+            ses_suffix=self.SESSION_SUFFIX,
+            **timeline,
+        )
+        return nibabel.load(fp, mmap=True)
+
+    def _get_fmri_frequency(self) -> float:
+        return 1.0 / self.TR_FMRI_S

--- a/neuralfetch-repo/neuralfetch/studies/hebart2023thingsmeg.py
+++ b/neuralfetch-repo/neuralfetch/studies/hebart2023thingsmeg.py
@@ -5,9 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import logging
-import os
 import re
-import shutil
 import typing as tp
 import warnings
 from functools import lru_cache
@@ -90,8 +88,8 @@ class Hebart2023ThingsMeg(study.Study):
         - CTF MEG data format
         - Includes event timing and image annotations
         - Multiple train/test split strategies
-        - Preprocessed images available in preprocessed/images/
-        - Shared THINGS image database expected in ../THINGS-images/
+        - Image stimuli are sourced from the shared THINGS image database in
+          ../THINGS-images/ (downloaded automatically; see Download Requirements)
 
     Download Requirements:
         - OpenNeuro dataset: ds004212
@@ -101,7 +99,6 @@ class Hebart2023ThingsMeg(study.Study):
             * Read license terms in password_images.txt
             * Extract with password to agree to terms
             * Place at ../THINGS-images/ (sibling directory to study folder)
-        - Note: Preprocessed images extraction requires password (currently disabled)
     """
 
     aliases: tp.ClassVar[tuple[str, ...]] = ("THINGS-MEG1",)
@@ -131,7 +128,7 @@ class Hebart2023ThingsMeg(study.Study):
         "THINGS-data: MEG recordings from 4 participants viewing 1,854 diverse "
         "object concepts."
     )
-    requirements: tp.ClassVar[tuple[str, ...]] = ("pyunpack", "boto3", "osfclient>=0.0.5")
+    requirements: tp.ClassVar[tuple[str, ...]] = ("boto3", "osfclient>=0.0.5")
 
     _info: tp.ClassVar[study.StudyInfo] = study.StudyInfo(
         num_timelines=480,
@@ -143,51 +140,12 @@ class Hebart2023ThingsMeg(study.Study):
     )
 
     def _download(self) -> None:
-        # Check for / Download THINGS-images database (used across multiple THINGS studies)
+        # Image stimuli are sourced from the shared THINGS-images database (used
+        # across multiple THINGS studies); the OpenNeuro dataset bundles the same
+        # object images as password-protected archives, but extracting them is
+        # redundant with the shared DB, so we skip it.
         utils.download_things_images(self.path)
         download.Openneuro("ds004212", self.path).download()  # type: ignore
-
-        # Decompress
-        parts = "A-C", "D-K", "L-Q", "R-S", "T-Z"
-        prep_dir = self.path / "preprocessed" / "images"
-        prep_dir.mkdir(parents=True, exist_ok=True)
-        for part in parts:
-            success = prep_dir / f"{part}_success.txt"
-            if success.exists():
-                continue
-            from pyunpack import Archive  # noqa
-
-            password = os.environ.get("NEURALHUB_THINGS_PASSWORD")
-            if not password:
-                raise RuntimeError(
-                    "THINGS-images requires accepting a licence agreement.\n"
-                    "Please export NEURALHUB_THINGS_PASSWORD=<pwd> where the password can be found "
-                    "in password_images.txt at https://osf.io/jum2f/files/52wrx"
-                )
-
-            img_dir = (
-                self.path / "download" / "stimuli" / "download" / "THINGS" / "Images"
-            )
-            zip_file = img_dir / f"object_images_{part}.zip"
-            print(f"Unzipping {zip_file.name}...")
-            Archive(str(zip_file), password=password).extractall(str(prep_dir))
-
-            # fix bad unzipping: the L-Q archive extracts into a nested subdirectory
-            if part == "L-Q":
-                bad_dir = prep_dir / "object_images_L-Q"
-                if bad_dir.exists():
-                    for folder in bad_dir.iterdir():
-                        if folder.is_file():
-                            continue
-
-                        target_dir = prep_dir / folder.name
-                        target_dir.mkdir(exist_ok=True)
-                        for file in folder.iterdir():
-                            print(file)
-                            shutil.move(str(file), str(target_dir / file.name))
-
-            with open(success, "w") as f:
-                f.write("done")
 
     def iter_timelines(self) -> tp.Iterator[dict[str, tp.Any]]:
         """Returns a generator of all recordings"""
@@ -246,8 +204,8 @@ class Hebart2023ThingsMeg(study.Study):
         if not all(events.duration < 0.550):
             raise RuntimeError("Some durations are too long")
 
-        # specify image path
-        img_dir = self.path / "prepare"
+        # specify image path (shared THINGS-images database)
+        img_dir = (self.path / ".." / "THINGS-images").resolve(strict=False)
 
         def format_path(img_path):
             if not img_path.endswith(".jpg"):
@@ -272,11 +230,14 @@ class Hebart2023ThingsMeg(study.Study):
         events.loc[~check, "split"] = None
         events.loc[~check, "valid"] = False
 
-        # Add shared filepaths
+        # Add shared filepaths (same shared THINGS-images database as `filepath`,
+        # built element-wise so each row gets its own path)
         shared_things_path = (self.path / ".." / "THINGS-images").resolve(strict=False)
         if shared_things_path.exists():
-            fp = f"{shared_things_path}/{events.category}/{events.stem}.jpg"
-            events["shared_filepath"] = fp
+            base = str(shared_things_path)
+            events["shared_filepath"] = (
+                base + "/" + events.category + "/" + events.stem + ".jpg"
+            )
 
         events["type"] = "Image"
         events["filepath"] = events.filepath.apply(str)

--- a/neuralfetch-repo/neuralfetch/studies/xu2024alljoined.py
+++ b/neuralfetch-repo/neuralfetch/studies/xu2024alljoined.py
@@ -1,0 +1,163 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+NOTE: The data is currently available as `.fif` files, however the GitHub documentation suggests
+there exists a BIDS version as well. If this becomes available, it might make sense to rewrite the
+implementation to use the BIDS version instead.
+"""
+
+import typing as tp
+from itertools import product
+from pathlib import Path
+
+import mne
+import pandas as pd
+
+from neuralfetch import download
+from neuralset.events import study
+
+
+class Xu2024Alljoined(study.Study):
+    url: tp.ClassVar[str] = "https://osf.io/kqgs8"
+    """Alljoined: EEG responses to static images for EEG-to-Image decoding.
+
+    8 participants viewing static images from the NSD stimulus set, recorded
+    with 64-channel EEG at 512 Hz. Predecessor to the larger Alljoined-1.6M
+    dataset (Xu2025).
+
+    Experimental Design:
+        - EEG recordings (64-channel, standard 1020 montage, FIF format)
+        - 8 participants, 2 sessions each
+        - Image presentation duration: 300 ms
+        - Paradigm: passive viewing of NSD natural images
+
+    Notes:
+        - Data available as ``.fif`` files; a BIDS version may exist.
+        - Requires NSD stimuli from Allen2022Massive for image filepaths.
+        - Known broken/missing files: subj02 ses2, subj03 ses1, subj07 ses2, subj08 ses2.
+    """
+
+    aliases: tp.ClassVar[tuple[str, ...]] = ("Alljoined1",)
+
+    bibtex: tp.ClassVar[str] = """
+    @article{xu2024alljoined,
+        title={Alljoined -- A dataset for {EEG}-to-Image decoding},
+        author={Xu, Jonathan and Aristimunha, Bruno and Feucht, Max Emanuel and Qian, Emma
+        and Liu, Charles and Shahjahan, Tazik and Spyra, Martyna and Zhang, Steven Zifan
+        and Short, Nicholas and Kim, Jioh and others},
+        journal={arXiv preprint arXiv:2404.05553},
+        year={2024},
+        doi={10.48550/arXiv.2404.05553},
+        archiveprefix={arXiv},
+        eprint={2404.05553}
+    }
+
+    @misc{xu2025alljoined1,
+        title={Alljoined1},
+        url={osf.io/kqgs8},
+        publisher={OSF},
+        author={Xu, Jonathan},
+        year={2025},
+        month={Sep}
+    }
+    """
+    licence: tp.ClassVar[str] = "UNKNOWN"
+    description: tp.ClassVar[str] = (
+        "8 participants viewing static NSD images in 64-channel EEG at 512 Hz."
+    )
+    requirements: tp.ClassVar[tuple[str, ...]] = (
+        "h5py",
+        "tables",
+    )
+
+    _info: tp.ClassVar[study.StudyInfo] = study.StudyInfo(
+        num_timelines=12,
+        num_subjects=8,
+        num_events_in_query=3836,
+        event_types_in_query={"Eeg", "Image"},
+        data_shape=(64, 1778688),
+        frequency=512.0,
+    )
+
+    def _download(self) -> None:
+        download.Osf(study="kqgs8", dset_dir=self.path, folder="xu2024").download()
+
+    @staticmethod
+    def _get_fname(
+        path: str | Path,
+        subject: str,
+        session: int,
+        kind: tp.Literal["raw", "epochs", "h5"] = "raw",
+    ):
+        if kind == "raw":
+            folder, suffix = "raw", "_eeg.fif"
+        elif kind == "epochs":
+            folder, suffix = "raw", "_epo.fif"
+        elif kind == "h5":
+            folder, suffix = "05_125", ".h5"
+        return Path(path) / folder / f"subj{int(subject):02}_session{session}{suffix}"
+
+    def iter_timelines(self) -> tp.Iterator[dict[str, tp.Any]]:
+        """Returns a generator of all recordings.
+
+        A timeline is only yielded when both the raw EEG (``.fif``) and the
+        image-event (``.h5``) files exist. Some recordings ship the raw EEG
+        without the accompanying event file (e.g. subj03 session1), and those
+        would otherwise yield empty event frames downstream.
+        """
+        for subject, session in product(range(1, 9), range(1, 3)):
+            raw_fname = self._get_fname(self.path, str(subject), session, kind="raw")
+            h5_fname = self._get_fname(self.path, str(subject), session, kind="h5")
+            if raw_fname.exists() and h5_fname.exists():
+                yield dict(subject=str(subject), session=session)
+
+    def _get_nsd_stimuli_path(self) -> Path:
+        from neuralfetch.studies.allen2022massive import (
+            get_allen2022massive_common_path,
+        )
+
+        return get_allen2022massive_common_path(self.path) / "nsd_stimuli"
+
+    def _load_raw(self, timeline: dict[str, tp.Any]) -> mne.io.RawArray:
+        tl = timeline
+        # Necessary to ensure montage information is available in the Raw object
+        filepath = str(
+            self._get_fname(self.path, tl["subject"], tl["session"], kind="raw")
+        )
+        raw = mne.io.read_raw(filepath)
+        raw.set_montage("standard_1020")
+        return raw
+
+    def _load_timeline_events(self, timeline: dict[str, tp.Any]) -> pd.DataFrame:
+        """
+        Broken/missing files:
+        - subj02, session 2
+        - subj03, session 1
+        - subj07, session 2
+        - subj08, session 2
+        """
+        tl = timeline
+        # Load image event information
+        h5_fname = self._get_fname(self.path, tl["subject"], tl["session"], kind="h5")
+        events = pd.read_hdf(h5_fname).drop("eeg", axis=1)
+        events["filepath"] = events["73k_id"].apply(
+            lambda x: str(self._get_nsd_stimuli_path() / f"{x}.png")
+        )
+        events["start"] = events.curr_time
+        events["duration"] = 0.3
+        events["type"] = "Image"
+
+        events = events.drop(columns=["subject_id", "session", "curr_time"])
+
+        info = study.SpecialLoader(method=self._load_raw, timeline=timeline).to_json()
+        eeg = {
+            "type": "Eeg",
+            "start": 0.0,
+            "filepath": info,
+        }
+        events = pd.concat([pd.DataFrame([eeg]), events])  # type: ignore
+        return events

--- a/neuralfetch-repo/neuralfetch/studies/xu2025alljoined.py
+++ b/neuralfetch-repo/neuralfetch/studies/xu2025alljoined.py
@@ -1,0 +1,201 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+import os
+import typing as tp
+from itertools import product
+from pathlib import Path
+
+import mne
+import pandas as pd
+
+from neuralfetch import download
+from neuralset.events import study
+
+logger = logging.getLogger(__name__)
+
+
+class Xu2025Alljoined(study.Study):
+    url: tp.ClassVar[str] = (
+        "https://huggingface.co/datasets/Alljoined/Alljoined-1.6M/tree/main/raw_eeg"
+    )
+    """Alljoined-1.6M: large-scale EEG responses to static images.
+
+    A million-trial EEG dataset from 20 participants viewing static images,
+    recorded with affordable consumer-grade EEG (Emotiv). Designed for evaluating
+    brain-computer interfaces and EEG-to-image decoding at scale. Each participant
+    completed up to 4 sessions with up to 19 blocks each, with 100 ms image
+    presentations.
+
+    Experimental Design:
+        - EEG recordings (Emotiv, standard 1005 montage, EDF format)
+        - 20 participants, up to 4 sessions x 19 blocks each
+        - Image presentation duration: 100 ms
+        - Paradigm: passive viewing of static images
+
+    Notes:
+        - Successor to Alljoined (xu2024.py) with ~10x more data.
+        - Subject 8 has mislabeled files (sessions 1/3/4); handled in code.
+        - Image stimuli are extracted from a zip archive during download.
+    """
+
+    aliases: tp.ClassVar[tuple[str, ...]] = ("Alljoined-1.6M",)
+
+    bibtex: tp.ClassVar[str] = """
+    @misc{xu2025alljoined,
+        title={Alljoined-1.{{6M}}: {{A Million-Trial EEG-Image Dataset}} for {{Evaluating Affordable Brain-Computer Interfaces}}},
+        shorttitle={Alljoined-1.{{6M}}},
+        author={Xu, Jonathan and Nunes, Ugo Bruzadin and Jiang, Wangshu and Ryther, Samuel and Pringle, Jordan and Scotti, Paul S. and Delorme, Arnaud and Kneeland, Reese},
+        year=2025,
+        month=aug,
+        number={arXiv:2508.18571},
+        eprint={2508.18571},
+        primaryclass={q-bio},
+        publisher={arXiv},
+        doi={10.48550/arXiv.2508.18571},
+        archiveprefix={arXiv}
+    }
+
+    @misc{xu2025_data,
+        url={https://huggingface.co/datasets/Alljoined/Alljoined-1.6M/tree/main/raw_eeg}
+    }
+    """
+    licence: tp.ClassVar[str] = "CC-BY-NC-SA-4.0"
+    description: tp.ClassVar[str] = "20 participants watching static images in EEG."
+
+    def _download(self, overwrite=False) -> None:
+        accept = os.environ.get("ALLJOINED_ACCEPT_LICENCE", "").lower() in (
+            "1",
+            "true",
+            "yes",
+        )
+        if not accept:
+            raise RuntimeError(
+                "Alljoined-1.6M is released under CC-BY-NC-SA-4.0 (non-commercial use). "
+                "Set ALLJOINED_ACCEPT_LICENCE=1 to accept the licence before downloading."
+            )
+        hf_org = "Alljoined"
+        hf_repo = "Alljoined-1.6M"
+        hg = download.Huggingface(org=hf_org, study=hf_repo, dset_dir=self.path)
+        if hg.get_success_file().exists() and not overwrite:
+            return
+        hg.download(overwrite=overwrite)
+        self._extract_stimuli(self.path, overwrite=overwrite)
+
+    @classmethod
+    def _extract_stimuli(cls, path: Path, overwrite=False) -> None:
+        # The HF repo ships the image stimuli only as `stimuli.zip` (top-level
+        # `images/*.jpg`); `_load_timeline_events` reads them from the extracted
+        # `stimuli/images/` dir, so we must unpack on first download. Gate on
+        # whether the images already exist (idempotent) rather than `overwrite`,
+        # which previously skipped extraction on every normal download.
+        zip_filepath = path / "download" / "stimuli.zip"
+        stimuli_dir = path / "download" / "stimuli"
+        images_dir = stimuli_dir / "images"
+        if images_dir.exists() and not overwrite:
+            return
+        from zipfile import ZipFile
+
+        with ZipFile(zip_filepath, "r") as FILE:
+            FILE.extractall(stimuli_dir)
+
+        logger.info("Success: Stimuli extraction complete.")
+
+    @staticmethod
+    def _get_fname(path: str | Path, subject: int, session: int, run: int) -> Path:
+        folder, suffix = "raw_eeg", ".edf"
+        dir_path = (
+            Path(path)
+            / "download"
+            / folder
+            / f"sub-{subject:02d}"
+            / f"session_{session:02d}"
+            / f"block_{run:02d}"
+        )
+        # This subject is mislabeled within its directory so we update
+        # the logic here to find the correct file
+        # Also, I made a PR to notify the team these files were mislabeled
+        # and they only corrected one of the runs
+        # https://huggingface.co/datasets/Alljoined/Alljoined-1.6M/discussions/3
+        mislabeled = list(product([8], [1], range(2, 20))) + list(
+            product([8], [3, 4], range(1, 20))
+        )
+        if (subject, session, run) in mislabeled:
+            subject = 19
+        pattern = f"Subject {subject}, Session {session}, Block {run}*{suffix}"
+        matches = [f for f in dir_path.glob(pattern)]
+        if len(matches) != 1:
+            raise ValueError(
+                f"Expected 1 match, got {len(matches)} for {pattern} in {dir_path}"
+            )
+        fpath = matches[0]
+
+        return fpath
+
+    def iter_timelines(self) -> tp.Iterator[dict[str, tp.Any]]:
+        """Returns a generator of all recordings"""
+        for subject, session, run in product(range(1, 21), range(1, 5), range(1, 20)):
+            fname = self._get_fname(self.path, subject, session, run)
+            if fname.exists():
+                yield dict(subject=str(subject), session=session, run=run)
+
+    def _load_raw(self, timeline: dict[str, tp.Any]) -> mne.io.BaseRaw:
+        # `iter_timelines` yields `subject` as a string for the global index;
+        # `_get_fname` formats it with `:02d`, so cast back to int here.
+        filepath = str(
+            self._get_fname(
+                self.path,
+                int(timeline["subject"]),
+                timeline["session"],
+                timeline["run"],
+            )
+        )
+        # When loading, all the channels are marked as EEG
+        raw = mne.io.read_raw(filepath)
+        # For some of the files, Emotiv writes AFz as Afz
+        if "Afz" in raw.ch_names:
+            raw.rename_channels({"Afz": "AFz"})
+        # Set the montage to channels that correspond to EEG placement
+        # Emotiv doesn't use a standard 1020. it's closer to a 1010 placement
+        montage = mne.channels.make_standard_montage("standard_1005")
+        eeg_ch_names = set.intersection(set(raw.ch_names), set(montage.ch_names))
+        misc_ch_names = set.difference(set(raw.ch_names), eeg_ch_names)
+        eeg_mapping = list(zip(eeg_ch_names, ["eeg" for _ in eeg_ch_names]))
+        misc_mapping = list(zip(misc_ch_names, ["misc" for _ in misc_ch_names]))
+        raw.set_channel_types(dict(eeg_mapping + misc_mapping), on_unit_change="ignore")
+        raw.set_montage("standard_1005", on_missing="ignore", match_case=False)
+        return raw
+
+    def _load_timeline_events(self, timeline: dict[str, tp.Any]) -> pd.DataFrame:
+        """
+        NOTE: EDF annotations were validated against the json annotation files accompanying the dataset.
+        """
+        raw = self._load_raw(timeline)
+        frequency = raw.info["sfreq"]
+        # extract annotations
+        events_df = raw.annotations.to_data_frame(time_format=None)
+        events_df.rename(columns={"onset": "start"}, inplace=True)
+        # stimulus presentation defined in the study as 100ms
+        events_df["duration"] = 0.1
+        events_df["type"] = "Image"
+        events_df[["label", "value", "deleted", "orig_index"]] = events_df[
+            "description"
+        ].str.split(",", expand=True)
+        events_df["filepath"] = events_df["value"].apply(
+            lambda x: str(
+                Path(self.path).resolve()
+                / "download"
+                / "stimuli"
+                / "images"
+                / f"{int(x):05d}.jpg"
+            )
+        )
+        # add raw event
+        info = study.SpecialLoader(method=self._load_raw, timeline=timeline).to_json()
+        eeg = dict(type="Eeg", filepath=info, frequency=frequency, start=0)
+        events_df = pd.concat([pd.DataFrame([eeg]), events_df], ignore_index=True)
+        return events_df

--- a/neuralfetch-repo/neuralfetch/utils.py
+++ b/neuralfetch-repo/neuralfetch/utils.py
@@ -373,6 +373,9 @@ def ensure_imagenet22k(
     return imagenet_path
 
 
+THINGS_PASSWORD_ENV = "NEURALFETCH_THINGS_PASSWORD"
+
+
 def download_things_images(
     study_path: Path,
     fail_on_error: bool = False,
@@ -401,11 +404,13 @@ def download_things_images(
 
     logger.warning(f"THINGS-images not found at expected location: {things_images_path}")
 
-    password = os.environ.get("NEURALFETCH_THINGS_PASSWORD")
-    if password is None:
+    # Licence gate: only required once we actually need to download (an
+    # already-present dataset above short-circuits before this).
+    password = os.environ.get(THINGS_PASSWORD_ENV)
+    if not password:
         raise RuntimeError(
             "THINGS-images requires accepting a licence agreement.\n"
-            "Please export NEURALFETCH_THINGS_PASSWORD=<pwd> where the password can be found "
+            f"Please export {THINGS_PASSWORD_ENV}=<pwd> where the password can be found "
             "in password_images.txt at https://osf.io/jum2f/files/52wrx"
         )
 

--- a/neuralset-repo/neuralset/extractors/data/huggingface-repos.txt
+++ b/neuralset-repo/neuralset/extractors/data/huggingface-repos.txt
@@ -43,6 +43,7 @@ facebook/dinov2-small-imagenet1k-1-layer
 facebook/dpt-dinov2-base-kitti
 facebook/hf-seamless-m4t-medium
 facebook/opt-1.3b
+facebook/opt-125m
 facebook/opt-13b
 facebook/opt-2.7b
 facebook/opt-6.7b

--- a/neuraltrain-repo/neuraltrain/models/labram.py
+++ b/neuraltrain-repo/neuraltrain/models/labram.py
@@ -41,8 +41,8 @@ class _LabramChannelWrapper(nn.Module):
 
     * ``_labram_names`` -- the LaBraM-cased name to forward to the inner
       model for each union channel (channels with no LaBraM mapping fall
-      back to their original name and are dropped by braindecode's
-      case-insensitive ``ch_names`` matching).
+      back to their original name; see ``_known_mask`` below for how those
+      are then filtered out before reaching braindecode).
     * ``_positionless_mask`` -- a boolean buffer marking channels that have
       a valid LaBraM mapping but no montage position (bipolar derivations
       resolved via anode fallback, or channels added via an explicit
@@ -50,11 +50,20 @@ class _LabramChannelWrapper(nn.Module):
       ``channel_positions`` row, so e.g. SleepEDF's bipolar ``Fpz-Cz`` or
       Geodesic E-numbers reach LaBraM even when ``set_montage`` could not
       assign them coordinates.
+    * ``_known_mask`` -- a boolean buffer marking channels whose
+      wrapper-resolved name is in :data:`LABRAM_CHANNEL_ORDER`
+      (case-insensitively).  Channels that fail this check (e.g. unmapped
+      EGI ``E5``, ``E7``, ...) are filtered out entirely so braindecode
+      never sees them.  This matters because braindecode dropped its
+      ``on_unknown_chs`` parameter in ``>=1.5`` and now hard-raises a
+      ``ValueError`` on the first unknown name; doing the filtering here
+      keeps the wrapper's behaviour ("warn-and-drop") stable across
+      braindecode versions.
 
-    At forward time the per-sample mask ``(channel_positions != sentinel)``
-    is OR-combined with ``_positionless_mask`` and intersected across the
-    batch (LaBraM's ``ch_names`` is per-batch, so heterogeneous batches
-    fall back to the channels valid in every sample).
+    At forward time the per-sample position mask is OR-combined with
+    ``_positionless_mask``, AND-combined with ``_known_mask``, then
+    intersected across the batch (LaBraM's ``ch_names`` is per-batch, so
+    heterogeneous batches fall back to the channels valid in every sample).
 
     Parameters
     ----------
@@ -66,8 +75,8 @@ class _LabramChannelWrapper(nn.Module):
     ch_name_to_labram : dict mapping str to str
         Mapping from dataset channel names to LaBraM channel names, as
         returned by :meth:`NtLabram._build_channel_remapping`.  Channels not
-        in this dict are forwarded with their original name and dropped by
-        braindecode's case-insensitive ``ch_names`` matching.
+        in this dict are dropped by the wrapper before the inner model
+        sees them.
     positionless_ch_names : set of str, optional
         Subset of ``ch_name_to_labram`` keys whose channels are not expected
         to carry montage positions.  Defaults to an empty set.
@@ -101,6 +110,24 @@ class _LabramChannelWrapper(nn.Module):
                 dtype=torch.bool,
             ),
         )
+        # ``_known_mask`` gates whether each union channel survives to the
+        # inner braindecode model.  Built lazily-imported because braindecode
+        # is an optional dependency at module-import time (model is
+        # instantiated only when present, so reaching here implies the
+        # import works).
+        from braindecode.models.labram import LABRAM_CHANNEL_ORDER
+
+        labram_upper = {ch.upper() for ch in LABRAM_CHANNEL_ORDER}
+        known = [name.upper() in labram_upper for name in self._labram_names]
+        if not all(known):
+            unknown = sorted({union_ch_names[i] for i, ok in enumerate(known) if not ok})
+            logger.warning(
+                "%d channel(s) not in LABRAM_CHANNEL_ORDER will be dropped "
+                "at forward time: %s",
+                len(unknown),
+                unknown,
+            )
+        self.register_buffer("_known_mask", torch.tensor(known, dtype=torch.bool))
 
     def forward(self, x: torch.Tensor, channel_positions: torch.Tensor) -> torch.Tensor:
         """Forward pass with dynamic channel selection.
@@ -112,6 +139,7 @@ class _LabramChannelWrapper(nn.Module):
         """
         valid = (channel_positions != INVALID_POS_VALUE).any(dim=-1)
         valid = valid | self._positionless_mask  # type: ignore[operator]
+        valid = valid & self._known_mask  # type: ignore[operator]
         # Intersect across the batch: braindecode's ``ch_names`` is per-batch.
         common = valid.all(dim=0)
 

--- a/neuraltrain-repo/neuraltrain/models/test_labram.py
+++ b/neuraltrain-repo/neuraltrain/models/test_labram.py
@@ -54,6 +54,7 @@ def _make_wrapper(names, remap=None):
 # ---------------------------------------------------------------------------
 
 
+@requires_labram_channel_order
 def test_wrapper_filters_to_valid_channels():
     wrapper, inner = _make_wrapper(CH_NAMES)
 
@@ -70,16 +71,46 @@ def test_wrapper_filters_to_valid_channels():
     assert inner.last_x_shape == (B, 3, T)
 
 
-def test_wrapper_remapping_and_passthrough():
-    """Mapped names are remapped; unmapped names pass through as-is."""
+@requires_labram_channel_order
+def test_wrapper_remapping_and_unknown_dropped():
+    """Mapped names are remapped; names not in LABRAM_CHANNEL_ORDER are dropped.
+
+    Filtering happens inside the wrapper rather than relying on
+    braindecode, because braindecode>=1.5 hard-raises on unknown names
+    instead of silently dropping them.
+    """
     remap = {"Fp1": "FP1", "C3": "C3"}
     wrapper, inner = _make_wrapper(["Fp1", "C3", "WEIRD_CH"], remap)
 
     wrapper(torch.randn(1, 3, 50), torch.rand(1, 3, 2))
 
-    assert inner.last_ch_names == ["FP1", "C3", "WEIRD_CH"]
+    assert inner.last_ch_names == ["FP1", "C3"]
+    assert inner.last_x_shape == (1, 2, 50)
 
 
+@requires_labram_channel_order
+def test_wrapper_drops_unmapped_egi_channels():
+    """Regression test for HBN-style EGI E-channels mixed with mapped names.
+
+    Mirrors the production failure mode on the HBN ``reaction_time`` task:
+    most ``E*`` channels are absent from ``channel_mappings/labram.json``
+    but still carry valid montage positions, so without explicit filtering
+    they would reach braindecode and trigger
+    ``ValueError: ch_names contains a name not in LABRAM_CHANNEL_ORDER``.
+    """
+    union = ["Fp1", "E5", "Cz", "E7", "O2"]
+    remap = {"Fp1": "FP1", "Cz": "CZ", "O2": "O2"}
+    wrapper, inner = _make_wrapper(union, remap)
+
+    B, C, T, D = 1, len(union), 50, 2
+    pos = torch.rand(B, C, D)
+    wrapper(torch.randn(B, C, T), pos)
+
+    assert inner.last_ch_names == ["FP1", "CZ", "O2"]
+    assert inner.last_x_shape == (B, 3, T)
+
+
+@requires_labram_channel_order
 def test_wrapper_heterogeneous_batch_uses_intersection():
     wrapper, inner = _make_wrapper(CH_NAMES)
 


### PR DESCRIPTION
Ports three internal NeuralBench changes into the public benchmark.

New dataset support:
- EEG image decoding: Xu2024Alljoined, Xu2025Alljoined, Grootswagers2022Human
- EEG sleep stage and sleep onset: Ghassemi2018You, Alvarez2022Haaglanden
- fMRI image decoding: Allen2022MassiveRaw, Chang2019Bold5000, Hebart2023ThingsBold

Adds the corresponding NeuralFetch studies, dataset configs, LaBraM model
updates, task documentation, and debug-study filters.

Also adds the NeurIPS 2026 competition starter-kit documentation: a new
"07_biosignal_challenge_2026" tutorial gallery (overview, submission guide,
and tracks for EEG-to-Image, EEG-to-BCI, sleep onset, EMG-to-Text, and
foundation transfer) wired into the NeuralBench docs.

Co-authored-by: Katie Begany <4326145+kbegany@users.noreply.github.com>
Co-authored-by: Yohann Benchetrit <20583750+yohann-benchetrit@users.noreply.github.com>
Co-authored-by: Jérémy Rapin <11429864+jrapin@users.noreply.github.com>
Co-authored-by: Teon L Brooks <1578674+teonbrooks@users.noreply.github.com>