### PR TITLE
NeuralBench prediction logging

### DIFF
--- a/docs/neuralbench/tutorials/05_advanced/save_test_predictions.py
+++ b/docs/neuralbench/tutorials/05_advanced/save_test_predictions.py
@@ -69,7 +69,7 @@ without re-running the experiment.
 # a separate object: ``y_true`` holds the per-window target embeddings (one row
 # per window, with repeats), and the ``group`` column records which stimulus
 # each row corresponds to.  That is enough to reconstruct the retrieval set by
-# de-duplicating ``y_true`` per ``group`` (see the retrieval example below).
+# de-duplicating ``y_true`` per ``group``.
 
 # %%
 # Reading the predictions back
@@ -122,45 +122,6 @@ without re-running the experiment.
 # The metadata columns make it easy to slice first, e.g. compute the metric
 # per subject with ``metadata.groupby("subject_id")`` and indexing into
 # ``y_pred`` / ``y_true`` with each group's row indices.
-
-# %%
-# Recomputing a retrieval metric
-# ------------------------------
-#
-# For retrieval tasks, rebuild the retrieval set by de-duplicating the target
-# embeddings per ``group``, then score each window's predicted embedding against
-# that set.  The snippet below ranks the true stimulus among all candidates and
-# reports top-1 accuracy:
-#
-# .. code-block:: python
-#
-#    import numpy as np
-#
-#    preds = experiment.test_predictions()
-#    meta = preds["metadata"]
-#    y_pred = np.asarray(preds["y_pred"])
-#    y_true = np.asarray(preds["y_true"])
-#
-#    # Retrieval set: one (de-duplicated) target embedding per stimulus.
-#    groups = meta["group"].to_numpy()
-#    unique_groups, first_idx = np.unique(groups, return_index=True)
-#    retrieval_set = y_true[first_idx]          # (n_stimuli, dim)
-#    group_to_row = {g: i for i, g in enumerate(unique_groups)}
-#
-#    # Cosine similarity of each prediction to every retrieval-set item.
-#    def _l2_normalize(x):
-#        return x / (np.linalg.norm(x, axis=-1, keepdims=True) + 1e-8)
-#
-#    scores = _l2_normalize(y_pred) @ _l2_normalize(retrieval_set).T
-#    ranking = np.argsort(-scores, axis=1)
-#    target_rows = np.array([group_to_row[g] for g in groups])
-#    top1 = (ranking[:, 0] == target_rows).mean()
-#    print("top-1 retrieval accuracy:", top1)
-#
-# This mirrors what :class:`~neuralbench.callbacks.TestFullRetrievalMetrics`
-# does internally; logging the predictions lets you reproduce or vary it offline
-# (different retrieval-set sizes, per-subject aggregation, alternative
-# similarity functions, ...).
 
 # %%
 # Caveats

--- a/docs/neuralbench/tutorials/05_advanced/save_test_predictions.py
+++ b/docs/neuralbench/tutorials/05_advanced/save_test_predictions.py
@@ -171,7 +171,9 @@ without re-running the experiment.
 #   concatenates the per-batch chunks, so loading materializes the full arrays
 #   in RAM.  For very large outputs, read and process the chunk keys directly
 #   from the underlying ``CacheDict`` instead.
-# - **Multi-GPU testing.** Only global rank zero writes predictions, so under
-#   distributed testing the saved set covers rank zero's shard only.
+# - **Multi-GPU training.** NeuralBench always runs the test loop on a single
+#   device (global rank zero, ``devices=1``, after the training process group is
+#   torn down), so the saved predictions cover the full test set even when
+#   training used multiple GPUs.
 # - **Disk usage.** The arrays are stored uncompressed; budget roughly
 #   ``n_windows * output_dim * 4`` bytes each for ``y_true`` and ``y_pred``.

--- a/docs/neuralbench/tutorials/05_advanced/save_test_predictions.py
+++ b/docs/neuralbench/tutorials/05_advanced/save_test_predictions.py
@@ -1,0 +1,177 @@
+"""
+Saving and Reusing Test Predictions
+====================================
+
+By default NeuralBench only keeps the **aggregate** test metrics returned by
+:meth:`~neuralbench.main.Experiment.run`.  When you want to inspect the model's
+behaviour window-by-window -- to compute a new metric, plot error
+distributions, or build a retrieval analysis -- you can ask the experiment to
+log the **raw per-window predictions and targets** to disk.
+
+This is controlled by the opt-in ``save_test_predictions`` flag on
+:class:`~neuralbench.main.Experiment`.  When enabled, a
+:class:`~neuralbench.callbacks.WindowPredictionCollector` streams the
+``(y_pred, y_true)`` produced during the test loop to the experiment's cache
+folder, alongside a small per-window metadata table.  The predictions live next
+to the cached result, so they survive cache hits and can be read back later
+without re-running the experiment.
+"""
+
+# %%
+# Enabling prediction logging
+# ---------------------------
+#
+# Set ``save_test_predictions: true`` in your experiment config (it is an
+# :class:`~neuralbench.main.Experiment` field, so it sits at the top level of
+# ``config.yaml`` next to ``seed``, ``infra``, ``trainer_config``, ...):
+#
+# .. code-block:: yaml
+#
+#    seed: 0
+#    save_test_predictions: true
+#    infra:
+#      folder: /path/to/cache   # required: predictions are stored here
+#      ...
+#
+# The flag is part of the exca cache key, so toggling it produces a *fresh*
+# cache entry rather than invalidating existing results.  An ``infra.folder``
+# must be configured -- the predictions are written under
+# ``<uid_folder>/test_predictions``.
+#
+# .. note::
+#
+#    Logging is **opt-in** because it can use a lot of memory and disk for
+#    high-dimensional outputs (e.g. word/video embeddings, fMRI voxel targets,
+#    or CTC log-probs).  Arrays are streamed one batch at a time, so the *write*
+#    path stays light, but reading everything back concatenates the full arrays
+#    in RAM (see the caveats at the bottom).
+
+# %%
+# What gets saved
+# ---------------
+#
+# The collector writes three things to ``<uid_folder>/test_predictions``:
+#
+# - ``metadata`` -- a :class:`pandas.DataFrame` with one row per test window:
+#
+#   * ``timeline`` -- the recording the window came from;
+#   * ``batch_idx`` / ``dataloader_idx`` -- where it appeared in the test loop;
+#   * ``subject_id`` -- the encoded subject (when the batch exposes one);
+#   * ``group`` -- the stimulus identity for retrieval tasks (e.g. the word
+#     ``text``), when available.
+#
+# - ``y_true`` / ``y_pred`` -- arrays of shape ``(n_windows, ...)`` aligned with
+#   ``metadata``, stored with their **native** per-task shape (class logits,
+#   regression vectors, retrieval embeddings, CTC log-probs, ...).  No per-task
+#   aggregation is applied.
+#
+# For **retrieval** tasks, note that the retrieval *set* itself is not stored as
+# a separate object: ``y_true`` holds the per-window target embeddings (one row
+# per window, with repeats), and the ``group`` column records which stimulus
+# each row corresponds to.  That is enough to reconstruct the retrieval set by
+# de-duplicating ``y_true`` per ``group`` (see the retrieval example below).
+
+# %%
+# Reading the predictions back
+# ----------------------------
+#
+# Rebuild the *same* experiment config (so it matches the cache entry) and call
+# :meth:`~neuralbench.main.Experiment.test_predictions`.  Because the result is
+# cached, ``run()`` returns immediately and the predictions are read from disk:
+#
+# .. code-block:: python
+#
+#    from neuralbench.main import Experiment
+#
+#    experiment = Experiment(**config)  # same config used to run, flag on
+#    experiment.run()                   # cache hit -> returns instantly
+#
+#    preds = experiment.test_predictions()
+#    metadata = preds["metadata"]       # DataFrame, one row per window
+#    y_true = preds["y_true"]           # np.ndarray, shape (n_windows, ...)
+#    y_pred = preds["y_pred"]
+#
+#    print(metadata.head())
+#    print(y_pred.shape, y_true.shape)
+
+# %%
+# Recomputing a metric offline
+# ----------------------------
+#
+# Because the raw logits and targets are available, you can compute *any*
+# metric after the fact -- without re-running the model.  For a classification
+# task whose ``y_pred`` are class logits and ``y_true`` are integer labels:
+#
+# .. code-block:: python
+#
+#    import numpy as np
+#    import torch
+#    import torchmetrics
+#
+#    preds = experiment.test_predictions()
+#    y_pred = torch.from_numpy(np.asarray(preds["y_pred"]))
+#    y_true = torch.from_numpy(np.asarray(preds["y_true"])).long()
+#
+#    num_classes = y_pred.shape[1]
+#    balanced_acc = torchmetrics.Accuracy(
+#        task="multiclass", num_classes=num_classes, average="macro"
+#    )
+#    balanced_acc.update(y_pred, y_true)
+#    print("balanced accuracy:", balanced_acc.compute().item())
+#
+# The metadata columns make it easy to slice first, e.g. compute the metric
+# per subject with ``metadata.groupby("subject_id")`` and indexing into
+# ``y_pred`` / ``y_true`` with each group's row indices.
+
+# %%
+# Recomputing a retrieval metric
+# ------------------------------
+#
+# For retrieval tasks, rebuild the retrieval set by de-duplicating the target
+# embeddings per ``group``, then score each window's predicted embedding against
+# that set.  The snippet below ranks the true stimulus among all candidates and
+# reports top-1 accuracy:
+#
+# .. code-block:: python
+#
+#    import numpy as np
+#
+#    preds = experiment.test_predictions()
+#    meta = preds["metadata"]
+#    y_pred = np.asarray(preds["y_pred"])
+#    y_true = np.asarray(preds["y_true"])
+#
+#    # Retrieval set: one (de-duplicated) target embedding per stimulus.
+#    groups = meta["group"].to_numpy()
+#    unique_groups, first_idx = np.unique(groups, return_index=True)
+#    retrieval_set = y_true[first_idx]          # (n_stimuli, dim)
+#    group_to_row = {g: i for i, g in enumerate(unique_groups)}
+#
+#    # Cosine similarity of each prediction to every retrieval-set item.
+#    def _l2_normalize(x):
+#        return x / (np.linalg.norm(x, axis=-1, keepdims=True) + 1e-8)
+#
+#    scores = _l2_normalize(y_pred) @ _l2_normalize(retrieval_set).T
+#    ranking = np.argsort(-scores, axis=1)
+#    target_rows = np.array([group_to_row[g] for g in groups])
+#    top1 = (ranking[:, 0] == target_rows).mean()
+#    print("top-1 retrieval accuracy:", top1)
+#
+# This mirrors what :class:`~neuralbench.callbacks.TestFullRetrievalMetrics`
+# does internally; logging the predictions lets you reproduce or vary it offline
+# (different retrieval-set sizes, per-subject aggregation, alternative
+# similarity functions, ...).
+
+# %%
+# Caveats
+# -------
+#
+# - **Memory on read.** Predictions are streamed to disk per batch (light on
+#   write), but :meth:`~neuralbench.main.Experiment.test_predictions`
+#   concatenates the per-batch chunks, so loading materializes the full arrays
+#   in RAM.  For very large outputs, read and process the chunk keys directly
+#   from the underlying ``CacheDict`` instead.
+# - **Multi-GPU testing.** Only global rank zero writes predictions, so under
+#   distributed testing the saved set covers rank zero's shard only.
+# - **Disk usage.** The arrays are stored uncompressed; budget roughly
+#   ``n_windows * output_dim * 4`` bytes each for ``y_true`` and ``y_pred``.

--- a/neuralbench-repo/neuralbench/aggregator.py
+++ b/neuralbench-repo/neuralbench/aggregator.py
@@ -115,6 +115,11 @@ class BenchmarkAggregator(ns.BaseModel):
         if cached_only and experiment.infra.status() != "completed":
             return None, task, model
         out = experiment.run()
+        # Per-window test predictions are saved as side artifacts in the uid
+        # folder; ``run`` only records a marker pointing at them. Drop it here
+        # so it does not pollute the results DataFrame. The predictions remain
+        # available via ``experiment.test_predictions()``.
+        out.pop("test_predictions_dir", None)
         out["task_name"] = experiment.task_name
         study = experiment.data.study
         if isinstance(study, ns.Chain):

--- a/neuralbench-repo/neuralbench/aggregator.py
+++ b/neuralbench-repo/neuralbench/aggregator.py
@@ -115,11 +115,6 @@ class BenchmarkAggregator(ns.BaseModel):
         if cached_only and experiment.infra.status() != "completed":
             return None, task, model
         out = experiment.run()
-        # Per-window test predictions are saved as side artifacts in the uid
-        # folder; ``run`` only records a marker pointing at them. Drop it here
-        # so it does not pollute the results DataFrame. The predictions remain
-        # available via ``experiment.test_predictions()``.
-        out.pop("test_predictions_dir", None)
         out["task_name"] = experiment.task_name
         study = experiment.data.study
         if isinstance(study, ns.Chain):

--- a/neuralbench-repo/neuralbench/callbacks.py
+++ b/neuralbench-repo/neuralbench/callbacks.py
@@ -380,8 +380,11 @@ class WindowPredictionCollector(Callback):
     shape (class logits, regression vectors, retrieval embeddings, CTC
     log-probs, ...), so no per-task aggregation happens here.
 
-    Writing only happens on global rank zero; under multi-GPU testing the saved
-    predictions cover rank zero's shard only.
+    Writing only happens on global rank zero. In neuralbench the test loop is
+    single-device by construction (``Experiment._test`` runs on global rank zero
+    with ``devices=1`` after the training process group is torn down), so the
+    saved predictions cover the *full* test set even after multi-GPU training;
+    the rank-zero guard is defensive against a hypothetical distributed tester.
 
     Parameters
     ----------

--- a/neuralbench-repo/neuralbench/callbacks.py
+++ b/neuralbench-repo/neuralbench/callbacks.py
@@ -362,6 +362,82 @@ class TestFullRetrievalMetrics(Callback):
         return out
 
 
+class WindowPredictionCollector(Callback):
+    """Collect raw per-window test predictions and targets for caching.
+
+    Accumulates the ``(y_pred, y_true)`` returned by ``test_step`` for every
+    window in the test set, plus light per-window metadata (recording
+    ``timeline`` and, when available, the encoded ``subject_id``). The result
+    is exposed on the module as ``test_predictions`` so :class:`Experiment` can
+    fold it into its exca-cached ``run`` result. exca then serializes the small
+    metadata table as CSV (human-readable) and the potentially large
+    ``y_true``/``y_pred`` arrays via its memmap handler (efficient, lazy).
+
+    This is task-agnostic: ``y_pred``/``y_true`` are stored with their native
+    shape (class logits, regression vectors, retrieval embeddings, CTC
+    log-probs, ...), so no per-task aggregation happens here.
+    """
+
+    def __init__(self) -> None:
+        self._y_pred: list[np.ndarray] = []
+        self._y_true: list[np.ndarray] = []
+        self._timeline: list[str] = []
+        self._subject_id: list[int] = []
+        self._batch_idx: list[int] = []
+        self._has_subject = True
+
+    def on_test_epoch_start(
+        self, trainer: pl.Trainer, pl_module: pl.LightningModule
+    ) -> None:
+        self._y_pred = []
+        self._y_true = []
+        self._timeline = []
+        self._subject_id = []
+        self._batch_idx = []
+        self._has_subject = True
+
+    def on_test_batch_end(
+        self,
+        trainer: pl.Trainer,
+        pl_module: pl.LightningModule,
+        outputs,
+        batch,
+        batch_idx,
+        dataloader_idx=0,
+    ) -> None:
+        y_pred, y_true = outputs
+        self._y_pred.append(y_pred.detach().cpu().numpy())
+        self._y_true.append(y_true.detach().cpu().numpy())
+        self._timeline.extend(segment.timeline for segment in batch.segments)
+        self._batch_idx.extend([batch_idx] * len(batch.segments))
+
+        subject = batch.data.get("subject_id")
+        if subject is None:
+            self._has_subject = False
+        else:
+            self._subject_id.extend(subject.detach().cpu().reshape(-1).tolist())
+
+    def on_test_epoch_end(
+        self, trainer: pl.Trainer, pl_module: pl.LightningModule
+    ) -> None:
+        if not self._y_pred:
+            return
+
+        metadata = {"timeline": self._timeline, "batch_idx": self._batch_idx}
+        if self._has_subject and len(self._subject_id) == len(self._timeline):
+            metadata["subject_id"] = self._subject_id  # type: ignore[assignment]
+
+        setattr(
+            pl_module,
+            "test_predictions",
+            {
+                "metadata": pd.DataFrame(metadata),
+                "y_true": np.concatenate(self._y_true, axis=0),
+                "y_pred": np.concatenate(self._y_pred, axis=0),
+            },
+        )
+
+
 class RecordingLevelEval(Callback):
     """Callback to evaluate average prediction over each recording (timeline)."""
 
@@ -432,7 +508,7 @@ class RecordingLevelEval(Callback):
                 lambda counts: counts[i] / sum(counts) if sum(counts) > 0 else 0.0
             )
 
-        # Create prediction tensor with shape (n_recordings, num_classes)
+        # Per-recording probabilities, shape (n_recordings, num_classes).
         pred_columns = [f"y_pred{i}" for i in range(self.num_classes)]
         y_pred_probs = torch.from_numpy(outputs_df[pred_columns].values)
         # Convert y_true to int64 explicitly to avoid object dtype issues

--- a/neuralbench-repo/neuralbench/callbacks.py
+++ b/neuralbench-repo/neuralbench/callbacks.py
@@ -18,6 +18,7 @@ import pandas as pd
 import seaborn as sns
 import torch
 import torchmetrics
+from exca.cachedict import CacheDict
 from lightning.pytorch.callbacks import Callback
 from matplotlib.figure import Figure
 from sklearn.metrics import ConfusionMatrixDisplay
@@ -363,38 +364,74 @@ class TestFullRetrievalMetrics(Callback):
 
 
 class WindowPredictionCollector(Callback):
-    """Collect raw per-window test predictions and targets for caching.
+    """Stream raw per-window test predictions and targets to disk.
 
-    Accumulates the ``(y_pred, y_true)`` returned by ``test_step`` for every
-    window in the test set, plus light per-window metadata (recording
-    ``timeline`` and, when available, the encoded ``subject_id``). The result
-    is exposed on the module as ``test_predictions`` so :class:`Experiment` can
-    fold it into its exca-cached ``run`` result. exca then serializes the small
-    metadata table as CSV (human-readable) and the potentially large
-    ``y_true``/``y_pred`` arrays via its memmap handler (efficient, lazy).
+    For every window in the test set, the ``(y_pred, y_true)`` returned by
+    ``test_step`` is written **incrementally** (one chunk per batch) to an
+    exca :class:`~exca.cachedict.CacheDict` under ``folder``, alongside light
+    per-window metadata (recording ``timeline``, ``batch_idx``,
+    ``dataloader_idx`` and, when available, the encoded ``subject_id`` and a
+    retrieval ``group`` label). Arrays go through exca's memmap handler (one
+    shared binary file, appended per batch) and the metadata table is stored as
+    CSV, so peak RAM stays proportional to a single batch rather than the whole
+    test set.
 
     This is task-agnostic: ``y_pred``/``y_true`` are stored with their native
     shape (class logits, regression vectors, retrieval embeddings, CTC
     log-probs, ...), so no per-task aggregation happens here.
+
+    Writing only happens on global rank zero; under multi-GPU testing the saved
+    predictions cover rank zero's shard only.
+
+    Parameters
+    ----------
+    folder:
+        Destination directory for the prediction artifacts. The folder is
+        cleared at the start of each test epoch.
+    group_field:
+        Trigger attribute used as the retrieval ``group`` label (the stimulus
+        identity, e.g. word ``text``). Falls back to ``category`` then
+        ``filepath`` when absent; the column is omitted if no window exposes
+        any of them.
     """
 
-    def __init__(self) -> None:
-        self._y_pred: list[np.ndarray] = []
-        self._y_true: list[np.ndarray] = []
-        self._timeline: list[str] = []
-        self._subject_id: list[int] = []
-        self._batch_idx: list[int] = []
+    _Y_PRED_PREFIX: tp.ClassVar[str] = "y_pred_"
+    _Y_TRUE_PREFIX: tp.ClassVar[str] = "y_true_"
+    _METADATA_KEY: tp.ClassVar[str] = "metadata"
+
+    def __init__(self, folder: Path | str, group_field: str = "text") -> None:
+        self._folder = Path(folder)
+        self._group_field = group_field
+        self._reset()
+
+    def _reset(self) -> None:
+        self._cache: CacheDict | None = None
+        self._writer: tp.Any = None
+        self._n_chunks = 0
+        self._metadata: dict[str, list[tp.Any]] = defaultdict(list)
         self._has_subject = True
+        self._has_group = True
+
+    def _segment_group(self, segment: tp.Any) -> tp.Any:
+        """Best-effort retrieval ``group`` label for a window's segment."""
+        trigger = getattr(segment, "trigger", None)
+        if trigger is None:
+            return None
+        for attr in (self._group_field, "category", "filepath"):
+            if hasattr(trigger, attr):
+                return getattr(trigger, attr)
+        return None
 
     def on_test_epoch_start(
         self, trainer: pl.Trainer, pl_module: pl.LightningModule
     ) -> None:
-        self._y_pred = []
-        self._y_true = []
-        self._timeline = []
-        self._subject_id = []
-        self._batch_idx = []
-        self._has_subject = True
+        self._reset()
+        if not trainer.is_global_zero:
+            return
+        self._cache = CacheDict(folder=self._folder)
+        self._cache.clear()  # avoid CacheDict's no-overwrite error on re-runs
+        self._writer = self._cache.write()
+        self._writer.__enter__()
 
     def on_test_batch_end(
         self,
@@ -405,37 +442,53 @@ class WindowPredictionCollector(Callback):
         batch_idx,
         dataloader_idx=0,
     ) -> None:
+        if self._cache is None:
+            return  # non-zero rank: nothing to persist
+
         y_pred, y_true = outputs
-        self._y_pred.append(y_pred.detach().cpu().numpy())
-        self._y_true.append(y_true.detach().cpu().numpy())
-        self._timeline.extend(segment.timeline for segment in batch.segments)
-        self._batch_idx.extend([batch_idx] * len(batch.segments))
+        chunk = f"{self._n_chunks:08d}"
+        self._cache[f"{self._Y_PRED_PREFIX}{chunk}"] = y_pred.detach().cpu().numpy()
+        self._cache[f"{self._Y_TRUE_PREFIX}{chunk}"] = y_true.detach().cpu().numpy()
+        self._n_chunks += 1
+
+        n_windows = len(batch.segments)
+        self._metadata["timeline"].extend(seg.timeline for seg in batch.segments)
+        self._metadata["batch_idx"].extend([batch_idx] * n_windows)
+        self._metadata["dataloader_idx"].extend([dataloader_idx] * n_windows)
 
         subject = batch.data.get("subject_id")
         if subject is None:
             self._has_subject = False
         else:
-            self._subject_id.extend(subject.detach().cpu().reshape(-1).tolist())
+            self._metadata["subject_id"].extend(
+                subject.detach().cpu().reshape(-1).tolist()
+            )
+
+        groups = [self._segment_group(seg) for seg in batch.segments]
+        if any(g is None for g in groups):
+            self._has_group = False
+        else:
+            self._metadata["group"].extend(groups)
 
     def on_test_epoch_end(
         self, trainer: pl.Trainer, pl_module: pl.LightningModule
     ) -> None:
-        if not self._y_pred:
+        if self._cache is None:
             return
-
-        metadata = {"timeline": self._timeline, "batch_idx": self._batch_idx}
-        if self._has_subject and len(self._subject_id) == len(self._timeline):
-            metadata["subject_id"] = self._subject_id  # type: ignore[assignment]
-
-        setattr(
-            pl_module,
-            "test_predictions",
-            {
-                "metadata": pd.DataFrame(metadata),
-                "y_true": np.concatenate(self._y_true, axis=0),
-                "y_pred": np.concatenate(self._y_pred, axis=0),
-            },
-        )
+        try:
+            if self._n_chunks:
+                n_windows = len(self._metadata["timeline"])
+                columns = ["timeline", "batch_idx", "dataloader_idx"]
+                if self._has_subject and len(self._metadata["subject_id"]) == n_windows:
+                    columns.append("subject_id")
+                if self._has_group and len(self._metadata["group"]) == n_windows:
+                    columns.append("group")
+                self._cache[self._METADATA_KEY] = pd.DataFrame(
+                    {col: self._metadata[col] for col in columns}
+                )
+        finally:
+            self._writer.__exit__(None, None, None)
+            self._writer = None
 
 
 class RecordingLevelEval(Callback):

--- a/neuralbench-repo/neuralbench/main.py
+++ b/neuralbench-repo/neuralbench/main.py
@@ -505,11 +505,12 @@ class Experiment(BaseExperiment):
 
         ``WindowPredictionCollector`` streams the predictions to the uid folder
         during the test loop (metadata as CSV, arrays appended to a shared
-        memmap file), so they survive cache hits and are read here without
-        re-running. The per-batch array chunks are concatenated on read, so
-        loading materializes the full arrays in RAM.
+        memmap file), so they survive cache hits and are read straight from
+        disk. This is a read-only accessor: call :meth:`run` first (a cache hit
+        is fine); if the artifacts are missing it raises rather than launching a
+        run. The per-batch array chunks are concatenated on read, so loading
+        materializes the full arrays in RAM.
         """
-        self.run()  # ensure the experiment ran (cache hit is fine)
         uid_folder = self.infra.uid_folder()
         if uid_folder is None:
             raise RuntimeError(

--- a/neuralbench-repo/neuralbench/main.py
+++ b/neuralbench-repo/neuralbench/main.py
@@ -13,6 +13,7 @@ import typing as tp
 from pathlib import Path
 
 import lightning.pytorch as pl
+import numpy as np
 import torch
 import yaml
 from exca import TaskInfra
@@ -270,7 +271,17 @@ class Experiment(BaseExperiment):
             callbacks.append(PlotConfusionMatrix(labels=labels))
         if is_test:
             if self.save_test_predictions:
-                callbacks.append(WindowPredictionCollector())
+                uid_folder = self.infra.uid_folder()
+                if uid_folder is None:
+                    raise RuntimeError(
+                        "save_test_predictions=True requires an infra cache "
+                        "folder; configure ``infra.folder``."
+                    )
+                callbacks.append(
+                    WindowPredictionCollector(
+                        folder=uid_folder / self._TEST_PREDICTIONS_DIR
+                    )
+                )
             if self.test_full_metrics:
                 callbacks.append(RecordingLevelEval())
             if self.test_full_retrieval_metrics:
@@ -456,19 +467,13 @@ class Experiment(BaseExperiment):
             torch.distributed.destroy_process_group()
 
         if trainer.global_rank == 0:
+            # ``WindowPredictionCollector`` (added in ``setup_trainer`` when
+            # ``save_test_predictions`` is set) streams the raw per-window
+            # predictions to ``infra.uid_folder()/<_TEST_PREDICTIONS_DIR>`` as a
+            # byproduct of the test loop. They live next to ``job.pkl`` so they
+            # survive cache hits and stay out of the cached result dict; read
+            # them back via ``test_predictions()``.
             test_results.update(self._test(loaders, best_model_path))
-            # Persist raw per-window predictions (a byproduct of the test loop)
-            # as side artifacts in the uid folder, via exca's CacheDict: the
-            # metadata is stored as CSV (human-readable) and the potentially
-            # large y_true/y_pred arrays via the MemmapArray handler (lazy,
-            # RAM-flat on load). They live next to ``job.pkl`` so they survive
-            # cache hits without bloating the cached result dict, which only
-            # records a small marker pointing at the artifact folder.
-            if self.save_test_predictions:
-                predictions = getattr(self._brain_module, "test_predictions", None)
-                if predictions is not None:
-                    self._write_test_predictions(predictions)
-                    test_results["test_predictions_dir"] = self._TEST_PREDICTIONS_DIR
 
         self._cleanup(trainer)
 
@@ -483,8 +488,8 @@ class Experiment(BaseExperiment):
         )
         return test_results
 
-    # Subfolder (under ``infra.uid_folder()``) holding the per-window test
-    # prediction artifacts written via exca's ``CacheDict``.
+    # Subfolder (under ``infra.uid_folder()``) where ``WindowPredictionCollector``
+    # streams the per-window test prediction artifacts via exca's ``CacheDict``.
     _TEST_PREDICTIONS_DIR: tp.ClassVar[str] = "test_predictions"
 
     def _test_predictions_cache(self) -> CacheDict:
@@ -492,18 +497,10 @@ class Experiment(BaseExperiment):
         uid_folder = self.infra.uid_folder()
         if uid_folder is None:
             raise RuntimeError(
-                "Cannot store test predictions without an infra cache folder; "
+                "Cannot read test predictions without an infra cache folder; "
                 "configure ``infra.folder``."
             )
         return CacheDict(folder=uid_folder / self._TEST_PREDICTIONS_DIR)
-
-    def _write_test_predictions(self, predictions: dict[str, tp.Any]) -> None:
-        """Dump per-window predictions as side artifacts (CSV + memmap)."""
-        cache = self._test_predictions_cache()
-        cache.clear()  # avoid CacheDict's no-overwrite error on re-runs
-        with cache.write():
-            for key, value in predictions.items():
-                cache[key] = value
 
     def test_predictions(self) -> dict[str, tp.Any]:
         """Raw per-window test predictions.
@@ -511,24 +508,42 @@ class Experiment(BaseExperiment):
         Requires ``save_test_predictions=True``. Returns a dict with:
 
         - ``"metadata"``: a :class:`pandas.DataFrame` with one row per test
-          window (``timeline``, ``batch_idx``, and ``subject_id`` when
-          available);
+          window (``timeline``, ``batch_idx``, ``dataloader_idx``, plus
+          ``subject_id`` and a retrieval ``group`` label when available);
         - ``"y_true"`` / ``"y_pred"``: arrays of shape ``(n_windows, ...)``
-          aligned with ``metadata``, returned as lazy ``np.memmap`` views.
+          aligned with ``metadata``, concatenated across batches.
 
-        The predictions are stored as side artifacts in the uid folder by
-        exca's ``CacheDict`` (metadata as CSV, arrays via the memmap handler),
-        so they survive cache hits and are read here without re-running.
+        ``WindowPredictionCollector`` streams the predictions to the uid folder
+        during the test loop (metadata as CSV, arrays appended to a shared
+        memmap file), so they survive cache hits and are read here without
+        re-running. The per-batch array chunks are concatenated on read, so
+        loading materializes the full arrays in RAM.
         """
-        results = self.run()
-        if "test_predictions_dir" not in results:
+        self.run()  # ensure the experiment ran (cache hit is fine)
+        cache = self._test_predictions_cache()
+        keys = set(cache.keys())
+        if not keys:
             raise ValueError(
                 "Test predictions are unavailable. Set "
                 "save_test_predictions=True and (re)run the experiment "
                 "(toggling the flag yields a fresh cache entry)."
             )
-        cache = self._test_predictions_cache()
-        return {key: cache[key] for key in cache.keys()}
+        collector = WindowPredictionCollector
+        y_pred = self._concat_prediction_chunks(cache, keys, collector._Y_PRED_PREFIX)
+        y_true = self._concat_prediction_chunks(cache, keys, collector._Y_TRUE_PREFIX)
+        return {
+            "metadata": cache[collector._METADATA_KEY],
+            "y_true": y_true,
+            "y_pred": y_pred,
+        }
+
+    @staticmethod
+    def _concat_prediction_chunks(
+        cache: CacheDict, keys: set[str], prefix: str
+    ) -> np.ndarray:
+        """Concatenate the per-batch array chunks sharing ``prefix``."""
+        chunk_keys = sorted(key for key in keys if key.startswith(prefix))
+        return np.concatenate([np.asarray(cache[key]) for key in chunk_keys], axis=0)
 
 
 # BenchmarkAggregator lives in aggregator.py and forward-references Experiment

--- a/neuralbench-repo/neuralbench/main.py
+++ b/neuralbench-repo/neuralbench/main.py
@@ -16,6 +16,7 @@ import lightning.pytorch as pl
 import torch
 import yaml
 from exca import TaskInfra
+from exca.cachedict import CacheDict
 from lightning.pytorch.callbacks import (
     Callback,
     EarlyStopping,
@@ -49,6 +50,7 @@ from .callbacks import (
     PlotRegressionVectors,
     RecordingLevelEval,
     TestFullRetrievalMetrics,
+    WindowPredictionCollector,
 )
 from .data import Data as Data  # noqa: F401
 from .model_factory import build_brain_model
@@ -88,6 +90,9 @@ class Experiment(BaseExperiment):
     validate_before_training: bool = True
     test_full_metrics: list[BaseMetric] = []
     test_full_retrieval_metrics: list[BaseMetric] = []
+    # When True, raw per-window test predictions/targets are folded into the
+    # cached ``run`` result (see ``WindowPredictionCollector``).
+    save_test_predictions: bool = False
 
     # Weights & Biases
     csv_config: CsvLoggerConfig | None = None
@@ -264,6 +269,8 @@ class Experiment(BaseExperiment):
                 labels = [ind_to_label[i] for i in sorted(ind_to_label)]
             callbacks.append(PlotConfusionMatrix(labels=labels))
         if is_test:
+            if self.save_test_predictions:
+                callbacks.append(WindowPredictionCollector())
             if self.test_full_metrics:
                 callbacks.append(RecordingLevelEval())
             if self.test_full_retrieval_metrics:
@@ -450,6 +457,18 @@ class Experiment(BaseExperiment):
 
         if trainer.global_rank == 0:
             test_results.update(self._test(loaders, best_model_path))
+            # Persist raw per-window predictions (a byproduct of the test loop)
+            # as side artifacts in the uid folder, via exca's CacheDict: the
+            # metadata is stored as CSV (human-readable) and the potentially
+            # large y_true/y_pred arrays via the MemmapArray handler (lazy,
+            # RAM-flat on load). They live next to ``job.pkl`` so they survive
+            # cache hits without bloating the cached result dict, which only
+            # records a small marker pointing at the artifact folder.
+            if self.save_test_predictions:
+                predictions = getattr(self._brain_module, "test_predictions", None)
+                if predictions is not None:
+                    self._write_test_predictions(predictions)
+                    test_results["test_predictions_dir"] = self._TEST_PREDICTIONS_DIR
 
         self._cleanup(trainer)
 
@@ -463,6 +482,53 @@ class Experiment(BaseExperiment):
             }
         )
         return test_results
+
+    # Subfolder (under ``infra.uid_folder()``) holding the per-window test
+    # prediction artifacts written via exca's ``CacheDict``.
+    _TEST_PREDICTIONS_DIR: tp.ClassVar[str] = "test_predictions"
+
+    def _test_predictions_cache(self) -> CacheDict:
+        """``CacheDict`` over the per-window prediction artifact folder."""
+        uid_folder = self.infra.uid_folder()
+        if uid_folder is None:
+            raise RuntimeError(
+                "Cannot store test predictions without an infra cache folder; "
+                "configure ``infra.folder``."
+            )
+        return CacheDict(folder=uid_folder / self._TEST_PREDICTIONS_DIR)
+
+    def _write_test_predictions(self, predictions: dict[str, tp.Any]) -> None:
+        """Dump per-window predictions as side artifacts (CSV + memmap)."""
+        cache = self._test_predictions_cache()
+        cache.clear()  # avoid CacheDict's no-overwrite error on re-runs
+        with cache.write():
+            for key, value in predictions.items():
+                cache[key] = value
+
+    def test_predictions(self) -> dict[str, tp.Any]:
+        """Raw per-window test predictions.
+
+        Requires ``save_test_predictions=True``. Returns a dict with:
+
+        - ``"metadata"``: a :class:`pandas.DataFrame` with one row per test
+          window (``timeline``, ``batch_idx``, and ``subject_id`` when
+          available);
+        - ``"y_true"`` / ``"y_pred"``: arrays of shape ``(n_windows, ...)``
+          aligned with ``metadata``, returned as lazy ``np.memmap`` views.
+
+        The predictions are stored as side artifacts in the uid folder by
+        exca's ``CacheDict`` (metadata as CSV, arrays via the memmap handler),
+        so they survive cache hits and are read here without re-running.
+        """
+        results = self.run()
+        if "test_predictions_dir" not in results:
+            raise ValueError(
+                "Test predictions are unavailable. Set "
+                "save_test_predictions=True and (re)run the experiment "
+                "(toggling the flag yields a fresh cache entry)."
+            )
+        cache = self._test_predictions_cache()
+        return {key: cache[key] for key in cache.keys()}
 
 
 # BenchmarkAggregator lives in aggregator.py and forward-references Experiment

--- a/neuralbench-repo/neuralbench/main.py
+++ b/neuralbench-repo/neuralbench/main.py
@@ -492,16 +492,6 @@ class Experiment(BaseExperiment):
     # streams the per-window test prediction artifacts via exca's ``CacheDict``.
     _TEST_PREDICTIONS_DIR: tp.ClassVar[str] = "test_predictions"
 
-    def _test_predictions_cache(self) -> CacheDict:
-        """``CacheDict`` over the per-window prediction artifact folder."""
-        uid_folder = self.infra.uid_folder()
-        if uid_folder is None:
-            raise RuntimeError(
-                "Cannot read test predictions without an infra cache folder; "
-                "configure ``infra.folder``."
-            )
-        return CacheDict(folder=uid_folder / self._TEST_PREDICTIONS_DIR)
-
     def test_predictions(self) -> dict[str, tp.Any]:
         """Raw per-window test predictions.
 
@@ -520,7 +510,13 @@ class Experiment(BaseExperiment):
         loading materializes the full arrays in RAM.
         """
         self.run()  # ensure the experiment ran (cache hit is fine)
-        cache = self._test_predictions_cache()
+        uid_folder = self.infra.uid_folder()
+        if uid_folder is None:
+            raise RuntimeError(
+                "Cannot read test predictions without an infra cache folder; "
+                "configure ``infra.folder``."
+            )
+        cache: CacheDict = CacheDict(folder=uid_folder / self._TEST_PREDICTIONS_DIR)
         keys = set(cache.keys())
         if not keys:
             raise ValueError(
@@ -528,22 +524,17 @@ class Experiment(BaseExperiment):
                 "save_test_predictions=True and (re)run the experiment "
                 "(toggling the flag yields a fresh cache entry)."
             )
+
+        def _concat(prefix: str) -> np.ndarray:
+            chunks = sorted(key for key in keys if key.startswith(prefix))
+            return np.concatenate([np.asarray(cache[key]) for key in chunks], axis=0)
+
         collector = WindowPredictionCollector
-        y_pred = self._concat_prediction_chunks(cache, keys, collector._Y_PRED_PREFIX)
-        y_true = self._concat_prediction_chunks(cache, keys, collector._Y_TRUE_PREFIX)
         return {
             "metadata": cache[collector._METADATA_KEY],
-            "y_true": y_true,
-            "y_pred": y_pred,
+            "y_true": _concat(collector._Y_TRUE_PREFIX),
+            "y_pred": _concat(collector._Y_PRED_PREFIX),
         }
-
-    @staticmethod
-    def _concat_prediction_chunks(
-        cache: CacheDict, keys: set[str], prefix: str
-    ) -> np.ndarray:
-        """Concatenate the per-batch array chunks sharing ``prefix``."""
-        chunk_keys = sorted(key for key in keys if key.startswith(prefix))
-        return np.concatenate([np.asarray(cache[key]) for key in chunk_keys], axis=0)
 
 
 # BenchmarkAggregator lives in aggregator.py and forward-references Experiment

--- a/neuralbench-repo/neuralbench/test_callbacks.py
+++ b/neuralbench-repo/neuralbench/test_callbacks.py
@@ -4,13 +4,14 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
+from types import SimpleNamespace
+
 import matplotlib
 import numpy as np
 import pandas as pd
 import pytest
 import torch
-import torchmetrics
-from torch import nn
+from exca.cachedict import CacheDict
 
 from .callbacks import (
     PlotRegressionScatter,
@@ -24,9 +25,11 @@ matplotlib.use("Agg")
 class MockSegment:
     """Mock segment with events containing timeline information."""
 
-    def __init__(self, timeline: str):
+    def __init__(self, timeline: str, group: str | None = None):
         self.timeline = timeline
         self.events = pd.DataFrame({"timeline": [timeline]})
+        if group is not None:
+            self.trigger = SimpleNamespace(text=group)
 
 
 class MockBatch:
@@ -122,97 +125,81 @@ def test_binary_single_window_per_recording(mock_trainer, mock_pl_module):
     assert torch.equal(y_true.long(), torch.tensor([0, 1, 1]))
 
 
-class _RealMetricModule:
-    """Minimal LightningModule stand-in exposing the real task torchmetrics."""
+def _read_predictions(folder):
+    """Read back a WindowPredictionCollector folder (metadata + arrays)."""
+    cache: CacheDict = CacheDict(folder=folder)
+    keys = set(cache.keys())
 
-    def __init__(self, num_classes: int) -> None:
-        self.test_full_metrics = nn.ModuleDict(
-            {
-                "test/acc": torchmetrics.Accuracy(
-                    task="multiclass", num_classes=num_classes
-                ),
-                "test/bal_acc": torchmetrics.Accuracy(
-                    task="multiclass", num_classes=num_classes, average="macro"
-                ),
-                "test/auroc": torchmetrics.AUROC(
-                    task="multiclass", num_classes=num_classes
-                ),
-            }
-        )
+    def concat(prefix):
+        chunks = sorted(k for k in keys if k.startswith(prefix))
+        return np.concatenate([np.asarray(cache[k]) for k in chunks], axis=0)
 
-    def log(self, *args, **kwargs) -> None:
-        pass
+    return {
+        "metadata": cache[WindowPredictionCollector._METADATA_KEY],
+        "y_pred": concat(WindowPredictionCollector._Y_PRED_PREFIX),
+        "y_true": concat(WindowPredictionCollector._Y_TRUE_PREFIX),
+    }
 
 
-@pytest.mark.parametrize("num_classes", [2, 3])
-def test_recording_level_eval_real_metrics(mock_trainer, num_classes):
-    """Callback runs with the real task torchmetrics (acc, macro acc, AUROC)
-    for binary and multiclass setups; metrics compute to a valid scalar."""
-    module = _RealMetricModule(num_classes)
-    callback = RecordingLevelEval()
-    callback.setup(mock_trainer, module, stage="test")
-    callback.on_test_epoch_start(mock_trainer, module)
+@pytest.mark.parametrize("with_subject", [True, False])
+def test_prediction_collector_streams_windows(tmp_path, with_subject):
+    """WindowPredictionCollector streams raw per-window y_pred/y_true across
+    batches to disk with aligned metadata (timeline, batch_idx, dataloader_idx,
+    and a retrieval group label), and drops subject_id when it is absent."""
+    trainer = SimpleNamespace(is_global_zero=True)
+    module = SimpleNamespace()
+    folder = tmp_path / "test_predictions"
+    callback = WindowPredictionCollector(folder=folder)
+    callback.on_test_epoch_start(trainer, module)
 
-    torch.manual_seed(0)
-    n_rec, n_win = 4, 3
-    timelines = [f"rec{r}" for r in range(n_rec) for _ in range(n_win)]
-    y_true = torch.tensor([r % num_classes for r in range(n_rec) for _ in range(n_win)])
-    logits = torch.randn(n_rec * n_win, num_classes)
-    batch = MockBatch([MockSegment(t) for t in timelines])
-
-    callback.on_test_batch_end(mock_trainer, module, (logits, y_true), batch, batch_idx=0)
-    callback.on_test_epoch_end(mock_trainer, module)
-
-    for metric in module.test_full_metrics.values():
-        assert 0.0 <= float(metric.compute()) <= 1.0
-
-
-def test_prediction_collector_concatenates_windows_and_metadata(mock_trainer, mocker):
-    """WindowPredictionCollector stacks raw per-window y_pred/y_true across
-    batches and builds aligned metadata (timeline, batch_idx, subject_id),
-    exposing them on the module for exca to cache."""
-    module = mocker.Mock()
-    callback = WindowPredictionCollector()
-    callback.on_test_epoch_start(mock_trainer, module)
-
-    # Two batches with multi-dim predictions (e.g. regression / embeddings).
+    # Two batches with multi-dim predictions (e.g. regression / embeddings) and
+    # a per-window group label exposed via the segment trigger.
+    data0 = {"subject_id": torch.tensor([0, 0])} if with_subject else {}
+    data1 = {"subject_id": torch.tensor([1])} if with_subject else {}
     batch0 = MockBatch(
-        [MockSegment("rec0"), MockSegment("rec0")],
-        data={"subject_id": torch.tensor([0, 0])},
+        [MockSegment("rec0", group="cat"), MockSegment("rec0", group="dog")],
+        data=data0,
     )
-    batch1 = MockBatch(
-        [MockSegment("rec1")],
-        data={"subject_id": torch.tensor([1])},
+    batch1 = MockBatch([MockSegment("rec1", group="cat")], data=data1)
+
+    callback.on_test_batch_end(
+        trainer, module, (torch.zeros(2, 4), torch.ones(2, 4)), batch0, batch_idx=0
     )
-    out0 = (torch.zeros(2, 4), torch.ones(2, 4))
-    out1 = (torch.zeros(1, 4), torch.ones(1, 4))
+    callback.on_test_batch_end(
+        trainer, module, (torch.zeros(1, 4), torch.ones(1, 4)), batch1, batch_idx=1
+    )
+    callback.on_test_epoch_end(trainer, module)
 
-    callback.on_test_batch_end(mock_trainer, module, out0, batch0, batch_idx=0)
-    callback.on_test_batch_end(mock_trainer, module, out1, batch1, batch_idx=1)
-    callback.on_test_epoch_end(mock_trainer, module)
-
-    preds = module.test_predictions
+    preds = _read_predictions(folder)
     assert preds["y_pred"].shape == (3, 4)
     assert preds["y_true"].shape == (3, 4)
     meta = preds["metadata"]
     assert list(meta["timeline"]) == ["rec0", "rec0", "rec1"]
     assert list(meta["batch_idx"]) == [0, 0, 1]
-    assert list(meta["subject_id"]) == [0, 0, 1]
+    assert list(meta["dataloader_idx"]) == [0, 0, 0]
+    assert list(meta["group"]) == ["cat", "dog", "cat"]
+    if with_subject:
+        assert list(meta["subject_id"]) == [0, 0, 1]
+    else:
+        assert "subject_id" not in meta.columns
 
 
-def test_prediction_collector_omits_subject_when_absent(mock_trainer, mocker):
-    """subject_id column is dropped when the batch has no subject_id."""
-    module = mocker.Mock()
-    callback = WindowPredictionCollector()
-    callback.on_test_epoch_start(mock_trainer, module)
-
-    batch = MockBatch([MockSegment("rec0")])  # no data["subject_id"]
+def test_prediction_collector_skips_non_zero_rank(tmp_path):
+    """Only global rank zero persists predictions."""
+    trainer = SimpleNamespace(is_global_zero=False)
+    module = SimpleNamespace()
+    folder = tmp_path / "test_predictions"
+    callback = WindowPredictionCollector(folder=folder)
+    callback.on_test_epoch_start(trainer, module)
     callback.on_test_batch_end(
-        mock_trainer, module, (torch.zeros(1, 2), torch.ones(1, 2)), batch, batch_idx=0
+        trainer,
+        module,
+        (torch.zeros(1, 2), torch.ones(1, 2)),
+        MockBatch([MockSegment("rec0")]),
+        batch_idx=0,
     )
-    callback.on_test_epoch_end(mock_trainer, module)
-
-    assert "subject_id" not in module.test_predictions["metadata"].columns
+    callback.on_test_epoch_end(trainer, module)
+    assert not folder.exists()
 
 
 def test_binary_multiple_windows_per_recording(mock_trainer, mock_pl_module):

--- a/neuralbench-repo/neuralbench/test_callbacks.py
+++ b/neuralbench-repo/neuralbench/test_callbacks.py
@@ -9,8 +9,14 @@ import numpy as np
 import pandas as pd
 import pytest
 import torch
+import torchmetrics
+from torch import nn
 
-from .callbacks import PlotRegressionScatter, RecordingLevelEval
+from .callbacks import (
+    PlotRegressionScatter,
+    RecordingLevelEval,
+    WindowPredictionCollector,
+)
 
 matplotlib.use("Agg")
 
@@ -19,14 +25,18 @@ class MockSegment:
     """Mock segment with events containing timeline information."""
 
     def __init__(self, timeline: str):
+        self.timeline = timeline
         self.events = pd.DataFrame({"timeline": [timeline]})
 
 
 class MockBatch:
     """Mock batch containing segments."""
 
-    def __init__(self, segments: list[MockSegment]):
+    def __init__(
+        self, segments: list[MockSegment], data: dict[str, torch.Tensor] | None = None
+    ):
         self.segments = segments
+        self.data = data if data is not None else {}
 
 
 @pytest.fixture
@@ -110,6 +120,99 @@ def test_binary_single_window_per_recording(mock_trainer, mock_pl_module):
 
     # Check true labels (convert to same dtype for comparison)
     assert torch.equal(y_true.long(), torch.tensor([0, 1, 1]))
+
+
+class _RealMetricModule:
+    """Minimal LightningModule stand-in exposing the real task torchmetrics."""
+
+    def __init__(self, num_classes: int) -> None:
+        self.test_full_metrics = nn.ModuleDict(
+            {
+                "test/acc": torchmetrics.Accuracy(
+                    task="multiclass", num_classes=num_classes
+                ),
+                "test/bal_acc": torchmetrics.Accuracy(
+                    task="multiclass", num_classes=num_classes, average="macro"
+                ),
+                "test/auroc": torchmetrics.AUROC(
+                    task="multiclass", num_classes=num_classes
+                ),
+            }
+        )
+
+    def log(self, *args, **kwargs) -> None:
+        pass
+
+
+@pytest.mark.parametrize("num_classes", [2, 3])
+def test_recording_level_eval_real_metrics(mock_trainer, num_classes):
+    """Callback runs with the real task torchmetrics (acc, macro acc, AUROC)
+    for binary and multiclass setups; metrics compute to a valid scalar."""
+    module = _RealMetricModule(num_classes)
+    callback = RecordingLevelEval()
+    callback.setup(mock_trainer, module, stage="test")
+    callback.on_test_epoch_start(mock_trainer, module)
+
+    torch.manual_seed(0)
+    n_rec, n_win = 4, 3
+    timelines = [f"rec{r}" for r in range(n_rec) for _ in range(n_win)]
+    y_true = torch.tensor([r % num_classes for r in range(n_rec) for _ in range(n_win)])
+    logits = torch.randn(n_rec * n_win, num_classes)
+    batch = MockBatch([MockSegment(t) for t in timelines])
+
+    callback.on_test_batch_end(mock_trainer, module, (logits, y_true), batch, batch_idx=0)
+    callback.on_test_epoch_end(mock_trainer, module)
+
+    for metric in module.test_full_metrics.values():
+        assert 0.0 <= float(metric.compute()) <= 1.0
+
+
+def test_prediction_collector_concatenates_windows_and_metadata(mock_trainer, mocker):
+    """WindowPredictionCollector stacks raw per-window y_pred/y_true across
+    batches and builds aligned metadata (timeline, batch_idx, subject_id),
+    exposing them on the module for exca to cache."""
+    module = mocker.Mock()
+    callback = WindowPredictionCollector()
+    callback.on_test_epoch_start(mock_trainer, module)
+
+    # Two batches with multi-dim predictions (e.g. regression / embeddings).
+    batch0 = MockBatch(
+        [MockSegment("rec0"), MockSegment("rec0")],
+        data={"subject_id": torch.tensor([0, 0])},
+    )
+    batch1 = MockBatch(
+        [MockSegment("rec1")],
+        data={"subject_id": torch.tensor([1])},
+    )
+    out0 = (torch.zeros(2, 4), torch.ones(2, 4))
+    out1 = (torch.zeros(1, 4), torch.ones(1, 4))
+
+    callback.on_test_batch_end(mock_trainer, module, out0, batch0, batch_idx=0)
+    callback.on_test_batch_end(mock_trainer, module, out1, batch1, batch_idx=1)
+    callback.on_test_epoch_end(mock_trainer, module)
+
+    preds = module.test_predictions
+    assert preds["y_pred"].shape == (3, 4)
+    assert preds["y_true"].shape == (3, 4)
+    meta = preds["metadata"]
+    assert list(meta["timeline"]) == ["rec0", "rec0", "rec1"]
+    assert list(meta["batch_idx"]) == [0, 0, 1]
+    assert list(meta["subject_id"]) == [0, 0, 1]
+
+
+def test_prediction_collector_omits_subject_when_absent(mock_trainer, mocker):
+    """subject_id column is dropped when the batch has no subject_id."""
+    module = mocker.Mock()
+    callback = WindowPredictionCollector()
+    callback.on_test_epoch_start(mock_trainer, module)
+
+    batch = MockBatch([MockSegment("rec0")])  # no data["subject_id"]
+    callback.on_test_batch_end(
+        mock_trainer, module, (torch.zeros(1, 2), torch.ones(1, 2)), batch, batch_idx=0
+    )
+    callback.on_test_epoch_end(mock_trainer, module)
+
+    assert "subject_id" not in module.test_predictions["metadata"].columns
 
 
 def test_binary_multiple_windows_per_recording(mock_trainer, mock_pl_module):

--- a/neuralbench-repo/neuralbench/test_main.py
+++ b/neuralbench-repo/neuralbench/test_main.py
@@ -8,8 +8,12 @@ import typing as tp
 from types import SimpleNamespace
 
 import lightning.pytorch as pl
+import numpy as np
+import pandas as pd
+import pytest
 import torch
 from exca import TaskInfra
+from exca.cachedict import CacheDict
 from torch import nn
 from torch.utils.data import DataLoader
 
@@ -174,3 +178,84 @@ def test_run_seeds_before_preparing_dataloaders(monkeypatch) -> None:
     assert events[-2:] == ["prepare_pl_module", "cleanup"]
     assert result["n_total_params"] is None
     assert result["n_trainable_params"] is None
+
+
+_PREDS = {
+    "metadata": pd.DataFrame({"timeline": ["rec0", "rec1"], "batch_idx": [0, 0]}),
+    "y_true": np.array([[0.0, 1.0], [1.0, 0.0]]),
+    "y_pred": np.array([[0.2, 0.8], [0.7, 0.3]]),
+}
+
+
+def _make_eval_experiment(save_test_predictions: bool) -> Experiment:
+    class _DummyData:
+        def prepare(self) -> dict[str, object]:
+            return {"train": object(), "val": object(), "test": object()}
+
+    return Experiment.model_construct(
+        data=tp.cast(Data, _DummyData()),
+        brain_model_config=tp.cast(BaseModelConfig, object()),
+        trainer_config=tp.cast(TrainerConfig, object()),
+        loss=tp.cast(BaseLoss, _DummyLoss()),
+        lightning_optimizer_config=tp.cast(LightningOptimizer, object()),
+        metrics=[],
+        eval_only=True,
+        infra=TaskInfra(version="1", gpus_per_node=0),
+        save_test_predictions=save_test_predictions,
+    )
+
+
+def test_run_writes_test_predictions_when_flag_set(monkeypatch) -> None:
+    """``save_test_predictions`` gates persisting predictions in run():
+    True writes the artifacts and records a marker, False (default) leaves it
+    out so existing caches stay valid."""
+
+    def fake_prepare_pl_module(self, train_loader, val_loader=None) -> None:
+        del train_loader, val_loader
+        self._brain_module = SimpleNamespace(test_predictions=_PREDS)
+
+    written: list[dict] = []
+    monkeypatch.setattr(Experiment, "setup_run", lambda self: None)
+    monkeypatch.setattr(Experiment, "setup_trainer", lambda self, *a, **kw: SimpleNamespace(global_rank=0))
+    monkeypatch.setattr(Experiment, "prepare_pl_module", fake_prepare_pl_module)
+    monkeypatch.setattr(Experiment, "_test", lambda self, loaders, ckpt: {"test/acc": 1.0})
+    monkeypatch.setattr(Experiment, "_cleanup", lambda self, trainer: None)
+    monkeypatch.setattr(Experiment, "_write_test_predictions", lambda self, preds: written.append(preds))
+
+    # Call the unwrapped run() body directly: invoking the exca-wrapped method on
+    # a ``model_construct`` instance is order-dependent (binding happens in a
+    # pydantic validator that ``model_construct`` skips), which is irrelevant here.
+    raw_run = Experiment.model_fields["infra"].default._infra_method.method
+    result = raw_run(_make_eval_experiment(True))
+    assert result["test_predictions_dir"] == Experiment._TEST_PREDICTIONS_DIR
+    assert written and written[0] is _PREDS
+    assert "test_predictions_dir" not in raw_run(_make_eval_experiment(False))
+
+
+def test_test_predictions_roundtrip(monkeypatch, tmp_path) -> None:
+    """Predictions written via CacheDict round-trip through the accessor:
+    metadata as a DataFrame, arrays as memmaps."""
+    experiment = _make_eval_experiment(save_test_predictions=True)
+    folder = str(tmp_path / "test_predictions")
+    # Fresh CacheDict per call on the same folder -> a genuine disk round-trip.
+    monkeypatch.setattr(
+        Experiment, "_test_predictions_cache", lambda self: CacheDict(folder=folder)
+    )
+
+    experiment._write_test_predictions(_PREDS)
+    monkeypatch.setattr(
+        Experiment, "run", lambda self: {"test_predictions_dir": "test_predictions"}
+    )
+    out = experiment.test_predictions()
+
+    pd.testing.assert_frame_equal(out["metadata"], _PREDS["metadata"])
+    assert np.array_equal(np.asarray(out["y_true"]), _PREDS["y_true"])
+    assert np.array_equal(np.asarray(out["y_pred"]), _PREDS["y_pred"])
+
+
+def test_test_predictions_accessor_errors_when_unsaved(monkeypatch) -> None:
+    """The accessor errors when predictions were not saved."""
+    experiment = _make_eval_experiment(save_test_predictions=False)
+    monkeypatch.setattr(Experiment, "run", lambda self: {"test/acc": 1.0})
+    with pytest.raises(ValueError, match="save_test_predictions=True"):
+        experiment.test_predictions()

--- a/neuralbench-repo/neuralbench/test_main.py
+++ b/neuralbench-repo/neuralbench/test_main.py
@@ -21,6 +21,7 @@ from neuraltrain.losses import BaseLoss
 from neuraltrain.models.base import BaseModelConfig
 from neuraltrain.optimizers import LightningOptimizer
 
+from .callbacks import WindowPredictionCollector
 from .data import Data
 from .main import Experiment
 from .utils import TrainerConfig
@@ -181,9 +182,11 @@ def test_run_seeds_before_preparing_dataloaders(monkeypatch) -> None:
 
 
 _PREDS: dict[str, tp.Any] = {
-    "metadata": pd.DataFrame({"timeline": ["rec0", "rec1"], "batch_idx": [0, 0]}),
-    "y_true": np.array([[0.0, 1.0], [1.0, 0.0]]),
-    "y_pred": np.array([[0.2, 0.8], [0.7, 0.3]]),
+    "metadata": pd.DataFrame(
+        {"timeline": ["rec0", "rec1", "rec2"], "batch_idx": [0, 0, 1]}
+    ),
+    "y_true": np.array([[0.0, 1.0], [1.0, 0.0], [0.5, 0.5]]),
+    "y_pred": np.array([[0.2, 0.8], [0.7, 0.3], [0.4, 0.6]]),
 }
 
 
@@ -205,63 +208,44 @@ def _make_eval_experiment(save_test_predictions: bool) -> Experiment:
     )
 
 
-def test_run_writes_test_predictions_when_flag_set(monkeypatch) -> None:
-    """``save_test_predictions`` gates persisting predictions in run():
-    True writes the artifacts and records a marker, False (default) leaves it
-    out so existing caches stay valid."""
-
-    def fake_prepare_pl_module(self, train_loader, val_loader=None) -> None:
-        del train_loader, val_loader
-        self._brain_module = SimpleNamespace(test_predictions=_PREDS)
-
-    written: list[dict] = []
-    monkeypatch.setattr(Experiment, "setup_run", lambda self: None)
-    monkeypatch.setattr(
-        Experiment, "setup_trainer", lambda self, *a, **kw: SimpleNamespace(global_rank=0)
-    )
-    monkeypatch.setattr(Experiment, "prepare_pl_module", fake_prepare_pl_module)
-    monkeypatch.setattr(
-        Experiment, "_test", lambda self, loaders, ckpt: {"test/acc": 1.0}
-    )
-    monkeypatch.setattr(Experiment, "_cleanup", lambda self, trainer: None)
-    monkeypatch.setattr(
-        Experiment, "_write_test_predictions", lambda self, preds: written.append(preds)
-    )
-
-    # Call the unwrapped run() body directly: invoking the exca-wrapped method on
-    # a ``model_construct`` instance is order-dependent (binding happens in a
-    # pydantic validator that ``model_construct`` skips), which is irrelevant here.
-    raw_run = Experiment.model_fields["infra"].default._infra_method.method
-    result = raw_run(_make_eval_experiment(True))
-    assert result["test_predictions_dir"] == Experiment._TEST_PREDICTIONS_DIR
-    assert written and written[0] is _PREDS
-    assert "test_predictions_dir" not in raw_run(_make_eval_experiment(False))
+def _write_streamed_predictions(folder: str) -> None:
+    """Mimic WindowPredictionCollector's on-disk layout: per-batch array chunks
+    plus a single metadata table."""
+    cache: CacheDict = CacheDict(folder=folder)
+    with cache.write():
+        # Two "batches": rows [0:2] then [2:3], matching ``batch_idx``.
+        for chunk, sl in enumerate([slice(0, 2), slice(2, 3)]):
+            tag = f"{chunk:08d}"
+            cache[WindowPredictionCollector._Y_PRED_PREFIX + tag] = _PREDS["y_pred"][sl]
+            cache[WindowPredictionCollector._Y_TRUE_PREFIX + tag] = _PREDS["y_true"][sl]
+        cache[WindowPredictionCollector._METADATA_KEY] = _PREDS["metadata"]
 
 
 def test_test_predictions_roundtrip(monkeypatch, tmp_path) -> None:
-    """Predictions written via CacheDict round-trip through the accessor:
-    metadata as a DataFrame, arrays as memmaps."""
+    """Streamed per-batch chunks round-trip through the accessor: arrays are
+    concatenated in order and metadata is returned as a DataFrame."""
     experiment = _make_eval_experiment(save_test_predictions=True)
     folder = str(tmp_path / "test_predictions")
-    # Fresh CacheDict per call on the same folder -> a genuine disk round-trip.
+    _write_streamed_predictions(folder)
     monkeypatch.setattr(
         Experiment, "_test_predictions_cache", lambda self: CacheDict(folder=folder)
     )
+    monkeypatch.setattr(Experiment, "run", lambda self: {"test/acc": 1.0})
 
-    experiment._write_test_predictions(_PREDS)
-    monkeypatch.setattr(
-        Experiment, "run", lambda self: {"test_predictions_dir": "test_predictions"}
-    )
     out = experiment.test_predictions()
 
     pd.testing.assert_frame_equal(out["metadata"], _PREDS["metadata"])
-    assert np.array_equal(np.asarray(out["y_true"]), _PREDS["y_true"])
-    assert np.array_equal(np.asarray(out["y_pred"]), _PREDS["y_pred"])
+    assert np.array_equal(out["y_true"], _PREDS["y_true"])
+    assert np.array_equal(out["y_pred"], _PREDS["y_pred"])
 
 
-def test_test_predictions_accessor_errors_when_unsaved(monkeypatch) -> None:
-    """The accessor errors when predictions were not saved."""
+def test_test_predictions_accessor_errors_when_unsaved(monkeypatch, tmp_path) -> None:
+    """The accessor errors when the prediction folder is empty (flag was off)."""
     experiment = _make_eval_experiment(save_test_predictions=False)
+    folder = str(tmp_path / "test_predictions")
+    monkeypatch.setattr(
+        Experiment, "_test_predictions_cache", lambda self: CacheDict(folder=folder)
+    )
     monkeypatch.setattr(Experiment, "run", lambda self: {"test/acc": 1.0})
     with pytest.raises(ValueError, match="save_test_predictions=True"):
         experiment.test_predictions()

--- a/neuralbench-repo/neuralbench/test_main.py
+++ b/neuralbench-repo/neuralbench/test_main.py
@@ -225,11 +225,8 @@ def test_test_predictions_roundtrip(monkeypatch, tmp_path) -> None:
     """Streamed per-batch chunks round-trip through the accessor: arrays are
     concatenated in order and metadata is returned as a DataFrame."""
     experiment = _make_eval_experiment(save_test_predictions=True)
-    folder = str(tmp_path / "test_predictions")
-    _write_streamed_predictions(folder)
-    monkeypatch.setattr(
-        Experiment, "_test_predictions_cache", lambda self: CacheDict(folder=folder)
-    )
+    _write_streamed_predictions(str(tmp_path / Experiment._TEST_PREDICTIONS_DIR))
+    monkeypatch.setattr(type(experiment.infra), "uid_folder", lambda self: tmp_path)
     monkeypatch.setattr(Experiment, "run", lambda self: {"test/acc": 1.0})
 
     out = experiment.test_predictions()
@@ -242,10 +239,7 @@ def test_test_predictions_roundtrip(monkeypatch, tmp_path) -> None:
 def test_test_predictions_accessor_errors_when_unsaved(monkeypatch, tmp_path) -> None:
     """The accessor errors when the prediction folder is empty (flag was off)."""
     experiment = _make_eval_experiment(save_test_predictions=False)
-    folder = str(tmp_path / "test_predictions")
-    monkeypatch.setattr(
-        Experiment, "_test_predictions_cache", lambda self: CacheDict(folder=folder)
-    )
+    monkeypatch.setattr(type(experiment.infra), "uid_folder", lambda self: tmp_path)
     monkeypatch.setattr(Experiment, "run", lambda self: {"test/acc": 1.0})
     with pytest.raises(ValueError, match="save_test_predictions=True"):
         experiment.test_predictions()

--- a/neuralbench-repo/neuralbench/test_main.py
+++ b/neuralbench-repo/neuralbench/test_main.py
@@ -227,7 +227,6 @@ def test_test_predictions_roundtrip(monkeypatch, tmp_path) -> None:
     experiment = _make_eval_experiment(save_test_predictions=True)
     _write_streamed_predictions(str(tmp_path / Experiment._TEST_PREDICTIONS_DIR))
     monkeypatch.setattr(type(experiment.infra), "uid_folder", lambda self: tmp_path)
-    monkeypatch.setattr(Experiment, "run", lambda self: {"test/acc": 1.0})
 
     out = experiment.test_predictions()
 
@@ -240,6 +239,5 @@ def test_test_predictions_accessor_errors_when_unsaved(monkeypatch, tmp_path) ->
     """The accessor errors when the prediction folder is empty (flag was off)."""
     experiment = _make_eval_experiment(save_test_predictions=False)
     monkeypatch.setattr(type(experiment.infra), "uid_folder", lambda self: tmp_path)
-    monkeypatch.setattr(Experiment, "run", lambda self: {"test/acc": 1.0})
     with pytest.raises(ValueError, match="save_test_predictions=True"):
         experiment.test_predictions()

--- a/neuralbench-repo/neuralbench/test_main.py
+++ b/neuralbench-repo/neuralbench/test_main.py
@@ -180,7 +180,7 @@ def test_run_seeds_before_preparing_dataloaders(monkeypatch) -> None:
     assert result["n_trainable_params"] is None
 
 
-_PREDS = {
+_PREDS: dict[str, tp.Any] = {
     "metadata": pd.DataFrame({"timeline": ["rec0", "rec1"], "batch_idx": [0, 0]}),
     "y_true": np.array([[0.0, 1.0], [1.0, 0.0]]),
     "y_pred": np.array([[0.2, 0.8], [0.7, 0.3]]),

--- a/neuralbench-repo/neuralbench/test_main.py
+++ b/neuralbench-repo/neuralbench/test_main.py
@@ -216,11 +216,17 @@ def test_run_writes_test_predictions_when_flag_set(monkeypatch) -> None:
 
     written: list[dict] = []
     monkeypatch.setattr(Experiment, "setup_run", lambda self: None)
-    monkeypatch.setattr(Experiment, "setup_trainer", lambda self, *a, **kw: SimpleNamespace(global_rank=0))
+    monkeypatch.setattr(
+        Experiment, "setup_trainer", lambda self, *a, **kw: SimpleNamespace(global_rank=0)
+    )
     monkeypatch.setattr(Experiment, "prepare_pl_module", fake_prepare_pl_module)
-    monkeypatch.setattr(Experiment, "_test", lambda self, loaders, ckpt: {"test/acc": 1.0})
+    monkeypatch.setattr(
+        Experiment, "_test", lambda self, loaders, ckpt: {"test/acc": 1.0}
+    )
     monkeypatch.setattr(Experiment, "_cleanup", lambda self, trainer: None)
-    monkeypatch.setattr(Experiment, "_write_test_predictions", lambda self, preds: written.append(preds))
+    monkeypatch.setattr(
+        Experiment, "_write_test_predictions", lambda self, preds: written.append(preds)
+    )
 
     # Call the unwrapped run() body directly: invoking the exca-wrapped method on
     # a ``model_construct`` instance is order-dependent (binding happens in a


### PR DESCRIPTION
## Prediction logging for NeuralBench

Adds an opt-in way to persist **raw per-window test predictions and targets**, so any metric, error analysis, or retrieval study can be recomputed offline without re-running the model.

### What's new

- **`Experiment.save_test_predictions`** (default `False`): when enabled, a new **`WindowPredictionCollector`** callback streams the per-window `(y_pred, y_true)` from the test loop to the experiment's uid folder via an `exca` `CacheDict`, alongside a small per-window metadata table (`timeline`, `batch_idx`, `dataloader_idx`, and—when available—`subject_id` and a retrieval `group` label).
- **`Experiment.test_predictions()`**: a read-only accessor that returns `{"metadata", "y_true", "y_pred"}`, reading straight from disk so results survive cache hits.
- **Docs**: a new tutorial (`docs/neuralbench/tutorials/05_advanced/save_test_predictions.py`) covering how to enable logging, what gets saved, reading predictions back, recomputing a metric offline, and the caveats.

### Design notes

- **Memory-safe writes.** Arrays are appended to a shared memmap one batch at a time, so the write path is O(batch) rather than O(test-set)—important for high-dimensional outputs (word/video embeddings, fMRI voxels, CTC log-probs). Reading back concatenates the chunks into full arrays in RAM (documented).
- **Task-agnostic.** `y_pred`/`y_true` are stored with their native shape; no per-task aggregation. The retrieval *set* isn't stored separately—`y_true` + the `group` column are enough to reconstruct it.
- **Multi-GPU.** The test loop is single-device by construction (runs on global rank 0 with `devices=1` after the training process group is torn down), so saved predictions cover the full test set even after multi-GPU training.

### Implementation

- Saving lives entirely in the callback; `Experiment` just wires it up in `setup_trainer` and exposes the single `test_predictions()` accessor (no extra plumbing in `run()` or the aggregator).
- Tests: consolidated callback streaming/rank-skip tests and an `Experiment` round-trip + error-path test.