### PR TITLE
Clamp log_every_n_steps to effective train batches

### DIFF
--- a/neuralbench-repo/neuralbench/main.py
+++ b/neuralbench-repo/neuralbench/main.py
@@ -10,6 +10,7 @@ import platform
 import resource
 import time
 import typing as tp
+from collections.abc import Sized
 from pathlib import Path
 
 import lightning.pytorch as pl
@@ -252,7 +253,11 @@ class Experiment(BaseExperiment):
         if self.csv_config is not None:
             self._csv_logger = self.csv_config.build(save_dir=savedir)
 
-    def setup_trainer(self, is_test: bool = False) -> pl.Trainer:
+    def setup_trainer(
+        self,
+        is_test: bool = False,
+        train_loader: Sized | None = None,
+    ) -> pl.Trainer:
         """Create callbacks and setup Trainer."""
         callbacks: list[Callback] = []
         if "confusion_matrix" in [metric.log_name for metric in self.metrics]:
@@ -337,6 +342,11 @@ class Experiment(BaseExperiment):
             accelerator="cpu" if self.infra.gpus_per_node == 0 else "auto",
             devices=1 if is_test else self.infra.gpus_per_node,
             num_nodes=1,
+            log_every_n_steps=(
+                None
+                if is_test
+                else self.trainer_config.effective_log_every_n_steps(train_loader)
+            ),
         )
 
     def _test(
@@ -401,7 +411,7 @@ class Experiment(BaseExperiment):
         pl.seed_everything(self.seed, workers=True)
         self.setup_run()
         loaders = self.data.prepare()
-        trainer = self.setup_trainer()
+        trainer = self.setup_trainer(train_loader=loaders["train"])
         self.prepare_pl_module(loaders["train"], loaders.get("val"))
 
         test_results: dict[str, tp.Any] = {}

--- a/neuralbench-repo/neuralbench/test_main.py
+++ b/neuralbench-repo/neuralbench/test_main.py
@@ -136,7 +136,8 @@ def test_run_seeds_before_preparing_dataloaders(monkeypatch) -> None:
         del self
         events.append("setup_run")
 
-    def fake_setup_trainer(self):
+    def fake_setup_trainer(self, is_test: bool = False, train_loader=None):
+        del is_test, train_loader
         events.append("setup_trainer")
         return SimpleNamespace(global_rank=1)
 
@@ -174,3 +175,36 @@ def test_run_seeds_before_preparing_dataloaders(monkeypatch) -> None:
     assert events[-2:] == ["prepare_pl_module", "cleanup"]
     assert result["n_total_params"] is None
     assert result["n_trainable_params"] is None
+
+
+def test_setup_trainer_uses_effective_log_every_n_steps(monkeypatch) -> None:
+    captured: dict[str, tp.Any] = {}
+
+    def fake_build(
+        self,
+        logger,
+        callbacks,
+        accelerator=None,
+        devices=None,
+        num_nodes=None,
+        log_every_n_steps=None,
+    ):
+        del logger, callbacks, accelerator, devices, num_nodes
+        captured["log_every_n_steps"] = log_every_n_steps
+        return object()
+
+    monkeypatch.setattr(TrainerConfig, "build", fake_build)
+
+    experiment = Experiment.model_construct(
+        data=tp.cast(Data, SimpleNamespace(target=object())),
+        brain_model_config=tp.cast(BaseModelConfig, object()),
+        trainer_config=TrainerConfig(log_every_n_steps=20),
+        loss=tp.cast(BaseLoss, _DummyLoss()),
+        lightning_optimizer_config=tp.cast(LightningOptimizer, object()),
+        metrics=[],
+        infra=TaskInfra(version="1", gpus_per_node=0),
+    )
+
+    experiment.setup_trainer(train_loader=[0, 1, 2])
+
+    assert captured["log_every_n_steps"] == 3

--- a/neuralbench-repo/neuralbench/test_utils.py
+++ b/neuralbench-repo/neuralbench/test_utils.py
@@ -22,6 +22,7 @@ from neuralset.extractors.meta import CroppedExtractor
 from .data import Data
 from .utils import (
     _compute_regression_bin_weights,
+    TrainerConfig,
     make_regression_bin_sampler,
     make_weighted_sampler,
     seed_worker,
@@ -153,6 +154,24 @@ def test_make_regression_bin_sampler_balances_bins(mocker):
     counts = torch.bincount(drawn_bins, minlength=4).float()
     proportions = counts / counts.sum()
     assert torch.allclose(proportions, torch.full((4,), 0.25), atol=0.01)
+
+
+def test_effective_log_every_n_steps_clamps_to_train_batches():
+    config = TrainerConfig(log_every_n_steps=20)
+
+    assert config.effective_log_every_n_steps([0, 1, 2]) == 3
+
+
+def test_effective_log_every_n_steps_respects_smaller_user_setting():
+    config = TrainerConfig(log_every_n_steps=2)
+
+    assert config.effective_log_every_n_steps([0, 1, 2]) == 2
+
+
+def test_effective_log_every_n_steps_honors_limit_train_batches():
+    config = TrainerConfig(log_every_n_steps=20, limit_train_batches=1)
+
+    assert config.effective_log_every_n_steps([0, 1, 2]) == 1
 
 
 # --- SequenceLabelEncoder -------------------------------------------------

--- a/neuralbench-repo/neuralbench/test_utils.py
+++ b/neuralbench-repo/neuralbench/test_utils.py
@@ -21,8 +21,8 @@ from neuralset.extractors.meta import CroppedExtractor
 
 from .data import Data
 from .utils import (
-    _compute_regression_bin_weights,
     TrainerConfig,
+    _compute_regression_bin_weights,
     make_regression_bin_sampler,
     make_weighted_sampler,
     seed_worker,

--- a/neuralbench-repo/neuralbench/utils.py
+++ b/neuralbench-repo/neuralbench/utils.py
@@ -448,9 +448,7 @@ class TrainerConfig(ns.BaseModel):
             max_epochs=self.n_epochs,
             enable_progress_bar=self.enable_progress_bar,
             log_every_n_steps=(
-                self.log_every_n_steps
-                if log_every_n_steps is None
-                else log_every_n_steps
+                self.log_every_n_steps if log_every_n_steps is None else log_every_n_steps
             ),
             num_sanity_val_steps=self.num_sanity_val_steps,
             fast_dev_run=self.fast_dev_run,

--- a/neuralbench-repo/neuralbench/utils.py
+++ b/neuralbench-repo/neuralbench/utils.py
@@ -9,6 +9,7 @@
 import logging
 import random
 import typing as tp
+from collections.abc import Sized
 from copy import copy
 from hashlib import sha1
 from pathlib import Path
@@ -415,6 +416,17 @@ class TrainerConfig(ns.BaseModel):
     monitor: str = "val/loss"
     mode: str = "min"
 
+    def effective_log_every_n_steps(self, train_loader: Sized | None = None) -> int:
+        """Clamp the logging interval to the effective train batches per epoch."""
+        if train_loader is None:
+            return self.log_every_n_steps
+
+        train_batches = len(train_loader)
+        if self.limit_train_batches is not None:
+            train_batches = min(train_batches, self.limit_train_batches)
+
+        return max(1, min(self.log_every_n_steps, train_batches))
+
     def build(
         self,
         logger,
@@ -422,6 +434,7 @@ class TrainerConfig(ns.BaseModel):
         accelerator: str | None = None,
         devices: int | None = None,
         num_nodes: int | None = None,
+        log_every_n_steps: int | None = None,
     ) -> pl.Trainer:
         return pl.Trainer(
             strategy=self.strategy,
@@ -434,7 +447,11 @@ class TrainerConfig(ns.BaseModel):
             limit_val_batches=self.limit_val_batches,
             max_epochs=self.n_epochs,
             enable_progress_bar=self.enable_progress_bar,
-            log_every_n_steps=self.log_every_n_steps,
+            log_every_n_steps=(
+                self.log_every_n_steps
+                if log_every_n_steps is None
+                else log_every_n_steps
+            ),
             num_sanity_val_steps=self.num_sanity_val_steps,
             fast_dev_run=self.fast_dev_run,
             accumulate_grad_batches=self.accumulate_grad_batches,


### PR DESCRIPTION
## Summary
- clamp `log_every_n_steps` to the effective number of train batches per epoch
- compute the effective interval from the prepared train loader at `run()` time
- add focused tests for the helper and the trainer setup path

## Problem
Some NeuralBench runs finish and sync to W&B, but users do not see a step metric line chart such as `train/loss_step`.

This is surprising because the run exists in W&B and training completed normally.

The root cause is that small datasets can produce fewer train batches per epoch than the configured `log_every_n_steps`. For example, with 3 train batches per epoch and `log_every_n_steps=20`, early-stopped runs can finish before Lightning ever flushes a step metric to the logger. Those runs then have no step-series for W&B to plot.

## Fix
This keeps the configured value as an upper bound, but clamps it to the effective train batches per epoch:

`effective_log_every_n_steps = max(1, min(configured_log_every_n_steps, effective_train_batches))`

That preserves the existing behavior on larger runs and makes short runs emit at least one step log per epoch.

## Testing
- `pytest -q neuralbench/test_utils.py -k 'effective_log_every_n_steps'`
- `pytest -q neuralbench/test_main.py -k 'setup_trainer_uses_effective_log_every_n_steps or run_seeds_before_preparing_dataloaders or setup_run_skips_wandb_when_host_blank'`
