### PR TITLE
Add study folder name overrides

### DIFF
--- a/neuralfetch-repo/neuralfetch/studies/allen2022massive.py
+++ b/neuralfetch-repo/neuralfetch/studies/allen2022massive.py
@@ -645,6 +645,8 @@ class Allen2022MassiveRaw(Allen2022Massive):
         - Paradigm: passive viewing of 73,000 natural images from COCO dataset
     """
 
+    folder_name: tp.ClassVar[str | None] = "Allen2022Massive"
+
     description: tp.ClassVar[str] = (
         "Natural Scenes Dataset: 7T BOLD fMRI from 8 participants viewing "
         "73,000 natural images from Microsoft COCO dataset (BIDS/deepprep variant)"
@@ -897,6 +899,8 @@ class Allen2022MassiveSample(Allen2022Massive):
 
     Uses preprocessed timeseries for subject 1, session 1, runs 1-4.
     """
+
+    folder_name: tp.ClassVar[str | None] = "Allen2022Massive"
 
     description: tp.ClassVar[str] = (
         "Mini NSD: preprocessed 7T BOLD fMRI for subject 1, session 1, "

--- a/neuralfetch-repo/neuralfetch/studies/allen2022massive.py
+++ b/neuralfetch-repo/neuralfetch/studies/allen2022massive.py
@@ -138,6 +138,7 @@ class Allen2022Massive(study.Study):
         - Paradigm: passive viewing of 73,000 natural images from COCO dataset
     """
 
+    folder_name: tp.ClassVar[str | None] = "Allen2022Massive"
     aliases: tp.ClassVar[tuple[str, ...]] = ("NSD",)
     dataset_name: tp.ClassVar[str] = "Natural Scenes Dataset"
     bibtex: tp.ClassVar[str] = """
@@ -645,8 +646,6 @@ class Allen2022MassiveRaw(Allen2022Massive):
         - Paradigm: passive viewing of 73,000 natural images from COCO dataset
     """
 
-    folder_name: tp.ClassVar[str | None] = "Allen2022Massive"
-
     description: tp.ClassVar[str] = (
         "Natural Scenes Dataset: 7T BOLD fMRI from 8 participants viewing "
         "73,000 natural images from Microsoft COCO dataset (BIDS/deepprep variant)"
@@ -899,8 +898,6 @@ class Allen2022MassiveSample(Allen2022Massive):
 
     Uses preprocessed timeseries for subject 1, session 1, runs 1-4.
     """
-
-    folder_name: tp.ClassVar[str | None] = "Allen2022Massive"
 
     description: tp.ClassVar[str] = (
         "Mini NSD: preprocessed 7T BOLD fMRI for subject 1, session 1, "

--- a/neuralfetch-repo/neuralfetch/studies/bel2026petit.py
+++ b/neuralfetch-repo/neuralfetch/studies/bel2026petit.py
@@ -557,6 +557,8 @@ class Bel2026PetitListenSample(Bel2026PetitListen):
     OpenNeuro dataset: https://openneuro.org/datasets/ds007523
     """
 
+    folder_name: tp.ClassVar[str | None] = "Bel2026PetitListen"
+
     description: tp.ClassVar[str] = (
         "Sample Bel2026PetitListen: MEG listening to Le Petit Prince (subject 26, run 01)"
     )
@@ -627,6 +629,8 @@ class Bel2026PetitReadSample(Bel2026PetitRead):
 
     OpenNeuro dataset: https://openneuro.org/datasets/ds007524
     """
+
+    folder_name: tp.ClassVar[str | None] = "Bel2026PetitRead"
 
     description: tp.ClassVar[str] = (
         "Sample Bel2026PetitRead: MEG reading Le Petit Prince (subject 26, run 01)"

--- a/neuralfetch-repo/neuralfetch/studies/bel2026petit.py
+++ b/neuralfetch-repo/neuralfetch/studies/bel2026petit.py
@@ -207,6 +207,7 @@ class Bel2026PetitListen(_Bel2026PetitBase):
         - Some runs are excluded due to poor trigger alignment (see BAD_RUNS_LIST_LISTEN).
     """
 
+    folder_name: tp.ClassVar[str | None] = "Bel2026PetitListen"
     aliases: tp.ClassVar[tuple[str, ...]] = ("LPP-Listen", "LPP MEG Listen")
     bibtex: tp.ClassVar[str] = """
     @article{bel2026petit,
@@ -380,6 +381,7 @@ class Bel2026PetitRead(_Bel2026PetitBase):
         - Words that cannot be aligned to triggers are kept as MissedWord events.
     """
 
+    folder_name: tp.ClassVar[str | None] = "Bel2026PetitRead"
     aliases: tp.ClassVar[tuple[str, ...]] = ("LPP-Read", "LPP MEG Read")
     bibtex: tp.ClassVar[str] = """
     @article{bel2026petit,
@@ -557,8 +559,6 @@ class Bel2026PetitListenSample(Bel2026PetitListen):
     OpenNeuro dataset: https://openneuro.org/datasets/ds007523
     """
 
-    folder_name: tp.ClassVar[str | None] = "Bel2026PetitListen"
-
     description: tp.ClassVar[str] = (
         "Sample Bel2026PetitListen: MEG listening to Le Petit Prince (subject 26, run 01)"
     )
@@ -629,8 +629,6 @@ class Bel2026PetitReadSample(Bel2026PetitRead):
 
     OpenNeuro dataset: https://openneuro.org/datasets/ds007524
     """
-
-    folder_name: tp.ClassVar[str | None] = "Bel2026PetitRead"
 
     description: tp.ClassVar[str] = (
         "Sample Bel2026PetitRead: MEG reading Le Petit Prince (subject 26, run 01)"

--- a/neuralfetch-repo/neuralfetch/studies/bel2026petit.py
+++ b/neuralfetch-repo/neuralfetch/studies/bel2026petit.py
@@ -77,6 +77,7 @@ def _clean_text(text: str) -> str:
 
 
 class _Bel2026PetitBase(study.Study):
+    folder_name: tp.ClassVar[str | None] = "Bel2026Petit"
     requirements: tp.ClassVar[tuple[str, ...]] = ("openneuro-py",)
 
     task: tp.ClassVar[str]
@@ -207,7 +208,6 @@ class Bel2026PetitListen(_Bel2026PetitBase):
         - Some runs are excluded due to poor trigger alignment (see BAD_RUNS_LIST_LISTEN).
     """
 
-    folder_name: tp.ClassVar[str | None] = "Bel2026PetitListen"
     aliases: tp.ClassVar[tuple[str, ...]] = ("LPP-Listen", "LPP MEG Listen")
     bibtex: tp.ClassVar[str] = """
     @article{bel2026petit,
@@ -381,7 +381,6 @@ class Bel2026PetitRead(_Bel2026PetitBase):
         - Words that cannot be aligned to triggers are kept as MissedWord events.
     """
 
-    folder_name: tp.ClassVar[str | None] = "Bel2026PetitRead"
     aliases: tp.ClassVar[tuple[str, ...]] = ("LPP-Read", "LPP MEG Read")
     bibtex: tp.ClassVar[str] = """
     @article{bel2026petit,

--- a/neuralfetch-repo/neuralfetch/studies/grootswagers2022human.py
+++ b/neuralfetch-repo/neuralfetch/studies/grootswagers2022human.py
@@ -48,6 +48,7 @@ class Grootswagers2022Human(study.Study):
         - Participants 49-50 have 127 channels; all others have 63
     """
 
+    folder_name: tp.ClassVar[str | None] = "Grootswagers2022Human"
     aliases: tp.ClassVar[tuple[str, ...]] = ("THINGS-EEG1",)
     licence: tp.ClassVar[str] = "CC0-1.0"
     bibtex: tp.ClassVar[str] = """
@@ -200,8 +201,6 @@ class Grootswagers2022HumanSample(Grootswagers2022Human):
     Still needs to download the full THINGS-images database (shared across THINGS studies)
     to access the image files, but this is a much smaller download than the full EEG dataset.
     """
-
-    folder_name: tp.ClassVar[str | None] = "Grootswagers2022Human"
 
     description: tp.ClassVar[str] = (
         "Sample Grootswagers2022: OpenNeuro EEG + image events for sub-01."

--- a/neuralfetch-repo/neuralfetch/studies/grootswagers2022human.py
+++ b/neuralfetch-repo/neuralfetch/studies/grootswagers2022human.py
@@ -201,6 +201,8 @@ class Grootswagers2022HumanSample(Grootswagers2022Human):
     to access the image files, but this is a much smaller download than the full EEG dataset.
     """
 
+    folder_name: tp.ClassVar[str | None] = "Grootswagers2022Human"
+
     description: tp.ClassVar[str] = (
         "Sample Grootswagers2022: OpenNeuro EEG + image events for sub-01."
     )

--- a/neuralfetch-repo/neuralfetch/studies/li2022petit.py
+++ b/neuralfetch-repo/neuralfetch/studies/li2022petit.py
@@ -56,6 +56,7 @@ class Li2022Petit(study.Study):
         - Multiple text fixes applied for alignment between audio and transcripts.
     """
 
+    folder_name: tp.ClassVar[str | None] = "Li2022Petit"
     aliases: tp.ClassVar[tuple[str, ...]] = ("Le Petit Prince fMRI Corpus", "LPPC-fMRI")
 
     bibtex: tp.ClassVar[str] = """
@@ -293,8 +294,6 @@ class Li2022PetitSample(Li2022Petit):
     Note: The Li2022Petit dataset uses different run numbering in filenames due to
     scanning issues. EN057's section 1 corresponds to run 15 in the files.
     """
-
-    folder_name: tp.ClassVar[str | None] = "Li2022Petit"
 
     description: tp.ClassVar[str] = (
         "Ultra-minimal Le Petit Prince fMRI: Single subject (EN057), run 1 only. "

--- a/neuralfetch-repo/neuralfetch/studies/li2022petit.py
+++ b/neuralfetch-repo/neuralfetch/studies/li2022petit.py
@@ -294,6 +294,8 @@ class Li2022PetitSample(Li2022Petit):
     scanning issues. EN057's section 1 corresponds to run 15 in the files.
     """
 
+    folder_name: tp.ClassVar[str | None] = "Li2022Petit"
+
     description: tp.ClassVar[str] = (
         "Ultra-minimal Le Petit Prince fMRI: Single subject (EN057), run 1 only. "
         "Lightweight (~80MB) for rapid CI/CD testing and validation."

--- a/neuralfetch-repo/neuralfetch/studies/miltiadous2023dice.py
+++ b/neuralfetch-repo/neuralfetch/studies/miltiadous2023dice.py
@@ -33,6 +33,7 @@ class Miltiadous2023Dice(study.Study):
 
     """
 
+    folder_name: tp.ClassVar[str | None] = "Miltiadous2023Dice"
     bibtex: tp.ClassVar[str] = """
     @article{miltiadous2023dice,
         title={{{DICE-Net}}: {{A Novel Convolution-Transformer Architecture}} for {{Alzheimer Detection}} in {{EEG Signals}}},
@@ -153,8 +154,6 @@ class Miltiadous2023DiceSample(Miltiadous2023Dice):
     OpenNeuro dataset: https://openneuro.org/datasets/ds004504/
     Data: 19-channel EEG, 500 Hz, resting-state eyes-closed
     """
-
-    folder_name: tp.ClassVar[str | None] = "Miltiadous2023Dice"
 
     description: tp.ClassVar[str] = (
         "Sample Miltiadous2023Dice: 3 subjects (one per diagnosis group) for rapid testing. "

--- a/neuralfetch-repo/neuralfetch/studies/miltiadous2023dice.py
+++ b/neuralfetch-repo/neuralfetch/studies/miltiadous2023dice.py
@@ -154,6 +154,8 @@ class Miltiadous2023DiceSample(Miltiadous2023Dice):
     Data: 19-channel EEG, 500 Hz, resting-state eyes-closed
     """
 
+    folder_name: tp.ClassVar[str | None] = "Miltiadous2023Dice"
+
     description: tp.ClassVar[str] = (
         "Sample Miltiadous2023Dice: 3 subjects (one per diagnosis group) for rapid testing. "
         "EEG resting-state eyes-closed recordings."

--- a/neuralfetch-repo/neuralfetch/studies/tuh_eeg.py
+++ b/neuralfetch-repo/neuralfetch/studies/tuh_eeg.py
@@ -678,8 +678,6 @@ class HaratiAbhishaike2015Tuev(Harati2015Tuev):
     reused in BIOT, LaBraM, CBraMod, etc.
     """
 
-    folder_name: tp.ClassVar[str | None] = "Harati2015Tuev"
-
     _info: tp.ClassVar[study.StudyInfo] = study.StudyInfo(
         num_timelines=518,
         num_subjects=370,

--- a/neuralfetch-repo/neuralfetch/studies/tuh_eeg.py
+++ b/neuralfetch-repo/neuralfetch/studies/tuh_eeg.py
@@ -45,7 +45,6 @@ import pandas as pd
 from neuralfetch import utils
 from neuralset.events import study
 from neuralset.events.etypes import CategoricalEvent
-from neuralset.events.study import _identify_study_subfolder
 
 logger = logging.getLogger(__name__)
 
@@ -110,6 +109,7 @@ def _fix_ch_name(name: str) -> str:
 
 
 class _BaseTuhEeg(study.Study):
+    folder_name: tp.ClassVar[str | None] = "tuh_eeg"
     aliases: tp.ClassVar[tuple[str, ...]] = ("TUH EEG Corpus", "TUH EEG")
     STUDY_CODE_MAP: tp.ClassVar[dict] = {
         "obeid2016": "tueg",
@@ -678,6 +678,8 @@ class HaratiAbhishaike2015Tuev(Harati2015Tuev):
     reused in BIOT, LaBraM, CBraMod, etc.
     """
 
+    folder_name: tp.ClassVar[str | None] = "Harati2015Tuev"
+
     _info: tp.ClassVar[study.StudyInfo] = study.StudyInfo(
         num_timelines=518,
         num_subjects=370,
@@ -686,12 +688,6 @@ class HaratiAbhishaike2015Tuev(Harati2015Tuev):
         data_shape=(23, 306500),
         frequency=250.0,
     )
-
-    def model_post_init(self, log__: tp.Any) -> None:
-        # hack to use Harati2015Tuev subfolder
-        # pylint: disable=attribute-defined-outside-init
-        self.path = _identify_study_subfolder(self.path, "Harati2015Tuev")
-        super().model_post_init(log__)
 
     # pylint: disable=arguments-differ
     def _load_timeline_events(self, timeline: dict[str, tp.Any]) -> pd.DataFrame:  # type: ignore

--- a/neuralset-repo/neuralset/events/study.py
+++ b/neuralset-repo/neuralset/events/study.py
@@ -262,8 +262,8 @@ class Study(base.Step):
         Root directory for the study data. All studies can use the same
         ``path`` (e.g. ``path="/data"``): each study automatically
         resolves its own subfolder (e.g. ``/data/MyStudy``), so you
-        only need to configure one path for your entire data store. Set
-        :attr:`folder_name` on subclasses that share a parent data folder.
+        only need to configure one path for your entire data store. Parent
+        studies can set :attr:`folder_name` when their children share a data folder.
     infra_timelines : MapInfra
         Caching/compute backend for per-timeline event loading. Uses
         multiprocessing by default (``cluster="processpool"``); set

--- a/neuralset-repo/neuralset/events/study.py
+++ b/neuralset-repo/neuralset/events/study.py
@@ -262,7 +262,8 @@ class Study(base.Step):
         Root directory for the study data. All studies can use the same
         ``path`` (e.g. ``path="/data"``): each study automatically
         resolves its own subfolder (e.g. ``/data/MyStudy``), so you
-        only need to configure one path for your entire data store.
+        only need to configure one path for your entire data store. Set
+        :attr:`folder_name` on subclasses that share a parent data folder.
     infra_timelines : MapInfra
         Caching/compute backend for per-timeline event loading. Uses
         multiprocessing by default (``cluster="processpool"``); set
@@ -308,6 +309,7 @@ class Study(base.Step):
     bibtex: tp.ClassVar[str] = ""
     licence: tp.ClassVar[str] = ""
     description: tp.ClassVar[str] = ""
+    folder_name: tp.ClassVar[str | None] = None
 
     @classmethod
     def catalog(cls) -> dict[str, tp.Type["Study"]]:
@@ -380,8 +382,8 @@ class Study(base.Step):
     @tp.final
     def download(self, **kwargs: tp.Any) -> None:
         self._check_requirements()
-        # Ensure download goes into a subfolder named after the study
-        name = self.__class__.__name__
+        # Ensure download goes into the configured study data folder.
+        name = self._folder_name()
         if self.path.name.lower() != name.lower():
             self.path = self.path / name
             STUDY_PATHS[self.__class__.__name__] = self.path
@@ -428,6 +430,9 @@ class Study(base.Step):
     def _exclude_from_cls_uid(cls) -> list[str]:
         return super()._exclude_from_cls_uid() + ["path"]
 
+    def _folder_name(self) -> str:
+        return self.folder_name or self.__class__.__name__
+
     def model_post_init(self, log__: tp.Any) -> None:
         super().model_post_init(log__)
         if type(self) is Study:
@@ -435,7 +440,7 @@ class Study(base.Step):
                 "Study cannot be instantiated directly — use a subclass, "
                 "or pass name= to dispatch: Study(name='MyStudy2024', path=...)"
             )
-        name = self.__class__.__name__
+        name = self._folder_name()
         self.path = _identify_study_subfolder(self.path, name)
         STUDY_PATHS[self.__class__.__name__] = self.path  # record for path lookup
         # Auto-propagate cache folder and mode so users only need to set it once

--- a/neuralset-repo/neuralset/events/test_study.py
+++ b/neuralset-repo/neuralset/events/test_study.py
@@ -131,37 +131,6 @@ def test_download_appends_study_name(tmp_path: Path, with_name: bool) -> None:
     assert (study.path / "data.txt").is_file()
 
 
-def test_folder_name_overrides_study_subfolder(tmp_path: Path) -> None:
-    class FolderNameProbe9999(FakeData2025):
-        folder_name: tp.ClassVar[str | None] = "SharedFolderProbe9999"
-
-    root = tmp_path / "studies"
-    expected = root / "SharedFolderProbe9999"
-    expected.mkdir(parents=True)
-    try:
-        study = FolderNameProbe9999(path=root)
-        assert study.path == expected
-        assert base.STUDY_PATHS["FolderNameProbe9999"] == expected
-    finally:
-        base.STUDIES.pop("FolderNameProbe9999", None)
-        base.STUDY_PATHS.pop("FolderNameProbe9999", None)
-
-
-def test_download_uses_folder_name(tmp_path: Path) -> None:
-    class FolderNameDownloadProbe9999(FakeData2025):
-        folder_name: tp.ClassVar[str | None] = "SharedDownloadProbe9999"
-
-    try:
-        study = FolderNameDownloadProbe9999(path=tmp_path)
-        study._download = lambda: (study.path / "data.txt").touch()  # type: ignore
-        study.download()
-        assert study.path == tmp_path / "SharedDownloadProbe9999"
-        assert (study.path / "data.txt").is_file()
-    finally:
-        base.STUDIES.pop("FolderNameDownloadProbe9999", None)
-        base.STUDY_PATHS.pop("FolderNameDownloadProbe9999", None)
-
-
 def test_study_export() -> None:
     study = ns.Study(name="Mne2013Sample", path=ns.CACHE_FOLDER)
     dumped = study.model_dump()

--- a/neuralset-repo/neuralset/events/test_study.py
+++ b/neuralset-repo/neuralset/events/test_study.py
@@ -131,6 +131,37 @@ def test_download_appends_study_name(tmp_path: Path, with_name: bool) -> None:
     assert (study.path / "data.txt").is_file()
 
 
+def test_folder_name_overrides_study_subfolder(tmp_path: Path) -> None:
+    class FolderNameProbe9999(FakeData2025):
+        folder_name: tp.ClassVar[str | None] = "SharedFolderProbe9999"
+
+    root = tmp_path / "studies"
+    expected = root / "SharedFolderProbe9999"
+    expected.mkdir(parents=True)
+    try:
+        study = FolderNameProbe9999(path=root)
+        assert study.path == expected
+        assert base.STUDY_PATHS["FolderNameProbe9999"] == expected
+    finally:
+        base.STUDIES.pop("FolderNameProbe9999", None)
+        base.STUDY_PATHS.pop("FolderNameProbe9999", None)
+
+
+def test_download_uses_folder_name(tmp_path: Path) -> None:
+    class FolderNameDownloadProbe9999(FakeData2025):
+        folder_name: tp.ClassVar[str | None] = "SharedDownloadProbe9999"
+
+    try:
+        study = FolderNameDownloadProbe9999(path=tmp_path)
+        study._download = lambda: (study.path / "data.txt").touch()  # type: ignore
+        study.download()
+        assert study.path == tmp_path / "SharedDownloadProbe9999"
+        assert (study.path / "data.txt").is_file()
+    finally:
+        base.STUDIES.pop("FolderNameDownloadProbe9999", None)
+        base.STUDY_PATHS.pop("FolderNameDownloadProbe9999", None)
+
+
 def test_study_export() -> None:
     study = ns.Study(name="Mne2013Sample", path=ns.CACHE_FOLDER)
     dumped = study.model_dump()


### PR DESCRIPTION
## Issue Addressed

Studies that subclass another study can share data under the parent study folder. Before this change, `Study.model_post_init()` always looked for a subfolder named after `child.__class__.__name__`.
Example: Bel2026Petit has two subclasses Bel2026PetitRead and Bel2026PetitListen, but the data is shared in the same folder, Bel2026Petit.
When instantiating Bel2026PetitRead, Study looks for data in the Bel2026PetitRead instead of Bel2026Petit.
Our solution to this was to manually create a symlink Bel2026PetitRead->Bel2026Petit.

Issues with this symlink approach:
- Requires manual intervention for each new subclass and makes study folder messy
- Shared stimuli between the children will have different paths, which will force cache recomputation

## Summary
- Add a `Study.folder_name` class attribute. When not specified, fallback to class.__name__. 
- This folder name is used both for automatic folder discovery AND for study.download().
- This PR adds the folder_name for known parent classes such Bel2026Petit, TUH etc.
