### PR TITLE
Fix Brennan _download method to accept overwrite; Add nworker parameter to OpenNeuro

### DIFF
--- a/neuralfetch-repo/neuralfetch/download.py
+++ b/neuralfetch-repo/neuralfetch/download.py
@@ -568,7 +568,7 @@ class Datalad(BaseDownload):
             # raise RuntimeError(f"Clone Failed: {proc.stderr}")
 
     def _dl_item(self, cur_path: Path | str) -> None:
-        threads_ = "" if self.threads > 1 else f" -J {self.threads}"
+        threads_ = f" -J {self.threads}" if self.threads > 1 else ""
         cmd = f'datalad get "{cur_path}"{threads_}'
         self._datalad(cmd, self._dl_dir / self.repo_name)
 

--- a/neuralfetch-repo/neuralfetch/download.py
+++ b/neuralfetch-repo/neuralfetch/download.py
@@ -1097,16 +1097,27 @@ class Openneuro(BaseDownload):
     ``'sub-1/**/*run-01*'``. The pattern ``**`` will match any files and
     zero or more directories, subdirectories and symbolic links to
     directories.
+
+    The ``nworkers`` parameter controls how many files are downloaded in
+    parallel (forwarded to ``openneuro.download`` as
+    ``max_concurrent_downloads``). The openneuro-py default is 5; raise it to
+    speed up datasets with many files when network bandwidth allows.
     """
 
-    requirements: tp.ClassVar[tuple[str, ...]] = ("openneuro-py>=2025.2.0",)
+    requirements: tp.ClassVar[tuple[str, ...]] = ("openneuro-py>=2026.4.0",)
     excluded_patterns: list[str] = []
     include: list[str] | None = None
+    nworkers: int = 5
 
     def _download(self) -> None:
         import openneuro as on
 
-        on.download(dataset=self.study, target_dir=self._dl_dir, include=self.include)
+        on.download(
+            dataset=self.study,
+            target_dir=self._dl_dir,
+            include=self.include,
+            max_concurrent_downloads=self.nworkers,
+        )
 
 
 class Osf(BaseDownload):

--- a/neuralfetch-repo/neuralfetch/studies/brennan2019hierarchical.py
+++ b/neuralfetch-repo/neuralfetch/studies/brennan2019hierarchical.py
@@ -87,7 +87,7 @@ class Brennan2019Hierarchical(study.Study):
         frequency=500.0,
     )
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         dl_dir = self.path / "download"
 
         # Deep Blue Data guest collection + record-scoped path for Brennan2019


### PR DESCRIPTION
This adds support for the overwrite parameter. makes it compatible with a wip cli interface.