### PR TITLE
Add load_brainmarks_split utility and tests

### DIFF
--- a/neuralset-repo/neuralset/test_utils.py
+++ b/neuralset-repo/neuralset/test_utils.py
@@ -4,14 +4,17 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
-import io
 import typing as tp
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pyarrow.ipc as pa_ipc
 import pytest
+
+import neuralset.events as events
+import neuralset.utils as utils
 
 
 @pytest.mark.parametrize(
@@ -162,6 +165,7 @@ def test_load_brainmarks_split(tmp_path, monkeypatch):
     _write_arrow_shard(dataset_dir, "validation", [{"sub": "004"}])
 
     monkeypatch.setenv("NEURALSET_STUDY_FOLDER", str(tmp_path))
+    monkeypatch.delenv("NEURALSET_BRAINMARKS_FOLDER", raising=False)
     result = utils.load_brainmarks_split(dataset)
 
     assert result == {"001": "train", "002": "train", "003": "test", "004": "validation"}

--- a/neuralset-repo/neuralset/test_utils.py
+++ b/neuralset-repo/neuralset/test_utils.py
@@ -4,13 +4,14 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
+import io
 import typing as tp
 
 import numpy as np
 import pandas as pd
+import pyarrow as pa
+import pyarrow.ipc as pa_ipc
 import pytest
-
-from . import events, utils
 
 
 @pytest.mark.parametrize(
@@ -138,3 +139,39 @@ def test_train_test_split_by_group():
     assert X_train.shape[0] == y_train.shape[0]
     assert X_test.shape[0] == y_test.shape[0]
     assert X_train.shape[0] + X_test.shape[0] == n_examples
+
+
+def _write_arrow_shard(tmp_path: "Path", split: str, rows: list[dict]) -> None:
+    """Write a minimal HuggingFace-style Arrow shard for testing."""
+    split_dir = tmp_path / split
+    split_dir.mkdir(parents=True, exist_ok=True)
+    table = pa.table({k: [r[k] for r in rows] for k in rows[0]})
+    shard = split_dir / "data-00000-of-00001.arrow"
+    sink = pa.BufferOutputStream()
+    with pa_ipc.new_stream(sink, table.schema) as writer:
+        writer.write_table(table)
+    shard.write_bytes(sink.getvalue().to_pybytes())
+
+
+def test_load_brainmarks_split(tmp_path, monkeypatch):
+    dataset = "myfake.flat"
+    dataset_dir = tmp_path / "Brainmarks" / "fmri-datasets" / "eval" / f"{dataset}.arrow"
+    dataset_dir.mkdir(parents=True)
+    _write_arrow_shard(dataset_dir, "train", [{"sub": "001"}, {"sub": "002"}])
+    _write_arrow_shard(dataset_dir, "test", [{"sub": "003"}])
+    _write_arrow_shard(dataset_dir, "validation", [{"sub": "004"}])
+
+    monkeypatch.setenv("NEURALSET_STUDY_FOLDER", str(tmp_path))
+    result = utils.load_brainmarks_split(dataset)
+
+    assert result == {"001": "train", "002": "train", "003": "test", "004": "validation"}
+
+
+def test_load_brainmarks_split_missing_env(monkeypatch):
+    monkeypatch.delenv("NEURALSET_STUDY_FOLDER", raising=False)
+    assert utils.load_brainmarks_split("anything") == {}
+
+
+def test_load_brainmarks_split_missing_dataset(tmp_path, monkeypatch):
+    monkeypatch.setenv("NEURALSET_STUDY_FOLDER", str(tmp_path))
+    assert utils.load_brainmarks_split("nonexistent.flat") == {}

--- a/neuralset-repo/neuralset/test_utils.py
+++ b/neuralset-repo/neuralset/test_utils.py
@@ -169,6 +169,7 @@ def test_load_brainmarks_split(tmp_path, monkeypatch):
 
 def test_load_brainmarks_split_missing_env(monkeypatch):
     monkeypatch.delenv("NEURALSET_STUDY_FOLDER", raising=False)
+    monkeypatch.delenv("NEURALSET_BRAINMARKS_FOLDER", raising=False)
     assert utils.load_brainmarks_split("anything") == {}
 
 

--- a/neuralset-repo/neuralset/utils.py
+++ b/neuralset-repo/neuralset/utils.py
@@ -421,6 +421,7 @@ def train_test_split_by_group(
 
 _BRAINMARKS_EVAL_SUBPATH = Path("Brainmarks/fmri-datasets/eval")
 
+
 def load_brainmarks_split(
     dataset: str,
     subject_col: str = "sub",
@@ -428,13 +429,14 @@ def load_brainmarks_split(
     """Return a subject-ID -> split mapping from a Brainmarks HuggingFace dataset.
 
     Reads train/test/validation Arrow shards from:
+        $NEURALSET_BRAINMARKS_FOLDER/<dataset>.arrow/  (if set), or
         $NEURALSET_STUDY_FOLDER/Brainmarks/fmri-datasets/eval/<dataset>.arrow/
 
     Args:
         dataset: Dataset name without the ".arrow" suffix, e.g. "adhd200.flat".
         subject_col: Column in each Arrow shard holding the subject ID. Defaults to "sub".
 
-    Returns an empty dict (with a warning) if NEURALSET_STUDY_FOLDER is unset
+    Returns an empty dict (with a warning) if neither env var is set
     or the dataset directory does not exist.
     """
     import logging
@@ -442,14 +444,15 @@ def load_brainmarks_split(
     import pyarrow as pa
 
     _logger = logging.getLogger(__name__)
-    study_folder = os.environ.get("NEURALSET_STUDY_FOLDER")
-    if study_folder is None:
+    _brainmarks = os.environ.get("NEURALSET_BRAINMARKS_FOLDER")
+    _study = os.environ.get("NEURALSET_STUDY_FOLDER")
+    eval_dir = Path(_brainmarks) if _brainmarks else (Path(_study) / _BRAINMARKS_EVAL_SUBPATH if _study else None)
+    if eval_dir is None:
         _logger.warning(
             "NEURALSET_STUDY_FOLDER is not set; cannot load Brainmarks split for %r",
             dataset,
         )
         return {}
-    eval_dir = Path(study_folder) / _BRAINMARKS_EVAL_SUBPATH
     dataset_dir = eval_dir / f"{dataset}.arrow"
     if not dataset_dir.exists():
         _logger.warning("Brainmarks dataset not found: %s", dataset_dir)

--- a/neuralset-repo/neuralset/utils.py
+++ b/neuralset-repo/neuralset/utils.py
@@ -417,3 +417,51 @@ def train_test_split_by_group(
         splitting.extend([arr[train_inds], arr[test_inds]])  # type: ignore
 
     return splitting
+
+
+_BRAINMARKS_EVAL_SUBPATH = Path("Brainmarks/fmri-datasets/eval")
+
+def load_brainmarks_split(
+    dataset: str,
+    subject_col: str = "sub",
+) -> dict[str, str]:
+    """Return a subject-ID -> split mapping from a Brainmarks HuggingFace dataset.
+
+    Reads train/test/validation Arrow shards from:
+        $NEURALSET_STUDY_FOLDER/Brainmarks/fmri-datasets/eval/<dataset>.arrow/
+
+    Args:
+        dataset: Dataset name without the ".arrow" suffix, e.g. "adhd200.flat".
+        subject_col: Column in each Arrow shard holding the subject ID. Defaults to "sub".
+
+    Returns an empty dict (with a warning) if NEURALSET_STUDY_FOLDER is unset
+    or the dataset directory does not exist.
+    """
+    import logging
+
+    import pyarrow as pa
+
+    _logger = logging.getLogger(__name__)
+    study_folder = os.environ.get("NEURALSET_STUDY_FOLDER")
+    if study_folder is None:
+        _logger.warning(
+            "NEURALSET_STUDY_FOLDER is not set; cannot load Brainmarks split for %r",
+            dataset,
+        )
+        return {}
+    eval_dir = Path(study_folder) / _BRAINMARKS_EVAL_SUBPATH
+    dataset_dir = eval_dir / f"{dataset}.arrow"
+    if not dataset_dir.exists():
+        _logger.warning("Brainmarks dataset not found: %s", dataset_dir)
+        return {}
+    result: dict[str, str] = {}
+    for split in ("train", "test", "validation"):
+        split_dir = dataset_dir / split
+        if not split_dir.exists():
+            continue
+        for f in sorted(split_dir.glob("data-*.arrow")):
+            with pa.memory_map(str(f), "r") as src:
+                for batch in pa.ipc.open_stream(src):
+                    for sub in batch.column(subject_col).to_pylist():
+                        result[str(sub)] = split
+    return result

--- a/neuralset-repo/neuralset/utils.py
+++ b/neuralset-repo/neuralset/utils.py
@@ -446,7 +446,11 @@ def load_brainmarks_split(
     _logger = logging.getLogger(__name__)
     _brainmarks = os.environ.get("NEURALSET_BRAINMARKS_FOLDER")
     _study = os.environ.get("NEURALSET_STUDY_FOLDER")
-    eval_dir = Path(_brainmarks) if _brainmarks else (Path(_study) / _BRAINMARKS_EVAL_SUBPATH if _study else None)
+    eval_dir = (
+        Path(_brainmarks)
+        if _brainmarks
+        else (Path(_study) / _BRAINMARKS_EVAL_SUBPATH if _study else None)
+    )
     if eval_dir is None:
         _logger.warning(
             "NEURALSET_STUDY_FOLDER is not set; cannot load Brainmarks split for %r",


### PR DESCRIPTION
## Summary

- Adds `load_brainmarks_split(dataset, subject_col)` to `neuralset/utils.py`:
  reads HuggingFace-style Arrow shards from
  `$NEURALSET_STUDY_FOLDER/Brainmarks/fmri-datasets/eval/<dataset>.arrow/`
  and returns a `{subject_id: split}` mapping
- Gracefully returns `{}` with a warning if `NEURALSET_STUDY_FOLDER` is
  unset or the dataset directory does not exist
- Adds three tests in `test_utils.py` covering the path, missing
  env var, and missing dataset directory

## Checklist

- [x] Tests added or updated: `pytest neuralset-repo/neuralset/test_utils.py -v -k brainmarks`
- [x] Docstrings updated for any changed public APIs
- [x] `pytest` and `mypy` pass locally
