### PR TITLE
fix neuralfetch quickstart: use registered study and quickstart extra

### DIFF
--- a/docs/neuralfetch/index.rst
+++ b/docs/neuralfetch/index.rst
@@ -44,25 +44,22 @@ Quick install
    pip install neuralfetch
 
 Installing NeuralFetch automatically registers all curated studies in
-NeuralSet's catalog — no extra imports needed.
+NeuralSet's catalog — no extra imports needed. The public-data studies
+download through pluggable backends (OpenNeuro, OSF, S3, …) that ship
+with the ``quickstart`` extra:
+
+.. code-block:: bash
+
+   pip install 'neuralfetch[quickstart]'
 
 .. code-block:: python
 
    import neuralset as ns
 
-   study = ns.Study(name="Gwilliams2022Neural", path="/data")  # MEG + speech, from OSF
+   study = ns.Study(name="Bel2026PetitListenSample", path="/data")  # MEG + speech, OpenNeuro ds007523
    study.download()
    events = study.run()
-   events[["type", "start", "duration", "subject", "text"]].head()
-
-.. code-block:: text
-
-   type   start  duration              subject          text
-   Meg      0.0     396.0  Gwilliams2022Neural/A0001           NaN
-   Audio    0.0      42.3  Gwilliams2022Neural/A0001           NaN
-   Word     1.52     0.22  Gwilliams2022Neural/A0001         there
-   Word     1.74     0.18  Gwilliams2022Neural/A0001           was
-   Word     1.92     0.08  Gwilliams2022Neural/A0001             a
+   print(events[["type", "start", "duration", "subject", "text"]].head())
 
 ----
 

--- a/docs/neuralfetch/index.rst
+++ b/docs/neuralfetch/index.rst
@@ -44,9 +44,8 @@ Quick install
    pip install neuralfetch
 
 Installing NeuralFetch automatically registers all curated studies in
-NeuralSet's catalog — no extra imports needed. The public-data studies
-download through pluggable backends (OpenNeuro, OSF, S3, …) that ship
-with the ``quickstart`` extra:
+NeuralSet's catalog — no extra imports needed. Downloading their data
+needs the backends in the ``quickstart`` extra:
 
 .. code-block:: bash
 


### PR DESCRIPTION
## What does this PR do?

The landing-page quickstart could not run as written:

- `Gwilliams2022Neural` is not a registered study (absent from `Study.catalog()`), so `ns.Study(name=...)` raised `ImportError`.
- `pip install neuralfetch` pulls no download backend, so `download()` raised `ModuleNotFoundError: pip install openneuro-py`.

Switch the example to `Bel2026PetitListenSample` (MEG + spoken Le Petit Prince, OpenNeuro ds007523) and add the `pip install 'neuralfetch[quickstart]'` line, mirroring the bare-then-extras install shown on the neuralset and neuraltrain landing pages. Drop the hand-written output block (no other landing page pastes command output) and wrap the final call in `print(...)`.

## Related Issues

Closes #149

## Checklist

- [ ] Tests added or updated
- [ ] Docstrings updated for any changed public APIs
- [ ] `pytest` and `mypy` pass locally
