### PR TITLE
[doc] Fix Step applied to a dataframe

### DIFF
--- a/docs/neuralset/walkthrough/03_transforms.py
+++ b/docs/neuralset/walkthrough/03_transforms.py
@@ -188,7 +188,7 @@ demo_events = ns.events.standardize_events(
     )
 )
 
-filtered = DropShortEvents(min_duration=0.1).run(demo_events)
+filtered = DropShortEvents(min_duration=0.1)._run(demo_events)
 print(f"{len(demo_events)} -> {len(filtered)} events")
 
 # %%


### PR DESCRIPTION
Step.run is *supposed* to be applied on hashable "uid-able" objects, not dataframe. for running a transform directly we should use _run. this is slightly ugly though so could deserve surfacing some other method?

(broke with the updated `run_many` API)