### PR TITLE
fix: drop text kwarg for VideoMAE in HF video extractor

### DIFF
--- a/neuralset-repo/neuralset/extractors/video.py
+++ b/neuralset-repo/neuralset/extractors/video.py
@@ -441,6 +441,8 @@ class _HFVideoModel:
         field = "images"
         if "xclip" in self.model_name:
             field = "videos"
+        elif "videomae" in self.model_name:
+            del kwargs["text"]
         elif "llava" in self.model_name.lower():
             field = "videos"
             kwargs["text"] = self.layer_type


### PR DESCRIPTION
## Summary
- Remove the `text` kwarg when calling VideoMAE models in `_HFVideoModel.predict`, matching the existing handling for VJEPA2.
- Fixes runtime errors caused by passing an unsupported argument to the VideoMAE processor.

## Related Issues
Closes https://github.com/facebookresearch/neuroai/issues/29.

## Test plan
- [x] Run VideoMAE feature extraction and confirm it completes without processor errors


Made with [Cursor](https://cursor.com)