### PR TITLE
add new event type

### DIFF
--- a/neuralset-repo/neuralset/events/etypes.py
+++ b/neuralset-repo/neuralset/events/etypes.py
@@ -835,6 +835,35 @@ class Background(CategoricalEvent):
     """'Background' activity, i.e. no specific epilepsy or arousal event happening during this time."""
 
 
+class Hfo(CategoricalEvent):
+    """High-Frequency Oscillation (HFO) event in an iEEG recording.
+
+    HFOs are brief bursts of oscillatory activity (80–500 Hz) detected in
+    intracranial EEG and used as biomarkers of epileptogenic tissue.  They
+    are algorithmically detected (e.g. with STE, MNI, or Hilbert detectors)
+    and may optionally carry an expert classification label.
+
+    Parameters
+    ----------
+    channel : str
+        Electrode channel on which the HFO was detected (e.g. ``"LAF3"``).
+    detector : str
+        Algorithm used to detect the HFO (e.g. ``"ste"``, ``"mni"``,
+        ``"hilbert"``).
+    state : {'spkHFO', 'nonSpkHFO', 'artifact'} or None
+        Expert classification label.  ``None`` when only algorithmic
+        detection is available (no expert review).
+
+    See Also
+    --------
+    Duan2026OmniIeeg : Example usage
+    """
+
+    channel: str = ""
+    detector: str = ""
+    state: tp.Literal["spkHFO", "nonSpkHFO", "artifact"] | None = None
+
+
 class SleepStage(CategoricalEvent):
     """Sleep stage event following AASM manual classification [sleep1]_.
 

--- a/neuralset-repo/neuralset/events/test_etypes.py
+++ b/neuralset-repo/neuralset/events/test_etypes.py
@@ -469,3 +469,18 @@ def test_fmri_volume_chunked_read(tmp_path: Path) -> None:
     assert [c.duration for c in chunks] == [6.0, 8.0, 6.0]
     concat = np.concatenate([ch.read().get_fdata() for ch in chunks], axis=-1)
     np.testing.assert_array_equal(concat, full)
+def test_hfo_event() -> None:
+    hfo = etypes.Hfo(start=1.5, timeline="t", channel="LAF3", detector="ste", state="spkHFO")
+    assert hfo.type == "Hfo"
+    assert hfo.channel == "LAF3"
+    assert hfo.detector == "ste"
+    assert hfo.state == "spkHFO"
+    # unlabelled detection (no expert review)
+    hfo_unlabelled = etypes.Hfo(start=2.0, timeline="t", channel="LAF4", detector="ste")
+    assert hfo_unlabelled.state is None
+    # round-trip through dict
+    reconstructed = etypes.Event.from_dict(hfo.to_dict())
+    assert reconstructed.state == "spkHFO"  # type: ignore[attr-defined]
+    assert reconstructed.channel == "LAF3"  # type: ignore[attr-defined]
+    # registered in Event._CLASSES
+    assert "Hfo" in etypes.Event._CLASSES


### PR DESCRIPTION
## What does this PR do?

This PR introduces a new event type to neuralset. It indicates high-frequency oscillations (Hfo) which is used in classifying seizures.

## Checklist

- [ ] Tests added or updated
- [ ] Docstrings updated for any changed public APIs
- [ ] `pytest` and `mypy` pass locally
