### PR TITLE
Remove HuggingFace accelerate device mode

### DIFF
--- a/neuralset-repo/neuralset/extractors/__init__.py
+++ b/neuralset-repo/neuralset/extractors/__init__.py
@@ -18,6 +18,7 @@ from .audio import (
 from .base import BaseExtractor as BaseExtractor
 from .base import BaseStatic as BaseStatic
 from .base import EventDetector, EventField, LabelEncoder, Pulse
+from .base import HuggingFaceModelConfig as HuggingFaceModelConfig
 from .image import HOG, LBP, RFFT2D, ColorHistogram, HuggingFaceImage
 from .meta import (
     AggregatedExtractor,

--- a/neuralset-repo/neuralset/extractors/__init__.py
+++ b/neuralset-repo/neuralset/extractors/__init__.py
@@ -18,7 +18,7 @@ from .audio import (
 from .base import BaseExtractor as BaseExtractor
 from .base import BaseStatic as BaseStatic
 from .base import EventDetector, EventField, LabelEncoder, Pulse
-from .base import HuggingFaceModelConfig as HuggingFaceModelConfig
+from .base import HuggingFaceConfig as HuggingFaceConfig
 from .image import HOG, LBP, RFFT2D, ColorHistogram, HuggingFaceImage
 from .meta import (
     AggregatedExtractor,

--- a/neuralset-repo/neuralset/extractors/audio.py
+++ b/neuralset-repo/neuralset/extractors/audio.py
@@ -20,6 +20,7 @@ from torch.nn import functional as F
 from neuralset import base as nsbase
 from neuralset.events import etypes
 
+from . import base as extractor_base
 from .base import BaseExtractor, HuggingFaceMixin
 
 # pylint: disable=import-outside-toplevel
@@ -336,7 +337,9 @@ class HuggingFaceAudio(BaseAudio, HuggingFaceMixin):
         - ``'convolution'`` returns convolutional feature maps.
     """
 
-    model_name: str = "facebook/wav2vec2-large-xlsr-53"
+    model: extractor_base.HuggingFaceModelConfig = extractor_base.HuggingFaceModelConfig(
+        model_name="facebook/wav2vec2-large-xlsr-53"
+    )
     requirements: tp.ClassVar[tuple[str, ...]] = ("transformers>=4.29.2",)
 
     normalized: bool = True
@@ -380,7 +383,7 @@ class HuggingFaceAudio(BaseAudio, HuggingFaceMixin):
         return self._feature_extractor
 
     @property
-    def model(self) -> nn.Module:
+    def hf_model(self) -> nn.Module:
         if not hasattr(self, "_model"):
             self._model = self._get_sound_model(self.model_name)
         return self._model
@@ -393,8 +396,12 @@ class HuggingFaceAudio(BaseAudio, HuggingFaceMixin):
     def _get_sound_model(self, model_name: str) -> torch.nn.Module:
         from transformers import AutoModel
 
-        _model = AutoModel.from_pretrained(model_name)
-        _model.to(self.device)
+        _model = AutoModel.from_pretrained(model_name, **self._hf_model_kwargs())
+        return self._finalize_sound_model(_model)
+
+    def _finalize_sound_model(self, _model: torch.nn.Module) -> torch.nn.Module:
+        if self._should_move_hf_model():
+            _model.to(self.device)
         _model.eval()
         return _model
 
@@ -424,7 +431,10 @@ class HuggingFaceAudio(BaseAudio, HuggingFaceMixin):
     def _process_wav(self, wav: torch.Tensor) -> torch.Tensor:
         features = self._get_features(wav)
         with torch.no_grad():
-            outputs = self.model(features.to(self.device), output_hidden_states=True)
+            model = self.hf_model
+            outputs = model(
+                features.to(self._hf_input_device(model)), output_hidden_states=True
+            )
         if self.layer_type == "transformer":
             out: tp.Any = outputs.get("hidden_states")
         elif self.layer_type == "convolution":
@@ -457,7 +467,9 @@ class Wav2Vec(HuggingFaceAudio):
         ``"facebook/wav2vec2-large-xlsr-53"``.
     """
 
-    model_name: str = "facebook/wav2vec2-large-xlsr-53"
+    model: extractor_base.HuggingFaceModelConfig = extractor_base.HuggingFaceModelConfig(
+        model_name="facebook/wav2vec2-large-xlsr-53"
+    )
 
 
 class Wav2VecBert(HuggingFaceAudio):
@@ -475,15 +487,15 @@ class Wav2VecBert(HuggingFaceAudio):
         The Hugging Face model identifier to load. Defaults to ``"facebook/w2v-bert-2.0"``.
     """
 
-    model_name: str = "facebook/w2v-bert-2.0"
+    model: extractor_base.HuggingFaceModelConfig = extractor_base.HuggingFaceModelConfig(
+        model_name="facebook/w2v-bert-2.0"
+    )
 
     def _get_sound_model(self, model_name: str) -> torch.nn.Module:
         from transformers import Wav2Vec2BertModel
 
-        _model = Wav2Vec2BertModel.from_pretrained(model_name)
-        _model.to(self.device)
-        _model.eval()
-        return _model
+        _model = Wav2Vec2BertModel.from_pretrained(model_name, **self._hf_model_kwargs())
+        return self._finalize_sound_model(_model)
 
 
 class SeamlessM4T(HuggingFaceAudio):
@@ -501,17 +513,17 @@ class SeamlessM4T(HuggingFaceAudio):
         ``"facebook/hf-seamless-m4t-medium"``.
     """
 
-    model_name: str = "facebook/hf-seamless-m4t-medium"
+    model: extractor_base.HuggingFaceModelConfig = extractor_base.HuggingFaceModelConfig(
+        model_name="facebook/hf-seamless-m4t-medium"
+    )
 
     def _get_sound_model(self, model_name: str) -> torch.nn.Module:
         from transformers import SeamlessM4TModel
 
-        _model = SeamlessM4TModel.from_pretrained(model_name).speech_encoder.to(
-            self.device
-        )
-        _model.to(self.device)
-        _model.eval()
-        return _model
+        _model = SeamlessM4TModel.from_pretrained(
+            model_name, **self._hf_model_kwargs()
+        ).speech_encoder
+        return self._finalize_sound_model(_model)
 
 
 class Whisper(HuggingFaceAudio):
@@ -530,14 +542,14 @@ class Whisper(HuggingFaceAudio):
         ``"openai/whisper-large-v3-turbo"``.
     """
 
-    model_name: str = "openai/whisper-large-v3-turbo"
+    model: extractor_base.HuggingFaceModelConfig = extractor_base.HuggingFaceModelConfig(
+        model_name="openai/whisper-large-v3-turbo"
+    )
 
     def _get_sound_model(self, model_name: str) -> torch.nn.Module:
         from transformers import WhisperModel
 
         _model = WhisperModel.from_pretrained(
-            model_name, torch_dtype=torch.float32
+            model_name, **self._hf_model_kwargs(torch_dtype=torch.float32)
         ).encoder
-        _model.to(self.device)
-        _model.eval()
-        return _model
+        return self._finalize_sound_model(_model)

--- a/neuralset-repo/neuralset/extractors/audio.py
+++ b/neuralset-repo/neuralset/extractors/audio.py
@@ -337,7 +337,7 @@ class HuggingFaceAudio(BaseAudio, HuggingFaceMixin):
         - ``'convolution'`` returns convolutional feature maps.
     """
 
-    model: extractor_base.HuggingFaceModelConfig = extractor_base.HuggingFaceModelConfig(
+    hf_config: extractor_base.HuggingFaceConfig = extractor_base.HuggingFaceConfig(
         model_name="facebook/wav2vec2-large-xlsr-53"
     )
     requirements: tp.ClassVar[tuple[str, ...]] = ("transformers>=4.29.2",)
@@ -383,7 +383,7 @@ class HuggingFaceAudio(BaseAudio, HuggingFaceMixin):
         return self._feature_extractor
 
     @property
-    def hf_model(self) -> nn.Module:
+    def model(self) -> nn.Module:
         if not hasattr(self, "_model"):
             self._model = self._get_sound_model(self.model_name)
         return self._model
@@ -431,7 +431,7 @@ class HuggingFaceAudio(BaseAudio, HuggingFaceMixin):
     def _process_wav(self, wav: torch.Tensor) -> torch.Tensor:
         features = self._get_features(wav)
         with torch.no_grad():
-            model = self.hf_model
+            model = self.model
             outputs = model(
                 features.to(self._hf_input_device(model)), output_hidden_states=True
             )
@@ -467,7 +467,7 @@ class Wav2Vec(HuggingFaceAudio):
         ``"facebook/wav2vec2-large-xlsr-53"``.
     """
 
-    model: extractor_base.HuggingFaceModelConfig = extractor_base.HuggingFaceModelConfig(
+    hf_config: extractor_base.HuggingFaceConfig = extractor_base.HuggingFaceConfig(
         model_name="facebook/wav2vec2-large-xlsr-53"
     )
 
@@ -487,7 +487,7 @@ class Wav2VecBert(HuggingFaceAudio):
         The Hugging Face model identifier to load. Defaults to ``"facebook/w2v-bert-2.0"``.
     """
 
-    model: extractor_base.HuggingFaceModelConfig = extractor_base.HuggingFaceModelConfig(
+    hf_config: extractor_base.HuggingFaceConfig = extractor_base.HuggingFaceConfig(
         model_name="facebook/w2v-bert-2.0"
     )
 
@@ -513,7 +513,7 @@ class SeamlessM4T(HuggingFaceAudio):
         ``"facebook/hf-seamless-m4t-medium"``.
     """
 
-    model: extractor_base.HuggingFaceModelConfig = extractor_base.HuggingFaceModelConfig(
+    hf_config: extractor_base.HuggingFaceConfig = extractor_base.HuggingFaceConfig(
         model_name="facebook/hf-seamless-m4t-medium"
     )
 
@@ -542,7 +542,7 @@ class Whisper(HuggingFaceAudio):
         ``"openai/whisper-large-v3-turbo"``.
     """
 
-    model: extractor_base.HuggingFaceModelConfig = extractor_base.HuggingFaceModelConfig(
+    hf_config: extractor_base.HuggingFaceConfig = extractor_base.HuggingFaceConfig(
         model_name="openai/whisper-large-v3-turbo"
     )
 

--- a/neuralset-repo/neuralset/extractors/base.py
+++ b/neuralset-repo/neuralset/extractors/base.py
@@ -438,7 +438,7 @@ def _skip_new_event_types(key, val, prev):
 DEFAULT_CHECK_SKIPS.append(_skip_new_event_types)
 
 
-class HuggingFaceModelConfig(base.BaseModel):
+class HuggingFaceConfig(base.BaseModel):
     """Configuration for loading a HuggingFace model."""
 
     model_config = pydantic.ConfigDict(
@@ -475,7 +475,7 @@ class HuggingFaceMixin(base.BaseModel):
 
     Parameters
     ----------
-    model: HuggingFaceModelConfig
+    hf_config: HuggingFaceConfig
         Name of the model to use.
     device: str
         Device to use for the model:
@@ -507,7 +507,7 @@ class HuggingFaceMixin(base.BaseModel):
         "transformers>=4.29.2",
         "huggingface_hub>=0.27.0",
     )
-    model: HuggingFaceModelConfig
+    hf_config: HuggingFaceConfig
     device: tp.Literal["auto", "cpu", "cuda"] = "auto"
     layers: float | list[float] | tp.Literal["all"] = 2 / 3
     cache_n_layers: int | None = None
@@ -518,7 +518,7 @@ class HuggingFaceMixin(base.BaseModel):
 
     @pydantic.model_validator(mode="before")
     @classmethod
-    def _validate_model_config(cls, value: tp.Any) -> tp.Any:
+    def _validate_hf_config(cls, value: tp.Any) -> tp.Any:
         if not isinstance(value, dict):
             return value
         value = dict(value)
@@ -526,35 +526,35 @@ class HuggingFaceMixin(base.BaseModel):
             cls_name = cls.__name__
             msg = (
                 f"{cls_name}(model_name=...) is no longer supported. "
-                f"Use {cls_name}(model={{'model_name': ...}}) instead. "
+                f"Use {cls_name}(hf_config={{'model_name': ...}}) instead. "
                 "Model loading options such as torch_dtype and device_map also "
-                "belong under the model config."
+                "belong under the HuggingFace config."
             )
             raise ValueError(msg)
-        model_config = value.get("model", None)
-        default_config = cls.model_fields["model"].default
+        hf_config = value.get("hf_config", None)
+        default_config = cls.model_fields["hf_config"].default
         default_name = (
             default_config.model_name
-            if isinstance(default_config, HuggingFaceModelConfig)
+            if isinstance(default_config, HuggingFaceConfig)
             else None
         )
-        if isinstance(model_config, dict):
-            model_config = dict(model_config)
-            if "model_name" not in model_config and default_name is not None:
-                model_config["model_name"] = default_name
-        elif isinstance(model_config, HuggingFaceModelConfig):
-            model_config = model_config.model_dump()
-        if model_config is not None:
-            value["model"] = model_config
+        if isinstance(hf_config, dict):
+            hf_config = dict(hf_config)
+            if "model_name" not in hf_config and default_name is not None:
+                hf_config["model_name"] = default_name
+        elif isinstance(hf_config, HuggingFaceConfig):
+            hf_config = hf_config.model_dump()
+        if hf_config is not None:
+            value["hf_config"] = hf_config
         return value
 
     @property
     def model_name(self) -> str:
-        return self.model.model_name
+        return self.hf_config.model_name
 
     @model_name.setter
     def model_name(self, value: str) -> None:
-        self.model.model_name = value
+        self.hf_config.model_name = value
 
     def model_post_init(self, log__: tp.Any) -> None:
         super().model_post_init(log__)
@@ -573,17 +573,17 @@ class HuggingFaceMixin(base.BaseModel):
 
     def _hf_model_kwargs(self, **defaults: tp.Any) -> dict[str, tp.Any]:
         kwargs = dict(defaults)
-        if self.model.torch_dtype is not None:
-            kwargs["torch_dtype"] = self.model.torch_dtype
-        if self.model.device_map is not None:
-            kwargs["device_map"] = self.model.device_map
+        if self.hf_config.torch_dtype is not None:
+            kwargs["torch_dtype"] = self.hf_config.torch_dtype
+        if self.hf_config.device_map is not None:
+            kwargs["device_map"] = self.hf_config.device_map
         return kwargs
 
     def _should_move_hf_model(self) -> bool:
-        return self.model.device_map is None
+        return self.hf_config.device_map is None
 
     def _hf_input_device(self, model: tp.Any | None = None) -> str | torch.device:
-        if self.model.device_map is not None and model is not None:
+        if self.hf_config.device_map is not None and model is not None:
             device = getattr(model, "device", None)
             if device is not None:
                 return device
@@ -624,13 +624,13 @@ class HuggingFaceMixin(base.BaseModel):
         return ["device"]
 
     def _exclude_from_cache_uid(self) -> list[str]:
-        excluded = ["device", "model.torch_dtype", "model.device_map"]
-        default_config = self.__class__.model_fields["model"].default
+        excluded = ["device", "hf_config.torch_dtype", "hf_config.device_map"]
+        default_config = self.__class__.model_fields["hf_config"].default
         if (
-            isinstance(default_config, HuggingFaceModelConfig)
-            and self.model.model_name == default_config.model_name
+            isinstance(default_config, HuggingFaceConfig)
+            and self.hf_config.model_name == default_config.model_name
         ):
-            excluded.append("model.model_name")
+            excluded.append("hf_config.model_name")
         if self.cache_n_layers is not None:
             excluded.extend(["layers", "layer_aggregation"])
         return excluded

--- a/neuralset-repo/neuralset/extractors/base.py
+++ b/neuralset-repo/neuralset/extractors/base.py
@@ -518,11 +518,19 @@ class HuggingFaceMixin(base.BaseModel):
 
     @pydantic.model_validator(mode="before")
     @classmethod
-    def _migrate_model_name(cls, value: tp.Any) -> tp.Any:
+    def _validate_model_config(cls, value: tp.Any) -> tp.Any:
         if not isinstance(value, dict):
             return value
         value = dict(value)
-        model_name = value.pop("model_name", None)
+        if "model_name" in value:
+            cls_name = cls.__name__
+            msg = (
+                f"{cls_name}(model_name=...) is no longer supported. "
+                f"Use {cls_name}(model={{'model_name': ...}}) instead. "
+                "Model loading options such as torch_dtype and device_map also "
+                "belong under the model config."
+            )
+            raise ValueError(msg)
         model_config = value.get("model", None)
         default_config = cls.model_fields["model"].default
         default_name = (
@@ -536,18 +544,6 @@ class HuggingFaceMixin(base.BaseModel):
                 model_config["model_name"] = default_name
         elif isinstance(model_config, HuggingFaceModelConfig):
             model_config = model_config.model_dump()
-        elif model_config is None and model_name is not None:
-            model_config = {}
-        if model_name is not None:
-            if model_config is None:
-                model_config = {"model_name": model_name}
-            elif isinstance(model_config, dict):
-                previous = model_config.get("model_name")
-                if previous is not None and previous != model_name:
-                    raise ValueError(
-                        "Got conflicting HuggingFace model names in 'model' and 'model_name'"
-                    )
-                model_config["model_name"] = model_name
         if model_config is not None:
             value["model"] = model_config
         return value

--- a/neuralset-repo/neuralset/extractors/base.py
+++ b/neuralset-repo/neuralset/extractors/base.py
@@ -438,6 +438,36 @@ def _skip_new_event_types(key, val, prev):
 DEFAULT_CHECK_SKIPS.append(_skip_new_event_types)
 
 
+class HuggingFaceModelConfig(base.BaseModel):
+    """Configuration for loading a HuggingFace model."""
+
+    model_config = pydantic.ConfigDict(
+        protected_namespaces=(), extra="forbid", arbitrary_types_allowed=True
+    )
+
+    model_name: str
+    torch_dtype: torch.dtype | None = None
+    device_map: str | dict[str, tp.Any] | None = None
+
+    @pydantic.field_validator("torch_dtype", mode="before")
+    @classmethod
+    def _validate_torch_dtype(cls, value: tp.Any) -> torch.dtype | None:
+        if value is None or isinstance(value, torch.dtype):
+            return value
+        if isinstance(value, str):
+            name = value.removeprefix("torch.")
+            dtype = getattr(torch, name, None)
+            if isinstance(dtype, torch.dtype):
+                return dtype
+        raise TypeError(f"Invalid torch dtype: {value!r}")
+
+    @pydantic.field_serializer("torch_dtype")
+    def _serialize_torch_dtype(self, value: torch.dtype | None) -> str | None:
+        if value is None:
+            return None
+        return str(value).removeprefix("torch.")
+
+
 class HuggingFaceMixin(base.BaseModel):
     """Mixin for extractors that use a HuggingFace model.
     These extractors all return a tensor of shape (n_layers, n_tokens, *embedding_shape).
@@ -445,14 +475,13 @@ class HuggingFaceMixin(base.BaseModel):
 
     Parameters
     ----------
-    model_name: str
+    model: HuggingFaceModelConfig
         Name of the model to use.
     device: str
         Device to use for the model:
         - cpu: for cpu computation
         - cuda: for using gpu0
         - auto: to use gpu if available else cpu
-        - accelerate: to use huggingface accelerate (maps to multiple-gpus + use float16)
     layers: float | list[float] | "all"
         Specifies the layers to keep.
         - "all": keep all layers
@@ -478,14 +507,58 @@ class HuggingFaceMixin(base.BaseModel):
         "transformers>=4.29.2",
         "huggingface_hub>=0.27.0",
     )
-    model_name: str
-    device: tp.Literal["auto", "cpu", "cuda", "accelerate"] = "auto"
+    model: HuggingFaceModelConfig
+    device: tp.Literal["auto", "cpu", "cuda"] = "auto"
     layers: float | list[float] | tp.Literal["all"] = 2 / 3
     cache_n_layers: int | None = None
     layer_aggregation: tp.Literal["mean", "sum", "group_mean"] | None = "mean"
     token_aggregation: tp.Literal["first", "last", "mean", "sum", "max"] | None = "mean"
     _REPOS: tp.ClassVar[list[str]] = []
     _skip_repo_check: bool = False  # for simpler hacking (eg: custom dinov2 checkpoints)
+
+    @pydantic.model_validator(mode="before")
+    @classmethod
+    def _migrate_model_name(cls, value: tp.Any) -> tp.Any:
+        if not isinstance(value, dict):
+            return value
+        value = dict(value)
+        model_name = value.pop("model_name", None)
+        model_config = value.get("model", None)
+        default_config = cls.model_fields["model"].default
+        default_name = (
+            default_config.model_name
+            if isinstance(default_config, HuggingFaceModelConfig)
+            else None
+        )
+        if isinstance(model_config, dict):
+            model_config = dict(model_config)
+            if "model_name" not in model_config and default_name is not None:
+                model_config["model_name"] = default_name
+        elif isinstance(model_config, HuggingFaceModelConfig):
+            model_config = model_config.model_dump()
+        elif model_config is None and model_name is not None:
+            model_config = {}
+        if model_name is not None:
+            if model_config is None:
+                model_config = {"model_name": model_name}
+            elif isinstance(model_config, dict):
+                previous = model_config.get("model_name")
+                if previous is not None and previous != model_name:
+                    raise ValueError(
+                        "Got conflicting HuggingFace model names in 'model' and 'model_name'"
+                    )
+                model_config["model_name"] = model_name
+        if model_config is not None:
+            value["model"] = model_config
+        return value
+
+    @property
+    def model_name(self) -> str:
+        return self.model.model_name
+
+    @model_name.setter
+    def model_name(self, value: str) -> None:
+        self.model.model_name = value
 
     def model_post_init(self, log__: tp.Any) -> None:
         super().model_post_init(log__)
@@ -501,6 +574,30 @@ class HuggingFaceMixin(base.BaseModel):
             raise ValueError(msg)
         if not self._skip_repo_check and not self.repo_exists():
             raise ValueError(f"The model {self.model_name} does not exist")
+
+    def _hf_model_kwargs(self, **defaults: tp.Any) -> dict[str, tp.Any]:
+        kwargs = dict(defaults)
+        if self.model.torch_dtype is not None:
+            kwargs["torch_dtype"] = self.model.torch_dtype
+        if self.model.device_map is not None:
+            kwargs["device_map"] = self.model.device_map
+        return kwargs
+
+    def _should_move_hf_model(self) -> bool:
+        return self.model.device_map is None
+
+    def _hf_input_device(self, model: tp.Any | None = None) -> str | torch.device:
+        if self.model.device_map is not None and model is not None:
+            device = getattr(model, "device", None)
+            if device is not None:
+                return device
+            parameters = getattr(model, "parameters", None)
+            if parameters is not None:
+                try:
+                    return next(parameters()).device
+                except StopIteration:
+                    pass
+        return self.device
 
     def repo_exists(self) -> bool:
         fp = Path(__file__).with_name("data") / "huggingface-repos.txt"
@@ -531,7 +628,13 @@ class HuggingFaceMixin(base.BaseModel):
         return ["device"]
 
     def _exclude_from_cache_uid(self) -> list[str]:
-        excluded = ["device"]
+        excluded = ["device", "model.torch_dtype", "model.device_map"]
+        default_config = self.__class__.model_fields["model"].default
+        if (
+            isinstance(default_config, HuggingFaceModelConfig)
+            and self.model.model_name == default_config.model_name
+        ):
+            excluded.append("model.model_name")
         if self.cache_n_layers is not None:
             excluded.extend(["layers", "layer_aggregation"])
         return excluded

--- a/neuralset-repo/neuralset/extractors/image.py
+++ b/neuralset-repo/neuralset/extractors/image.py
@@ -258,7 +258,7 @@ class HuggingFaceImage(BaseImage):
     """
 
     # class attributes
-    model: extractor_base.HuggingFaceModelConfig = extractor_base.HuggingFaceModelConfig(
+    hf_config: extractor_base.HuggingFaceConfig = extractor_base.HuggingFaceConfig(
         model_name="facebook/dinov2-base"
     )
     # extractor attributes
@@ -290,14 +290,14 @@ class HuggingFaceImage(BaseImage):
         super().model_post_init(log__)
 
     @property
-    def hf_model(self) -> nn.Module:
+    def model(self) -> nn.Module:
         if not hasattr(self, "_model") or self._model is None:
             self._model = _HuggingFace(
                 model_name=self.model_name,
                 output_hidden_states=True,
                 pretrained=self.pretrained,
-                torch_dtype=self.model.torch_dtype,
-                device_map=self.model.device_map,
+                torch_dtype=self.hf_config.torch_dtype,
+                device_map=self.hf_config.device_map,
             )
             if self._should_move_hf_model():
                 self._model.to(self.device)
@@ -306,7 +306,7 @@ class HuggingFaceImage(BaseImage):
     def _get_hidden_states(self, images: torch.Tensor) -> list[torch.Tensor]:
         """Extract hidden_states as n_layers n_layers x (batch, tokens,  features)"""
         # this method is overridden in experimental extractors for more hugging face models
-        out = self.hf_model._full_predict(images)  # type: ignore
+        out = self.model._full_predict(images)  # type: ignore
         out = getattr(out, "vision_model_output", out)  # for clip
         states = out.hidden_states
         if states is None:

--- a/neuralset-repo/neuralset/extractors/image.py
+++ b/neuralset-repo/neuralset/extractors/image.py
@@ -18,6 +18,7 @@ from tqdm import tqdm
 from neuralset.events import etypes
 from neuralset.utils import warn_once
 
+from . import base as extractor_base
 from .base import BaseStatic, HuggingFaceMixin
 
 logger = logging.getLogger(__name__)
@@ -61,6 +62,8 @@ class _HuggingFace(nn.Module):
         model_name: str,
         output_hidden_states: bool = False,
         pretrained: bool = True,
+        torch_dtype: torch.dtype | None = None,
+        device_map: str | dict[str, tp.Any] | None = None,
     ) -> None:
         super().__init__()
         Model: tp.Any  # ignore typing as we'll override the imports
@@ -68,11 +71,16 @@ class _HuggingFace(nn.Module):
         from transformers import AutoModel as Model
         from transformers import AutoProcessor as Processor
 
+        model_kwargs: dict[str, tp.Any] = {}
+        if torch_dtype is not None:
+            model_kwargs["torch_dtype"] = torch_dtype
+        if device_map is not None:
+            model_kwargs["device_map"] = device_map
         if model_name == "facebook/dpt-dinov2-base-kitti":
             from transformers import DPTForDepthEstimation as Model
         try:
             self.model = Model.from_pretrained(
-                model_name, output_hidden_states=output_hidden_states
+                model_name, output_hidden_states=output_hidden_states, **model_kwargs
             )
         except ValueError as e:
             # handle specific cases
@@ -85,7 +93,7 @@ class _HuggingFace(nn.Module):
             elif "UperNetConfig" in str(e):
                 from transformers import UperNetForSemanticSegmentation as Model
             self.model = Model.from_pretrained(
-                model_name, output_hidden_states=output_hidden_states
+                model_name, output_hidden_states=output_hidden_states, **model_kwargs
             )
         if not pretrained:
             self.model = Model.from_config(self.model.config)
@@ -250,7 +258,9 @@ class HuggingFaceImage(BaseImage):
     """
 
     # class attributes
-    model_name: str = "facebook/dinov2-base"
+    model: extractor_base.HuggingFaceModelConfig = extractor_base.HuggingFaceModelConfig(
+        model_name="facebook/dinov2-base"
+    )
     # extractor attributes
     pretrained: bool = True
     # for precomputing/caching
@@ -280,20 +290,23 @@ class HuggingFaceImage(BaseImage):
         super().model_post_init(log__)
 
     @property
-    def model(self) -> nn.Module:
+    def hf_model(self) -> nn.Module:
         if not hasattr(self, "_model") or self._model is None:
             self._model = _HuggingFace(
                 model_name=self.model_name,
                 output_hidden_states=True,
                 pretrained=self.pretrained,
+                torch_dtype=self.model.torch_dtype,
+                device_map=self.model.device_map,
             )
-            self._model.to(self.device)
+            if self._should_move_hf_model():
+                self._model.to(self.device)
         return self._model
 
     def _get_hidden_states(self, images: torch.Tensor) -> list[torch.Tensor]:
         """Extract hidden_states as n_layers n_layers x (batch, tokens,  features)"""
         # this method is overridden in experimental extractors for more hugging face models
-        out = self.model._full_predict(images)  # type: ignore
+        out = self.hf_model._full_predict(images)  # type: ignore
         out = getattr(out, "vision_model_output", out)  # for clip
         states = out.hidden_states
         if states is None:

--- a/neuralset-repo/neuralset/extractors/test_audio.py
+++ b/neuralset-repo/neuralset/extractors/test_audio.py
@@ -98,7 +98,9 @@ def test_wav2vec_layers(
     create_wav(fp, fs=44100, duration=10)
     event = etypes.Audio(start=0, timeline="whatever", filepath=fp)
     m = "facebook/wav2vec2-base"
-    feat = audio.HuggingFaceAudio(model={"model_name": m}, layers=layers, device="cpu")
+    feat = audio.HuggingFaceAudio(
+        hf_config={"model_name": m}, layers=layers, device="cpu"
+    )
     out = feat(event, start=8, duration=4)
 
     assert out.shape == (768, 200)
@@ -110,7 +112,7 @@ def test_wav2vec_cache_n_layers(tmp_path: Path) -> None:
     event = etypes.Audio(start=0, timeline="whatever", filepath=fp)
     infra = {"folder": tmp_path / "cache"}
     cfg: dict[str, tp.Any] = dict(frequency=50, device="cpu", infra=infra)
-    cfg["model"] = {"model_name": "facebook/wav2vec2-base"}
+    cfg["hf_config"] = {"model_name": "facebook/wav2vec2-base"}
     layers = [0, 0.1, 0.2]
     feat1 = audio.HuggingFaceAudio(layers=layers, cache_n_layers=11, **cfg)
     layers2 = [0.8, 0.9, 1]

--- a/neuralset-repo/neuralset/extractors/test_audio.py
+++ b/neuralset-repo/neuralset/extractors/test_audio.py
@@ -98,7 +98,7 @@ def test_wav2vec_layers(
     create_wav(fp, fs=44100, duration=10)
     event = etypes.Audio(start=0, timeline="whatever", filepath=fp)
     m = "facebook/wav2vec2-base"
-    feat = audio.HuggingFaceAudio(model_name=m, layers=layers, device="cpu")
+    feat = audio.HuggingFaceAudio(model={"model_name": m}, layers=layers, device="cpu")
     out = feat(event, start=8, duration=4)
 
     assert out.shape == (768, 200)
@@ -110,7 +110,7 @@ def test_wav2vec_cache_n_layers(tmp_path: Path) -> None:
     event = etypes.Audio(start=0, timeline="whatever", filepath=fp)
     infra = {"folder": tmp_path / "cache"}
     cfg: dict[str, tp.Any] = dict(frequency=50, device="cpu", infra=infra)
-    cfg["model_name"] = "facebook/wav2vec2-base"
+    cfg["model"] = {"model_name": "facebook/wav2vec2-base"}
     layers = [0, 0.1, 0.2]
     feat1 = audio.HuggingFaceAudio(layers=layers, cache_n_layers=11, **cfg)
     layers2 = [0.8, 0.9, 1]

--- a/neuralset-repo/neuralset/extractors/test_base.py
+++ b/neuralset-repo/neuralset/extractors/test_base.py
@@ -338,25 +338,27 @@ def test_hf_aggregate_tokens(
 
 
 def test_huggingface_model_exists():
-    base.HuggingFaceMixin(model={"model_name": "gpt2"})
+    base.HuggingFaceMixin(hf_config={"model_name": "gpt2"})
     with pytest.raises(ValueError):
-        base.HuggingFaceMixin(model={"model_name": "not_a_model"})
+        base.HuggingFaceMixin(hf_config={"model_name": "not_a_model"})
 
 
 def test_huggingface_model_config():
     cfg = base.HuggingFaceMixin(
-        model={"model_name": "gpt2", "torch_dtype": "float16", "device_map": "auto"}
+        hf_config={"model_name": "gpt2", "torch_dtype": "float16", "device_map": "auto"}
     )
-    assert cfg.model.model_name == "gpt2"
-    assert cfg.model.torch_dtype is torch.float16
+    assert cfg.hf_config.model_name == "gpt2"
+    assert cfg.hf_config.torch_dtype is torch.float16
     assert cfg._hf_model_kwargs() == {
         "torch_dtype": torch.float16,
         "device_map": "auto",
     }
-    with pytest.raises(pydantic.ValidationError, match=r"Use HuggingFaceMixin\(model="):
+    with pytest.raises(
+        pydantic.ValidationError, match=r"Use HuggingFaceMixin\(hf_config="
+    ):
         base.HuggingFaceMixin(model_name="gpt2")
     with pytest.raises(pydantic.ValidationError):
-        base.HuggingFaceMixin(model={"model_name": "gpt2"}, device="accelerate")
+        base.HuggingFaceMixin(hf_config={"model_name": "gpt2"}, device="accelerate")
 
 
 @pytest.mark.parametrize(

--- a/neuralset-repo/neuralset/extractors/test_base.py
+++ b/neuralset-repo/neuralset/extractors/test_base.py
@@ -338,9 +338,9 @@ def test_hf_aggregate_tokens(
 
 
 def test_huggingface_model_exists():
-    base.HuggingFaceMixin(model_name="gpt2")
+    base.HuggingFaceMixin(model={"model_name": "gpt2"})
     with pytest.raises(ValueError):
-        base.HuggingFaceMixin(model_name="not_a_model")
+        base.HuggingFaceMixin(model={"model_name": "not_a_model"})
 
 
 def test_huggingface_model_config():
@@ -353,8 +353,10 @@ def test_huggingface_model_config():
         "torch_dtype": torch.float16,
         "device_map": "auto",
     }
+    with pytest.raises(pydantic.ValidationError, match=r"Use HuggingFaceMixin\(model="):
+        base.HuggingFaceMixin(model_name="gpt2")
     with pytest.raises(pydantic.ValidationError):
-        base.HuggingFaceMixin(model_name="gpt2", device="accelerate")
+        base.HuggingFaceMixin(model={"model_name": "gpt2"}, device="accelerate")
 
 
 @pytest.mark.parametrize(

--- a/neuralset-repo/neuralset/extractors/test_base.py
+++ b/neuralset-repo/neuralset/extractors/test_base.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import exca
 import numpy as np
 import pandas as pd
+import pydantic
 import pytest
 import torch
 from sklearn.preprocessing import OneHotEncoder, OrdinalEncoder
@@ -340,6 +341,20 @@ def test_huggingface_model_exists():
     base.HuggingFaceMixin(model_name="gpt2")
     with pytest.raises(ValueError):
         base.HuggingFaceMixin(model_name="not_a_model")
+
+
+def test_huggingface_model_config():
+    cfg = base.HuggingFaceMixin(
+        model={"model_name": "gpt2", "torch_dtype": "float16", "device_map": "auto"}
+    )
+    assert cfg.model.model_name == "gpt2"
+    assert cfg.model.torch_dtype is torch.float16
+    assert cfg._hf_model_kwargs() == {
+        "torch_dtype": torch.float16,
+        "device_map": "auto",
+    }
+    with pytest.raises(pydantic.ValidationError):
+        base.HuggingFaceMixin(model_name="gpt2", device="accelerate")
 
 
 @pytest.mark.parametrize(

--- a/neuralset-repo/neuralset/extractors/test_image.py
+++ b/neuralset-repo/neuralset/extractors/test_image.py
@@ -64,7 +64,7 @@ def test_image(tmp_path: Path) -> None:
     expected = {
         "allow_missing",
         "name",
-        "model_name",
+        "model",
         "event_types",
         "token_aggregation",
         "layer_aggregation",
@@ -79,7 +79,6 @@ def test_image(tmp_path: Path) -> None:
     assert extractor_keys == expected
     expected = {
         "name",
-        "model_name",
         "imsize",
         "infra",
         "event_types",
@@ -96,6 +95,29 @@ def test_image_infra_override(tmp_path: Path) -> None:
     infra: tp.Any = {"folder": tmp_path, "cluster": "local"}
     extractor = ns.extractors.HuggingFaceImage(infra=infra)
     assert extractor.infra.gpus_per_node == 1
+
+
+def test_image_model_load_options_excluded_from_cache_uid(tmp_path: Path) -> None:
+    infra: tp.Any = {"folder": tmp_path}
+    base_extractor = ns.extractors.HuggingFaceImage(infra=infra, device="cpu")
+    dispatched = ns.extractors.HuggingFaceImage(
+        infra=infra,
+        device="cpu",
+        model={"torch_dtype": torch.float16, "device_map": "auto"},
+    )
+    assert base_extractor.infra.uid() == dispatched.infra.uid()
+    assert base_extractor.infra.uid_folder() == dispatched.infra.uid_folder()
+    assert "model" not in dispatched.infra.config()
+
+    other_model = ns.extractors.HuggingFaceImage(
+        infra=infra,
+        device="cpu",
+        model_name="facebook/dinov2-small-imagenet1k-1-layer",
+    )
+    assert other_model.infra.uid() != base_extractor.infra.uid()
+    assert other_model.infra.config()["model"] == {
+        "model_name": "facebook/dinov2-small-imagenet1k-1-layer"
+    }
 
 
 def make_cat_event(folder: str | Path) -> etypes.Image:
@@ -166,7 +188,7 @@ def test_openai_clip(
         token_aggregation=token_aggregation,
     )
     record = RecordedOutputs.as_mocked_method(
-        extractor.model._full_predict, text=["a photo of a cat", "a photo of a dog"]
+        extractor.hf_model._full_predict, text=["a photo of a cat", "a photo of a dog"]
     )
     latent = next(iter(extractor._get_data([cat_event])))
     if token_aggregation is None:
@@ -196,7 +218,7 @@ def test_openai_clip_layer(
         cache_n_layers=cache_n_layers,
     )
     record = RecordedOutputs.as_mocked_method(
-        extractor.model._full_predict, text=["a photo of a cat", "a photo of a dog"]
+        extractor.hf_model._full_predict, text=["a photo of a cat", "a photo of a dog"]
     )
     latent = next(iter(extractor._get_data([cat_event])))
     expected_shape = {
@@ -245,10 +267,10 @@ def test_hf_dinov2(cat_event: etypes.Image) -> None:
     )
     from transformers import AutoModelForImageClassification
 
-    extractor.model.model = AutoModelForImageClassification.from_pretrained(
+    extractor.hf_model.model = AutoModelForImageClassification.from_pretrained(
         extractor.model_name
     )
-    record = RecordedOutputs.as_mocked_method(extractor.model._full_predict)
+    record = RecordedOutputs.as_mocked_method(extractor.hf_model._full_predict)
     try:
         extractor._get_data([cat_event])
     except:  # not the right output layer as we overrode the model
@@ -256,7 +278,7 @@ def test_hf_dinov2(cat_event: etypes.Image) -> None:
     assert len(record.outputs) == 1
     pred = record.outputs[0]
     idx = pred.logits.argmax(-1).item()
-    assert extractor.model.model.config.id2label[idx] == "tabby, tabby cat"  # type: ignore
+    assert extractor.hf_model.model.config.id2label[idx] == "tabby, tabby cat"  # type: ignore
 
 
 @pytest.mark.parametrize("imsize", [None, 512])

--- a/neuralset-repo/neuralset/extractors/test_image.py
+++ b/neuralset-repo/neuralset/extractors/test_image.py
@@ -64,7 +64,7 @@ def test_image(tmp_path: Path) -> None:
     expected = {
         "allow_missing",
         "name",
-        "model",
+        "hf_config",
         "event_types",
         "token_aggregation",
         "layer_aggregation",
@@ -103,19 +103,19 @@ def test_image_model_load_options_excluded_from_cache_uid(tmp_path: Path) -> Non
     dispatched = ns.extractors.HuggingFaceImage(
         infra=infra,
         device="cpu",
-        model={"torch_dtype": torch.float16, "device_map": "auto"},
+        hf_config={"torch_dtype": torch.float16, "device_map": "auto"},
     )
     assert base_extractor.infra.uid() == dispatched.infra.uid()
     assert base_extractor.infra.uid_folder() == dispatched.infra.uid_folder()
-    assert "model" not in dispatched.infra.config()
+    assert "hf_config" not in dispatched.infra.config()
 
     other_model = ns.extractors.HuggingFaceImage(
         infra=infra,
         device="cpu",
-        model={"model_name": "facebook/dinov2-small-imagenet1k-1-layer"},
+        hf_config={"model_name": "facebook/dinov2-small-imagenet1k-1-layer"},
     )
     assert other_model.infra.uid() != base_extractor.infra.uid()
-    assert other_model.infra.config()["model"] == {
+    assert other_model.infra.config()["hf_config"] == {
         "model_name": "facebook/dinov2-small-imagenet1k-1-layer"
     }
 
@@ -184,11 +184,11 @@ def test_openai_clip(
 ) -> None:
     extractor = ns.extractors.HuggingFaceImage(
         device="cpu",
-        model={"model_name": "openai/clip-vit-base-patch32"},
+        hf_config={"model_name": "openai/clip-vit-base-patch32"},
         token_aggregation=token_aggregation,
     )
     record = RecordedOutputs.as_mocked_method(
-        extractor.hf_model._full_predict, text=["a photo of a cat", "a photo of a dog"]
+        extractor.model._full_predict, text=["a photo of a cat", "a photo of a dog"]
     )
     latent = next(iter(extractor._get_data([cat_event])))
     if token_aggregation is None:
@@ -212,13 +212,13 @@ def test_openai_clip_layer(
 ) -> None:
     extractor = ns.extractors.HuggingFaceImage(
         device="cpu",
-        model={"model_name": "openai/clip-vit-base-patch32"},
+        hf_config={"model_name": "openai/clip-vit-base-patch32"},
         pretrained=pretrained,
         token_aggregation=token_aggregation,
         cache_n_layers=cache_n_layers,
     )
     record = RecordedOutputs.as_mocked_method(
-        extractor.hf_model._full_predict, text=["a photo of a cat", "a photo of a dog"]
+        extractor.model._full_predict, text=["a photo of a cat", "a photo of a dog"]
     )
     latent = next(iter(extractor._get_data([cat_event])))
     expected_shape = {
@@ -248,7 +248,7 @@ def test_openai_clip_layer(
 def test_hf_dinov2(cat_event: etypes.Image) -> None:
     extractor = ns.extractors.HuggingFaceImage(
         device="cpu",
-        model={"model_name": "facebook/dinov2-small-imagenet1k-1-layer"},
+        hf_config={"model_name": "facebook/dinov2-small-imagenet1k-1-layer"},
         token_aggregation=None,
     )
     latent = next(iter(extractor._get_data([cat_event])))
@@ -263,14 +263,14 @@ def test_hf_dinov2(cat_event: etypes.Image) -> None:
     # now check labels are correct with the appropriate classif model (hacky)
     extractor = ns.extractors.HuggingFaceImage(  # new cache
         device="cpu",
-        model={"model_name": "facebook/dinov2-small-imagenet1k-1-layer"},
+        hf_config={"model_name": "facebook/dinov2-small-imagenet1k-1-layer"},
     )
     from transformers import AutoModelForImageClassification
 
-    extractor.hf_model.model = AutoModelForImageClassification.from_pretrained(
+    extractor.model.model = AutoModelForImageClassification.from_pretrained(
         extractor.model_name
     )
-    record = RecordedOutputs.as_mocked_method(extractor.hf_model._full_predict)
+    record = RecordedOutputs.as_mocked_method(extractor.model._full_predict)
     try:
         extractor._get_data([cat_event])
     except:  # not the right output layer as we overrode the model
@@ -278,7 +278,7 @@ def test_hf_dinov2(cat_event: etypes.Image) -> None:
     assert len(record.outputs) == 1
     pred = record.outputs[0]
     idx = pred.logits.argmax(-1).item()
-    assert extractor.hf_model.model.config.id2label[idx] == "tabby, tabby cat"  # type: ignore
+    assert extractor.model.model.config.id2label[idx] == "tabby, tabby cat"  # type: ignore
 
 
 @pytest.mark.parametrize("imsize", [None, 512])

--- a/neuralset-repo/neuralset/extractors/test_image.py
+++ b/neuralset-repo/neuralset/extractors/test_image.py
@@ -112,7 +112,7 @@ def test_image_model_load_options_excluded_from_cache_uid(tmp_path: Path) -> Non
     other_model = ns.extractors.HuggingFaceImage(
         infra=infra,
         device="cpu",
-        model_name="facebook/dinov2-small-imagenet1k-1-layer",
+        model={"model_name": "facebook/dinov2-small-imagenet1k-1-layer"},
     )
     assert other_model.infra.uid() != base_extractor.infra.uid()
     assert other_model.infra.config()["model"] == {
@@ -184,7 +184,7 @@ def test_openai_clip(
 ) -> None:
     extractor = ns.extractors.HuggingFaceImage(
         device="cpu",
-        model_name="openai/clip-vit-base-patch32",
+        model={"model_name": "openai/clip-vit-base-patch32"},
         token_aggregation=token_aggregation,
     )
     record = RecordedOutputs.as_mocked_method(
@@ -212,7 +212,7 @@ def test_openai_clip_layer(
 ) -> None:
     extractor = ns.extractors.HuggingFaceImage(
         device="cpu",
-        model_name="openai/clip-vit-base-patch32",
+        model={"model_name": "openai/clip-vit-base-patch32"},
         pretrained=pretrained,
         token_aggregation=token_aggregation,
         cache_n_layers=cache_n_layers,
@@ -248,7 +248,7 @@ def test_openai_clip_layer(
 def test_hf_dinov2(cat_event: etypes.Image) -> None:
     extractor = ns.extractors.HuggingFaceImage(
         device="cpu",
-        model_name="facebook/dinov2-small-imagenet1k-1-layer",
+        model={"model_name": "facebook/dinov2-small-imagenet1k-1-layer"},
         token_aggregation=None,
     )
     latent = next(iter(extractor._get_data([cat_event])))
@@ -263,7 +263,7 @@ def test_hf_dinov2(cat_event: etypes.Image) -> None:
     # now check labels are correct with the appropriate classif model (hacky)
     extractor = ns.extractors.HuggingFaceImage(  # new cache
         device="cpu",
-        model_name="facebook/dinov2-small-imagenet1k-1-layer",
+        model={"model_name": "facebook/dinov2-small-imagenet1k-1-layer"},
     )
     from transformers import AutoModelForImageClassification
 

--- a/neuralset-repo/neuralset/extractors/test_text.py
+++ b/neuralset-repo/neuralset/extractors/test_text.py
@@ -111,7 +111,7 @@ def test_llm(
         aggregation="sum",
         layers=layer,
         contextualized=contextualized,
-        model={"model_name": model_name},
+        hf_config={"model_name": model_name},
         cache_n_layers=cache_n_layers,
     )
     if hasattr(extractor, "model_name"):
@@ -129,7 +129,7 @@ def test_layer_aggregation(
 ):
     events = _make_test_events()
     extractor = text.HuggingFaceText(
-        model={"model_name": "gpt2"},
+        hf_config={"model_name": "gpt2"},
         layer_aggregation=layer_aggregation,
         layers=[0, 0.5, 1],
         aggregation="sum",
@@ -206,7 +206,7 @@ def test_llm_explicit_error() -> None:
         aggregation="sum",
         layers=1,
         contextualized=True,
-        model={"model_name": "openai-community/gpt2"},
+        hf_config={"model_name": "openai-community/gpt2"},
     )
     word = etypes.Word(text="word", start=0, duration=1, timeline="x")
     with pytest.raises(ValueError):
@@ -219,7 +219,7 @@ def test_dynamic_text() -> None:
         aggregation="sum",
         layers=1,
         contextualized=False,
-        model={"model_name": "openai-community/gpt2"},
+        hf_config={"model_name": "openai-community/gpt2"},
     )
     word = etypes.Word(text="word", start=1, duration=1, timeline="x")
     out = extractor(word, start=0, duration=3).cpu().numpy()
@@ -241,7 +241,7 @@ def test_llm_long_context() -> None:
     extractor = text.HuggingFaceText(
         aggregation="sum",
         contextualized=True,
-        model={"model_name": "openai-community/gpt2"},
+        hf_config={"model_name": "openai-community/gpt2"},
         device="cpu",
     )
     word = _make_word()
@@ -252,7 +252,7 @@ def test_llm_long_context() -> None:
 
 def test_max_length_real_limit() -> None:
     extractor = text.HuggingFaceText(
-        model={"model_name": "openai-community/gpt2"}, device="cpu"
+        hf_config={"model_name": "openai-community/gpt2"}, device="cpu"
     )
     assert extractor.tokenizer.model_max_length == 1024
     assert extractor._get_max_length() == 1024
@@ -267,13 +267,13 @@ def test_max_length_sentinel_fallback() -> None:
     word.context = " ".join(str(k) for k in range(4000))  # >2050 tokens
     try:
         extractor = text.HuggingFaceText(
-            model={"model_name": "facebook/opt-125m"},
+            hf_config={"model_name": "facebook/opt-125m"},
             contextualized=True,
             device="cpu",
         )
         tokenizer = extractor.tokenizer
         assert tokenizer.model_max_length >= int(1e29)  # sentinel, not a real limit
-        config: tp.Any = extractor.hf_model.config  # type: ignore[union-attr]
+        config: tp.Any = extractor.model.config  # type: ignore[union-attr]
         assert extractor._get_max_length() == config.max_position_embeddings
         _ = extractor(word, 0, 1)
     except (OSError, RuntimeError, pydantic.ValidationError):
@@ -287,7 +287,7 @@ def test_bart() -> None:
     extractor = text.HuggingFaceText(
         aggregation="sum",
         contextualized=True,
-        model={"model_name": "facebook/bart-base"},
+        hf_config={"model_name": "facebook/bart-base"},
         device="cpu",
     )
     word = _make_word()
@@ -328,7 +328,7 @@ def test_contextualized_token_slicing(word_text: str, n_target_tokens: int) -> N
         aggregation="sum",
         contextualized=True,
         token_aggregation=None,
-        model={"model_name": "openai-community/gpt2"},
+        hf_config={"model_name": "openai-community/gpt2"},
         device="cpu",
     )
     encode: tp.Any = extractor.tokenizer.encode
@@ -346,7 +346,7 @@ def test_batched_target_slice_excludes_pads() -> None:
         aggregation="sum",
         contextualized=True,
         token_aggregation="sum",
-        model={"model_name": "openai-community/gpt2"},
+        hf_config={"model_name": "openai-community/gpt2"},
         device="cpu",
         batch_size=2,
     )

--- a/neuralset-repo/neuralset/extractors/test_text.py
+++ b/neuralset-repo/neuralset/extractors/test_text.py
@@ -111,7 +111,7 @@ def test_llm(
         aggregation="sum",
         layers=layer,
         contextualized=contextualized,
-        model_name=model_name,
+        model={"model_name": model_name},
         cache_n_layers=cache_n_layers,
     )
     if hasattr(extractor, "model_name"):
@@ -129,7 +129,7 @@ def test_layer_aggregation(
 ):
     events = _make_test_events()
     extractor = text.HuggingFaceText(
-        model_name="gpt2",
+        model={"model_name": "gpt2"},
         layer_aggregation=layer_aggregation,
         layers=[0, 0.5, 1],
         aggregation="sum",
@@ -206,7 +206,7 @@ def test_llm_explicit_error() -> None:
         aggregation="sum",
         layers=1,
         contextualized=True,
-        model_name="openai-community/gpt2",
+        model={"model_name": "openai-community/gpt2"},
     )
     word = etypes.Word(text="word", start=0, duration=1, timeline="x")
     with pytest.raises(ValueError):
@@ -219,7 +219,7 @@ def test_dynamic_text() -> None:
         aggregation="sum",
         layers=1,
         contextualized=False,
-        model_name="openai-community/gpt2",
+        model={"model_name": "openai-community/gpt2"},
     )
     word = etypes.Word(text="word", start=1, duration=1, timeline="x")
     out = extractor(word, start=0, duration=3).cpu().numpy()
@@ -241,7 +241,7 @@ def test_llm_long_context() -> None:
     extractor = text.HuggingFaceText(
         aggregation="sum",
         contextualized=True,
-        model_name="openai-community/gpt2",
+        model={"model_name": "openai-community/gpt2"},
         device="cpu",
     )
     word = _make_word()
@@ -251,7 +251,9 @@ def test_llm_long_context() -> None:
 
 
 def test_max_length_real_limit() -> None:
-    extractor = text.HuggingFaceText(model_name="openai-community/gpt2", device="cpu")
+    extractor = text.HuggingFaceText(
+        model={"model_name": "openai-community/gpt2"}, device="cpu"
+    )
     assert extractor.tokenizer.model_max_length == 1024
     assert extractor._get_max_length() == 1024
 
@@ -265,7 +267,7 @@ def test_max_length_sentinel_fallback() -> None:
     word.context = " ".join(str(k) for k in range(4000))  # >2050 tokens
     try:
         extractor = text.HuggingFaceText(
-            model_name="facebook/opt-125m",
+            model={"model_name": "facebook/opt-125m"},
             contextualized=True,
             device="cpu",
         )
@@ -285,7 +287,7 @@ def test_bart() -> None:
     extractor = text.HuggingFaceText(
         aggregation="sum",
         contextualized=True,
-        model_name="facebook/bart-base",
+        model={"model_name": "facebook/bart-base"},
         device="cpu",
     )
     word = _make_word()
@@ -326,7 +328,7 @@ def test_contextualized_token_slicing(word_text: str, n_target_tokens: int) -> N
         aggregation="sum",
         contextualized=True,
         token_aggregation=None,
-        model_name="openai-community/gpt2",
+        model={"model_name": "openai-community/gpt2"},
         device="cpu",
     )
     encode: tp.Any = extractor.tokenizer.encode
@@ -344,7 +346,7 @@ def test_batched_target_slice_excludes_pads() -> None:
         aggregation="sum",
         contextualized=True,
         token_aggregation="sum",
-        model_name="openai-community/gpt2",
+        model={"model_name": "openai-community/gpt2"},
         device="cpu",
         batch_size=2,
     )

--- a/neuralset-repo/neuralset/extractors/test_text.py
+++ b/neuralset-repo/neuralset/extractors/test_text.py
@@ -271,7 +271,7 @@ def test_max_length_sentinel_fallback() -> None:
         )
         tokenizer = extractor.tokenizer
         assert tokenizer.model_max_length >= int(1e29)  # sentinel, not a real limit
-        config: tp.Any = extractor.model.config  # type: ignore[union-attr]
+        config: tp.Any = extractor.hf_model.config  # type: ignore[union-attr]
         assert extractor._get_max_length() == config.max_position_embeddings
         _ = extractor(word, 0, 1)
     except (OSError, RuntimeError, pydantic.ValidationError):

--- a/neuralset-repo/neuralset/extractors/test_video.py
+++ b/neuralset-repo/neuralset/extractors/test_video.py
@@ -124,7 +124,11 @@ def test_video(video_event: etypes.Video, tmp_path: Path) -> None:
 def test_video_image_latent(video_event: etypes.Video, tmp_path: Path) -> None:
     cache = tmp_path / "cache"
     name = "facebook/dinov2-small-imagenet1k-1-layer"
-    im: tp.Any = {"device": "cpu", "model_name": name, "infra": {"keep_in_ram": False}}
+    im: tp.Any = {
+        "device": "cpu",
+        "model": {"model_name": name},
+        "infra": {"keep_in_ram": False},
+    }
     infra: tp.Any = {"folder": cache}
     video = ns.extractors.HuggingFaceVideo(
         frequency=0.5,
@@ -172,7 +176,7 @@ def test_video_models(
     imparams: tp.Any = {
         "device": "cpu",
         "name": "HuggingFaceImage",
-        "model_name": name,
+        "model": {"model_name": name},
         "infra": {"keep_in_ram": False},
         # show the full dimension
         "token_aggregation": None,

--- a/neuralset-repo/neuralset/extractors/test_video.py
+++ b/neuralset-repo/neuralset/extractors/test_video.py
@@ -126,7 +126,7 @@ def test_video_image_latent(video_event: etypes.Video, tmp_path: Path) -> None:
     name = "facebook/dinov2-small-imagenet1k-1-layer"
     im: tp.Any = {
         "device": "cpu",
-        "model": {"model_name": name},
+        "hf_config": {"model_name": name},
         "infra": {"keep_in_ram": False},
     }
     infra: tp.Any = {"folder": cache}
@@ -176,7 +176,7 @@ def test_video_models(
     imparams: tp.Any = {
         "device": "cpu",
         "name": "HuggingFaceImage",
-        "model": {"model_name": name},
+        "hf_config": {"model_name": name},
         "infra": {"keep_in_ram": False},
         # show the full dimension
         "token_aggregation": None,

--- a/neuralset-repo/neuralset/extractors/test_video.py
+++ b/neuralset-repo/neuralset/extractors/test_video.py
@@ -6,6 +6,8 @@
 
 import logging
 import os
+import sys
+import types
 import typing as tp
 from pathlib import Path
 
@@ -195,6 +197,52 @@ def test_video_huggingface() -> None:
     data = np.random.rand(hf.model.config.num_frames, 3, 64, 64)
     out = hf.predict_hidden_states(data)
     assert out.shape == (1, 13, 1568, 768)
+
+
+def test_video_model_load_options_forwarded(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorded: dict[str, tp.Any] = {}
+    transformers = types.ModuleType("transformers")
+
+    class FakeModel:
+        config = types.SimpleNamespace(num_frames=16)
+        device = torch.device("cpu")
+
+        @classmethod
+        def from_pretrained(
+            cls, model_name: str, output_hidden_states: bool, **kwargs: tp.Any
+        ) -> "FakeModel":
+            recorded["model_name"] = model_name
+            recorded["output_hidden_states"] = output_hidden_states
+            recorded["model_kwargs"] = kwargs
+            return cls()
+
+        def eval(self) -> None:
+            return None
+
+    class FakeProcessor:
+        @classmethod
+        def from_pretrained(cls, model_name: str, **kwargs: tp.Any) -> "FakeProcessor":
+            recorded["processor_name"] = model_name
+            recorded["processor_kwargs"] = kwargs
+            return cls()
+
+    transformers.AutoModel = FakeModel
+    transformers.AutoProcessor = FakeProcessor
+    monkeypatch.setitem(sys.modules, "transformers", transformers)
+
+    _HFVideoModel(
+        model_name="MCG-NJU/videomae-base",
+        torch_dtype=torch.float16,
+        device_map="auto",
+    )
+
+    assert recorded["model_name"] == "MCG-NJU/videomae-base"
+    assert recorded["output_hidden_states"] is True
+    assert recorded["model_kwargs"] == {
+        "torch_dtype": torch.float16,
+        "device_map": "auto",
+    }
+    assert recorded["processor_kwargs"] == {"do_rescale": True}
 
 
 # for future TEXT + VIDEO models?

--- a/neuralset-repo/neuralset/extractors/text.py
+++ b/neuralset-repo/neuralset/extractors/text.py
@@ -272,7 +272,7 @@ class HuggingFaceText(BaseStatic, HuggingFaceMixin):
     To get non-contextualized embeddings, set contextualized to False.
     """
 
-    model: extractor_base.HuggingFaceModelConfig = extractor_base.HuggingFaceModelConfig(
+    hf_config: extractor_base.HuggingFaceConfig = extractor_base.HuggingFaceConfig(
         model_name="openai-community/gpt2"
     )
 
@@ -320,7 +320,7 @@ class HuggingFaceText(BaseStatic, HuggingFaceMixin):
         )
 
     @property
-    def hf_model(self) -> nn.Module:
+    def model(self) -> nn.Module:
         if not hasattr(self, "_model"):
             from transformers import AutoTokenizer
 
@@ -385,7 +385,7 @@ class HuggingFaceText(BaseStatic, HuggingFaceMixin):
 
     @property
     def tokenizer(self) -> tp.Any:
-        self.hf_model
+        self.model
         return self._tokenizer
 
     def _get_max_length(self) -> int | None:
@@ -398,7 +398,7 @@ class HuggingFaceText(BaseStatic, HuggingFaceMixin):
             self._max_length = tok_max
             return self._max_length
         # learned-position table is sized capacity + offset, so the offset cancels
-        config = self.hf_model.config
+        config = self.model.config
         for attr in ("max_position_embeddings", "n_positions", "n_ctx"):
             value = getattr(config, attr, None)
             if isinstance(value, int) and value > 0:
@@ -445,7 +445,7 @@ class HuggingFaceText(BaseStatic, HuggingFaceMixin):
         # Processing the data in batches
         if len(dloader) > 1:
             dloader = tqdm(dloader, desc="Computing word embeddings")  # type: ignore
-        device = self._hf_input_device(self.hf_model)
+        device = self._hf_input_device(self.model)
         with torch.no_grad():
             for target_words, context in dloader:
                 # tokenize context
@@ -466,7 +466,7 @@ class HuggingFaceText(BaseStatic, HuggingFaceMixin):
                         truncation=True,  # beware to have set truncation_side="left" in init
                         max_length=self._get_max_length(),  # guard tokenizers reporting no real limit (e.g. OPT)
                     ).to(device)
-                outputs = self.hf_model(**inputs, output_hidden_states=True)
+                outputs = self.model(**inputs, output_hidden_states=True)
                 if "hidden_states" in outputs:
                     states = outputs.hidden_states
                 else:  # bart (encoder/decoder)
@@ -513,7 +513,7 @@ class HuggingFaceText(BaseStatic, HuggingFaceMixin):
                     yield out
                 # erase variables / free memory
                 del hidden_states, hidden_state, word_state, states, outputs, inputs
-                if self.model.device_map is not None and torch.cuda.is_available():
+                if self.hf_config.device_map is not None and torch.cuda.is_available():
                     # in case of multi-GPU models, explicitly empty cache "just in case"
                     torch.cuda.empty_cache()
 

--- a/neuralset-repo/neuralset/extractors/text.py
+++ b/neuralset-repo/neuralset/extractors/text.py
@@ -24,6 +24,8 @@ from neuralset import utils
 from neuralset.base import TimedArray
 from neuralset.extractors.base import BaseStatic, HuggingFaceMixin
 
+from . import base as extractor_base
+
 # pylint: disable=attribute-defined-outside-init
 # pylint: disable=unused-variable
 DataframeOrEventsOrSegments = (
@@ -270,7 +272,9 @@ class HuggingFaceText(BaseStatic, HuggingFaceMixin):
     To get non-contextualized embeddings, set contextualized to False.
     """
 
-    model_name: str = "openai-community/gpt2"
+    model: extractor_base.HuggingFaceModelConfig = extractor_base.HuggingFaceModelConfig(
+        model_name="openai-community/gpt2"
+    )
 
     # class attributes
     event_types: tp.Literal["Word", "Sentence"] = "Word"
@@ -316,7 +320,7 @@ class HuggingFaceText(BaseStatic, HuggingFaceMixin):
         )
 
     @property
-    def model(self) -> nn.Module:
+    def hf_model(self) -> nn.Module:
         if not hasattr(self, "_model"):
             from transformers import AutoTokenizer
 
@@ -361,8 +365,7 @@ class HuggingFaceText(BaseStatic, HuggingFaceMixin):
         elif "Llama-3.2-11B-Vision" in self.model_name:
             from transformers import MllamaForConditionalGeneration as Model
         # instantiate
-        if self.device == "accelerate":
-            kwargs = {"device_map": "auto", "torch_dtype": torch.float16}
+        kwargs = self._hf_model_kwargs(**kwargs)
         model = Model.from_pretrained(self.model_name, **kwargs)
         if not self.pretrained:
             rawmodel = Model.from_config(model.config)
@@ -375,14 +378,14 @@ class HuggingFaceText(BaseStatic, HuggingFaceMixin):
             with torch.no_grad():
                 for p in model.parameters():
                     part_reversal(p)
-        if self.device != "accelerate":
+        if self._should_move_hf_model():
             model.to(self.device)
         model.eval()
         return model
 
     @property
     def tokenizer(self) -> tp.Any:
-        self.model
+        self.hf_model
         return self._tokenizer
 
     def _get_max_length(self) -> int | None:
@@ -395,7 +398,7 @@ class HuggingFaceText(BaseStatic, HuggingFaceMixin):
             self._max_length = tok_max
             return self._max_length
         # learned-position table is sized capacity + offset, so the offset cancels
-        config = self.model.config
+        config = self.hf_model.config
         for attr in ("max_position_embeddings", "n_positions", "n_ctx"):
             value = getattr(config, attr, None)
             if isinstance(value, int) and value > 0:
@@ -442,9 +445,7 @@ class HuggingFaceText(BaseStatic, HuggingFaceMixin):
         # Processing the data in batches
         if len(dloader) > 1:
             dloader = tqdm(dloader, desc="Computing word embeddings")  # type: ignore
-        device = "auto" if self.device == "accelerate" else self.device
-        if device == "auto":
-            device = "cuda" if torch.cuda.is_available() else "cpu"
+        device = self._hf_input_device(self.hf_model)
         with torch.no_grad():
             for target_words, context in dloader:
                 # tokenize context
@@ -465,7 +466,7 @@ class HuggingFaceText(BaseStatic, HuggingFaceMixin):
                         truncation=True,  # beware to have set truncation_side="left" in init
                         max_length=self._get_max_length(),  # guard tokenizers reporting no real limit (e.g. OPT)
                     ).to(device)
-                outputs = self.model(**inputs, output_hidden_states=True)
+                outputs = self.hf_model(**inputs, output_hidden_states=True)
                 if "hidden_states" in outputs:
                     states = outputs.hidden_states
                 else:  # bart (encoder/decoder)
@@ -512,7 +513,7 @@ class HuggingFaceText(BaseStatic, HuggingFaceMixin):
                     yield out
                 # erase variables / free memory
                 del hidden_states, hidden_state, word_state, states, outputs, inputs
-                if self.device == "accelerate" and torch.cuda.is_available():
+                if self.model.device_map is not None and torch.cuda.is_available():
                     # in case of multi-GPU models, explicitly empty cache "just in case"
                     torch.cuda.empty_cache()
 

--- a/neuralset-repo/neuralset/extractors/video.py
+++ b/neuralset-repo/neuralset/extractors/video.py
@@ -110,7 +110,7 @@ class HuggingFaceVideo(BaseExtractor):
 
     Parameters
     ----------
-    image : HuggingFaceImage, default=HuggingFaceImage(model_name="MCG-NJU/videomae-base")
+    image : HuggingFaceImage, default=HuggingFaceImage(model={"model_name": "MCG-NJU/videomae-base"})
         Image or video feature extractor configuration. If `image.model_name` refers
         to an image model (e.g., ViT), frames are extracted and processed independently.
         If it's a video model, clips are processed using the native video architecture.
@@ -144,7 +144,7 @@ class HuggingFaceVideo(BaseExtractor):
         "julius>=0.2.7",
     )
     image: HuggingFaceImage = HuggingFaceImage(
-        model_name="MCG-NJU/videomae-base",
+        model={"model_name": "MCG-NJU/videomae-base"},
         infra=MapInfra(keep_in_ram=False),
         imsize=None,  # type: ignore[arg-type]
     )

--- a/neuralset-repo/neuralset/extractors/video.py
+++ b/neuralset-repo/neuralset/extractors/video.py
@@ -186,7 +186,7 @@ class HuggingFaceVideo(BaseExtractor):
         self, events: list[evts.Video]
     ) -> tp.Iterator[nsbase.TimedArray]:
         # read all videos of the events
-        config = getattr(self.image.model.model, "config", object())
+        config = getattr(self.image.hf_model.model, "config", object())
         config = getattr(config, "vision_config", config)  # xclip
         if hasattr(config, "num_frames"):
             name = self.image.model_name
@@ -261,9 +261,10 @@ class HuggingFaceVideo(BaseExtractor):
             pretrained=self.image.pretrained,
             layer_type=self.layer_type,
             num_frames=self.num_frames,
+            torch_dtype=self.image.model.torch_dtype,
+            device_map=self.image.model.device_map,
         )
-        if model.model.device.type == "cpu":
-            # may already be dispatched (with "accelerate")
+        if self.image.model.device_map is None and model.model.device.type == "cpu":
             model.model.to(self.image.device)
         # videomae = 16 frames
         # xclip = 8 or 16 frames (unclear)
@@ -366,6 +367,8 @@ class _HFVideoModel:
         pretrained: bool = True,
         layer_type: str = "",
         num_frames: int | None = None,
+        torch_dtype: torch.dtype | None = None,
+        device_map: str | dict[str, tp.Any] | None = None,
     ) -> None:
         super().__init__()
         if not any(z in model_name for z in self.MODELS):
@@ -386,7 +389,7 @@ class _HFVideoModel:
 
             extra = {"torch_dtype": torch.float16}
             if "34B" in model_name:
-                extra["device_map"] = "auto"  # uses accelerate
+                extra["device_map"] = "auto"
         if "Phi-4" in model_name:
             from transformers import AutoModelForCausalLM as Model
 
@@ -395,6 +398,10 @@ class _HFVideoModel:
         if "vjepa2" in model_name:
             from transformers import AutoVideoProcessor as Processor
 
+        if torch_dtype is not None:
+            extra["torch_dtype"] = torch_dtype
+        if device_map is not None:
+            extra["device_map"] = device_map
         self.model = Model.from_pretrained(model_name, output_hidden_states=True, **extra)
         if not pretrained:
             self.model = Model.from_config(self.model.config)

--- a/neuralset-repo/neuralset/extractors/video.py
+++ b/neuralset-repo/neuralset/extractors/video.py
@@ -110,7 +110,7 @@ class HuggingFaceVideo(BaseExtractor):
 
     Parameters
     ----------
-    image : HuggingFaceImage, default=HuggingFaceImage(model={"model_name": "MCG-NJU/videomae-base"})
+    image : HuggingFaceImage, default=HuggingFaceImage(hf_config={"model_name": "MCG-NJU/videomae-base"})
         Image or video feature extractor configuration. If `image.model_name` refers
         to an image model (e.g., ViT), frames are extracted and processed independently.
         If it's a video model, clips are processed using the native video architecture.
@@ -144,7 +144,7 @@ class HuggingFaceVideo(BaseExtractor):
         "julius>=0.2.7",
     )
     image: HuggingFaceImage = HuggingFaceImage(
-        model={"model_name": "MCG-NJU/videomae-base"},
+        hf_config={"model_name": "MCG-NJU/videomae-base"},
         infra=MapInfra(keep_in_ram=False),
         imsize=None,  # type: ignore[arg-type]
     )
@@ -186,7 +186,7 @@ class HuggingFaceVideo(BaseExtractor):
         self, events: list[evts.Video]
     ) -> tp.Iterator[nsbase.TimedArray]:
         # read all videos of the events
-        config = getattr(self.image.hf_model.model, "config", object())
+        config = getattr(self.image.model.model, "config", object())
         config = getattr(config, "vision_config", config)  # xclip
         if hasattr(config, "num_frames"):
             name = self.image.model_name
@@ -261,10 +261,10 @@ class HuggingFaceVideo(BaseExtractor):
             pretrained=self.image.pretrained,
             layer_type=self.layer_type,
             num_frames=self.num_frames,
-            torch_dtype=self.image.model.torch_dtype,
-            device_map=self.image.model.device_map,
+            torch_dtype=self.image.hf_config.torch_dtype,
+            device_map=self.image.hf_config.device_map,
         )
-        if self.image.model.device_map is None and model.model.device.type == "cpu":
+        if self.image.hf_config.device_map is None and model.model.device.type == "cpu":
             model.model.to(self.image.device)
         # videomae = 16 frames
         # xclip = 8 or 16 frames (unclear)


### PR DESCRIPTION
## Summary
- Remove `device="accelerate"` as a HuggingFace extractor mode; `device` now only accepts real torch placements (`auto`, `cpu`, `cuda`).
- Add `HuggingFaceConfig` under the `hf_config` field for `model_name`, `torch_dtype`, and `device_map`.
- Forward `torch_dtype` and `device_map` through image, text, audio, and video HuggingFace loaders and exclude placement/dtype load options from cache identity.

## Issue Addressed
`HuggingFaceImage(device="accelerate")` could crash on the first tensor movement because `accelerate` is a HuggingFace dispatch strategy, not a valid torch device. Video had the same trap, and native video model loading did not consistently pass `device_map="auto"` or fp16 options, so the old mode could silently do nothing for non-LLaVA video models.

## Usage
Before, dispatch was requested via the fake device mode:

```python
HuggingFaceImage(device="accelerate")
```

Now dispatch and dtype are explicit HuggingFace load options:

```python
HuggingFaceImage(
    hf_config={"device_map": "auto", "torch_dtype": "float16"},
)
```

To choose a model, use the same nested config:

```python
HuggingFaceImage(
    hf_config={"model_name": "openai/clip-vit-base-patch32"},
)
```

Top-level `model_name=` now raises an explicit error pointing to `hf_config={"model_name": ...}`.

## Test plan
- `.venv/bin/python -m pre_commit run --files neuralset-repo/neuralset/extractors/__init__.py neuralset-repo/neuralset/extractors/base.py neuralset-repo/neuralset/extractors/image.py neuralset-repo/neuralset/extractors/text.py neuralset-repo/neuralset/extractors/audio.py neuralset-repo/neuralset/extractors/video.py neuralset-repo/neuralset/extractors/test_base.py neuralset-repo/neuralset/extractors/test_image.py neuralset-repo/neuralset/extractors/test_text.py neuralset-repo/neuralset/extractors/test_audio.py neuralset-repo/neuralset/extractors/test_video.py`
- `.venv/bin/python -m pytest neuralset-repo/neuralset/extractors/test_base.py::test_huggingface_model_exists neuralset-repo/neuralset/extractors/test_base.py::test_huggingface_model_config neuralset-repo/neuralset/extractors/test_image.py::test_image_model_load_options_excluded_from_cache_uid neuralset-repo/neuralset/extractors/test_video.py::test_video_model_load_options_forwarded neuralset-repo/neuralset/extractors/test_image.py::test_image neuralset-repo/neuralset/extractors/test_text.py::test_max_length_real_limit 'neuralset-repo/neuralset/extractors/test_audio.py::test_wav2vec_layers[0.0]' neuralset-repo/neuralset/extractors/test_video.py::test_video_huggingface`