### PR TITLE
Adjust duration calculation to account for precision

### DIFF
--- a/neuralset-repo/neuralset/events/transforms/splitting.py
+++ b/neuralset-repo/neuralset/events/transforms/splitting.py
@@ -157,7 +157,7 @@ class AssignWordSplitAndContext(EventsTransform):
     ratios: tuple[float, float, float] = (0.8, 0.1, 0.1)
     seed: int = 0
     max_unmatched_ratio: float = 0.0
-    tol: float = 0.0
+    tolerance: float = 0.0
     sentence_only: bool = True
     max_context_len: int | None = None
     override_sentences: bool = False

--- a/neuralset-repo/neuralset/events/transforms/splitting.py
+++ b/neuralset-repo/neuralset/events/transforms/splitting.py
@@ -157,6 +157,7 @@ class AssignWordSplitAndContext(EventsTransform):
     ratios: tuple[float, float, float] = (0.8, 0.1, 0.1)
     seed: int = 0
     max_unmatched_ratio: float = 0.0
+    tol: float = 0.0
     sentence_only: bool = True
     max_context_len: int | None = None
     override_sentences: bool = False

--- a/neuralset-repo/neuralset/events/transforms/test_transforms.py
+++ b/neuralset-repo/neuralset/events/transforms/test_transforms.py
@@ -507,7 +507,7 @@ def test_ensure_texts_encloses_words() -> None:
     result = _transf.EnsureTexts(punctuation=None)(df)
     text = result.loc[result.type == "Text"].iloc[0]
     encl = ns.segments.find_enclosed(
-        result, start=float(text.start), duration=float(text.duration), tol=1e-6
+        result, start=float(text.start), duration=float(text.duration), tolerance=1e-6
     )
     words = result.index[result.type == "Word"]
     assert words.isin(encl).all()

--- a/neuralset-repo/neuralset/events/transforms/test_transforms.py
+++ b/neuralset-repo/neuralset/events/transforms/test_transforms.py
@@ -494,6 +494,25 @@ def test_ensure_texts() -> None:
     assert set(multi[multi.type == "Text"].timeline) == {"foo", "bar"}
 
 
+def test_ensure_texts_encloses_words() -> None:
+    df = pd.DataFrame(
+        dict(
+            type="Word",
+            text=["it", "is"],
+            start=[39.298, 3463.038],
+            duration=0.49,
+            timeline="test",
+        )
+    )
+    result = _transf.EnsureTexts(punctuation=None)(df)
+    text = result.loc[result.type == "Text"].iloc[0]
+    encl = ns.segments.find_enclosed(
+        result, start=float(text.start), duration=float(text.duration)
+    )
+    words = result.index[result.type == "Word"]
+    assert words.isin(encl).all()
+
+
 @pytest.mark.skipif("CI" in os.environ, reason="DL punctuation model not in CI")
 def test_ensure_texts_fullstop() -> None:
     _, df = _make_test_events()

--- a/neuralset-repo/neuralset/events/transforms/test_transforms.py
+++ b/neuralset-repo/neuralset/events/transforms/test_transforms.py
@@ -507,7 +507,7 @@ def test_ensure_texts_encloses_words() -> None:
     result = _transf.EnsureTexts(punctuation=None)(df)
     text = result.loc[result.type == "Text"].iloc[0]
     encl = ns.segments.find_enclosed(
-        result, start=float(text.start), duration=float(text.duration)
+        result, start=float(text.start), duration=float(text.duration), tol=1e-6
     )
     words = result.index[result.type == "Word"]
     assert words.isin(encl).all()

--- a/neuralset-repo/neuralset/events/transforms/text.py
+++ b/neuralset-repo/neuralset/events/transforms/text.py
@@ -133,14 +133,14 @@ class AddSentenceToWords(EventsTransform):
     ----------
     max_unmatched_ratio : float
         Maximum ratio of words without a character-positioned match.
-    tol : float, optional
-        Tolerance for Text event start and end times. Default is 0.0.
+    tolerance : float
+        Tolerance (in seconds) for Text event start and end times.
     override_sentences : bool, default=False
         Whether to replace existing Sentence rows if they are already present.
     """
 
     max_unmatched_ratio: float = 0.0  # raises if did not match enough words
-    tol: float = 0.0
+    tolerance: float = 0.0
     override_sentences: bool = False
 
     @classmethod
@@ -191,7 +191,7 @@ class AddSentenceToWords(EventsTransform):
                 events,
                 start=float(context.start),  # type: ignore[arg-type]
                 duration=float(context.duration),  # type: ignore[arg-type]
-                tol=self.tol,
+                tolerance=self.tolerance,
             )
             sub = events.loc[encl]
             sel = sub[sub.type.isin(wtypes.names)].index

--- a/neuralset-repo/neuralset/events/transforms/text.py
+++ b/neuralset-repo/neuralset/events/transforms/text.py
@@ -64,7 +64,6 @@ class EnsureTexts(EventsTransform):
         if words.empty:
             return events
         text_rows: list[dict[str, tp.Any]] = []
-        eps = 1e-6
         for timeline, word_group in words.groupby("timeline"):
             raw = " ".join(word_group.text.values)
             text_str = self._punctuate(raw, word_group)
@@ -74,7 +73,7 @@ class EnsureTexts(EventsTransform):
                 dict(
                     type="Text",
                     start=start,
-                    duration=stop - start + 2 * eps,
+                    duration=stop - start,
                     timeline=timeline,
                     text=text_str,
                     language=(
@@ -134,11 +133,14 @@ class AddSentenceToWords(EventsTransform):
     ----------
     max_unmatched_ratio : float
         Maximum ratio of words without a character-positioned match.
+    tol : float, optional
+        Tolerance for Text event start and end times. Default is 0.0.
     override_sentences : bool, default=False
         Whether to replace existing Sentence rows if they are already present.
     """
 
     max_unmatched_ratio: float = 0.0  # raises if did not match enough words
+    tol: float = 0.0
     override_sentences: bool = False
 
     @classmethod
@@ -189,6 +191,7 @@ class AddSentenceToWords(EventsTransform):
                 events,
                 start=float(context.start),  # type: ignore[arg-type]
                 duration=float(context.duration),  # type: ignore[arg-type]
+                tol=self.tol,
             )
             sub = events.loc[encl]
             sel = sub[sub.type.isin(wtypes.names)].index

--- a/neuralset-repo/neuralset/events/transforms/text.py
+++ b/neuralset-repo/neuralset/events/transforms/text.py
@@ -64,6 +64,7 @@ class EnsureTexts(EventsTransform):
         if words.empty:
             return events
         text_rows: list[dict[str, tp.Any]] = []
+        eps = 1e-6
         for timeline, word_group in words.groupby("timeline"):
             raw = " ".join(word_group.text.values)
             text_str = self._punctuate(raw, word_group)
@@ -73,7 +74,7 @@ class EnsureTexts(EventsTransform):
                 dict(
                     type="Text",
                     start=start,
-                    duration=stop - start,
+                    duration=stop - start + 2 * eps,
                     timeline=timeline,
                     text=text_str,
                     language=(

--- a/neuralset-repo/neuralset/events/transforms/utils.py
+++ b/neuralset-repo/neuralset/events/transforms/utils.py
@@ -43,7 +43,6 @@ def _extract_sentences(events) -> list[ev.Sentence]:
     words_df = events.loc[events.type.isin(wtypes.names), :]
     sentences = []
     words: list[tp.Any] = []
-    eps = 1e-6
     for k, word in enumerate(words_df.itertuples(index=False)):
         if words and words[-1].timeline == word.timeline:
             if word.start < words[-1].start:
@@ -68,11 +67,8 @@ def _extract_sentences(events) -> list[ev.Sentence]:
                     language = ""
                 sentences.append(
                     ev.Sentence(
-                        start=w0.start - eps,
-                        duration=words[-1].start
-                        + words[-1].duration
-                        - w0.start
-                        + 2 * eps,
+                        start=w0.start,
+                        duration=words[-1].start + words[-1].duration - w0.start,
                         timeline=w0.timeline,
                         text=text,
                         language=language,

--- a/neuralset-repo/neuralset/segments.py
+++ b/neuralset-repo/neuralset/segments.py
@@ -505,7 +505,7 @@ def _prepare_strided_windows(
 
 
 def find_enclosed(
-    df: pd.DataFrame, start: float, duration: float, tol: float = 0.0
+    df: pd.DataFrame, start: float, duration: float, tolerance: float = 0.0
 ) -> pd.Series:
     """Find events fully enclosed within a time window.
 
@@ -517,8 +517,8 @@ def find_enclosed(
         Start time of the enclosing window.
     duration : float
         Duration of the enclosing window.
-    tol : float, optional
-        Tolerance for event start and end times. Default is 0.0.
+    tolerance : float, optional
+        Tolerance (in seconds) for event start and end times. Default is 0.0.
 
     Returns
     -------
@@ -529,7 +529,7 @@ def find_enclosed(
     Notes
     -----
     An event is considered enclosed if both its start and end times fall within
-    the window: :code:`start - tol <= event_start` and :code:`event_end <= start + duration + tol`.
+    the window: :code:`start - tolerance <= event_start` and :code:`event_end <= start + duration + tolerance`.
 
     Examples
     --------
@@ -538,7 +538,9 @@ def find_enclosed(
     """
     estart = np.array(df.start)
     estop = estart + np.array(df.duration)
-    is_enclosed = np.logical_and(estart >= start - tol, estop <= start + duration + tol)
+    is_enclosed = np.logical_and(
+        estart >= start - tolerance, estop <= start + duration + tolerance
+    )
     return pd.Series(df.index[is_enclosed])
 
 

--- a/neuralset-repo/neuralset/segments.py
+++ b/neuralset-repo/neuralset/segments.py
@@ -504,7 +504,9 @@ def _prepare_strided_windows(
     return starts, durations
 
 
-def find_enclosed(df: pd.DataFrame, start: float, duration: float) -> pd.Series:
+def find_enclosed(
+    df: pd.DataFrame, start: float, duration: float, tol: float = 0.0
+) -> pd.Series:
     """Find events fully enclosed within a time window.
 
     Parameters
@@ -515,6 +517,8 @@ def find_enclosed(df: pd.DataFrame, start: float, duration: float) -> pd.Series:
         Start time of the enclosing window.
     duration : float
         Duration of the enclosing window.
+    tol : float, optional
+        Tolerance for event start and end times. Default is 0.0.
 
     Returns
     -------
@@ -525,7 +529,7 @@ def find_enclosed(df: pd.DataFrame, start: float, duration: float) -> pd.Series:
     Notes
     -----
     An event is considered enclosed if both its start and end times fall within
-    the window: :code:`start <= event_start` and :code:`event_end <= start + duration`.
+    the window: :code:`start - tol <= event_start` and :code:`event_end <= start + duration + tol`.
 
     Examples
     --------
@@ -534,7 +538,7 @@ def find_enclosed(df: pd.DataFrame, start: float, duration: float) -> pd.Series:
     """
     estart = np.array(df.start)
     estop = estart + np.array(df.duration)
-    is_enclosed = np.logical_and(estart >= start, estop <= start + duration)
+    is_enclosed = np.logical_and(estart >= start - tol, estop <= start + duration + tol)
     return pd.Series(df.index[is_enclosed])
 
 


### PR DESCRIPTION
## What does this PR do?

Small fix for decimal precision in `EnsureTexts` `EventsTransform` to be sure that all the `Word` events are enclosed in the newly created `Text` events.
Reused the same approach as in `_extract_sentences` in `utils`

