### PR TITLE
Fix _check_requirements to work with git+https:// URL requirements

### DIFF
--- a/neuralset-repo/neuralset/base.py
+++ b/neuralset-repo/neuralset/base.py
@@ -11,6 +11,7 @@ import logging
 import pprint
 import typing as tp
 from pathlib import Path
+from urllib.parse import urlparse
 
 import exca
 import exca.steps
@@ -18,6 +19,7 @@ import numpy as np
 import pydantic
 import yaml
 from exca.cachedict import DumpContext
+from packaging.requirements import Requirement
 
 PathLike = str | Path
 
@@ -151,10 +153,24 @@ class _Module(BaseModel):
         }
         missing = []
         for req in cls.requirements:
-            name = req.split(">")[0].split("<")[0].split("=")[0].split("[")[0]
+            if "://" in req:
+                # VCS URLs are not valid PEP 508 requirements, so parse by hand:
+                # prefer the #egg= fragment, else fall back to the last path segment.
+                parsed = urlparse(req.split("+", 1)[-1])
+                name = parsed.path.rsplit("/", 1)[-1].split("@")[0].removesuffix(".git")
+                for part in parsed.fragment.split("&"):
+                    if part.startswith("egg="):
+                        name = part.split("=", 1)[-1]
+                        break
+            else:
+                name = Requirement(req).name
             spec_name = import_names.get(name, name.replace("-", "_"))
-            if importlib.util.find_spec(spec_name) is None:
-                missing.append(name)
+            try:
+                found = importlib.util.find_spec(spec_name) is not None
+            except (ModuleNotFoundError, ValueError):
+                found = False
+            if not found:
+                missing.append(req)
         if missing:
             raise ModuleNotFoundError(
                 f"{cls.__name__} requires packages that are not installed.\n"

--- a/neuralset-repo/neuralset/test_base.py
+++ b/neuralset-repo/neuralset/test_base.py
@@ -41,6 +41,26 @@ def test_requirements() -> None:
     assert C.requirements == ("req_a", "req_b")
 
 
+@pytest.mark.parametrize(
+    "reqs,installed",
+    [
+        (("json",), True),
+        (("json>=1.0", "os~=2.0"), True),
+        (("git+https://github.com/python/json.git@main",), True),
+        (("git+https://github.com/org/wrong_name#egg=json",), True),  # egg overrides path
+        (("git+https://github.com/org/some_pkg.git@abc123",), False),
+        (("git+https://github.com/org/repo#egg=some_pkg",), False),
+    ],
+)
+def test_check_requirements(reqs: tuple[str, ...], installed: bool) -> None:
+    cls: type[base._Module] = type("_Tmp", (base._Module,), {"requirements": reqs})
+    if installed:
+        cls._check_requirements()
+    else:
+        with pytest.raises(ModuleNotFoundError, match="pip install"):
+            cls._check_requirements()
+
+
 def test_frequency_yaml() -> None:
     freq = yaml.safe_dump({"data": base.Frequency(10)})
     assert freq == "data: 10.0\n"


### PR DESCRIPTION
## Summary

- `_check_requirements()` crashed with `ModuleNotFoundError: No module named 'git+https://github'` when a study's `requirements` tuple contained `git+https://...` URLs (e.g. `Lebel2023Natural`).
- The name-extraction logic now detects URL-based requirements via `://` and parses the package name from the URL path (stripping `.git` suffix and `@commit` ref).
- Also wraps `importlib.util.find_spec` in try/except, since it can raise `ModuleNotFoundError` instead of returning `None` for some module names.