### PR TITLE
Add per-dataset size to StudyInfo and the dataset explorer table

### DIFF
--- a/docs/scripts/build_study_explorer.py
+++ b/docs/scripts/build_study_explorer.py
@@ -29,6 +29,7 @@ _SUMMARY_COLUMNS = [
     "n_timelines",
     "n_query_events",
     "n_hours",
+    "size_bytes",
     "data_shape",
     "frequency",
     "query",
@@ -47,6 +48,31 @@ def _estimate_hours(info: study.StudyInfo) -> float:
     if not info.data_shape or info.frequency <= 0 or info.num_timelines <= 0:
         return math.nan
     return info.num_timelines * info.data_shape[-1] / info.frequency / 3600
+
+
+def _format_size(value: float | None) -> str:
+    """Format a byte count as a human-readable size (e.g. ``1.5 GB``).
+
+    Returns an em dash for unmeasured (``None``/NaN) sizes so the column
+    reads cleanly while studies are populated incrementally.
+    """
+    if value is None or pd.isna(value) or value <= 0:
+        return "—"  # em dash
+    units = ["B", "KB", "MB", "GB", "TB", "PB"]
+    size = float(value)
+    index = 0
+    while size >= 1024 and index < len(units) - 1:
+        size /= 1024
+        index += 1
+    precision = 0 if size >= 100 or index == 0 else 1
+    return f"{size:.{precision}f} {units[index]}"
+
+
+def _size_attr(value: tp.Any) -> str:
+    """Render ``size_bytes`` as a numeric data attribute (empty when unmeasured)."""
+    if value is None or pd.isna(value) or value <= 0:
+        return ""
+    return str(int(value))
 
 
 def _format_number(value: float) -> str:
@@ -126,6 +152,7 @@ class StudyInfoSummaries(ns.BaseModel):
                     "n_timelines": info.num_timelines,
                     "n_query_events": info.num_events_in_query,
                     "n_hours": n_hours,
+                    "size_bytes": getattr(info, "size_bytes", None),
                     "data_shape": info.data_shape,
                     "frequency": info.frequency,
                     "query": info.query,
@@ -343,12 +370,14 @@ class StudyInfoSummaries(ns.BaseModel):
         n_subjects = int(summaries["n_subjects"].sum())
         n_timelines = int(summaries["n_timelines"].sum())
         n_hours = summaries["n_hours"].dropna().sum()
+        size_bytes = float(summaries["size_bytes"].dropna().sum())
         return (
             '<section class="summary">'
             f'<div><strong id="summary-studies">{len(summaries)}</strong><span>studies</span></div>'
             f'<div><strong id="summary-subjects">{n_subjects:,}</strong><span>subjects</span></div>'
             f'<div><strong id="summary-timelines">{n_timelines:,}</strong><span>timelines</span></div>'
             f'<div><strong id="summary-hours">{_format_number(n_hours)}</strong><span>estimated hours</span></div>'
+            f'<div><strong id="summary-size">{escape(_format_size(size_bytes))}</strong><span>total size</span></div>'
             "</section>"
         )
 
@@ -461,6 +490,7 @@ class StudyInfoSummaries(ns.BaseModel):
                 f'data-subjects="{int(row.n_subjects)}" '
                 f'data-timelines="{int(row.n_timelines)}" '
                 f'data-hours="{float(row.n_hours)}" '
+                f'data-size="{_size_attr(row.size_bytes)}" '
                 f'data-frequency="{float(row.frequency) if pd.notna(row.frequency) else 0}" '
                 f'data-channels="{_channel_count(row.data_shape)}" '
                 f'data-requirements="{escape(_data_list(row.requirements))}">'
@@ -511,7 +541,7 @@ class StudyInfoSummaries(ns.BaseModel):
         header = (
             "<thead>"
             '<tr class="event-super-header">'
-            '<th class="study-col" colspan="6"></th>'
+            '<th class="study-col" colspan="7"></th>'
             f'<th colspan="{len(neuro_event_types)}">Neuro events</th>'
             + (
                 f'<th colspan="{len(other_event_types)}">Other events</th>'
@@ -525,6 +555,7 @@ class StudyInfoSummaries(ns.BaseModel):
             "<th>Subjects</th>"
             "<th>Timelines</th>"
             "<th>Hours</th>"
+            "<th>Size</th>"
             + "".join(
                 _event_header(event_type, "neuro-event-col", "device")
                 for event_type in neuro_event_types
@@ -554,6 +585,7 @@ class StudyInfoSummaries(ns.BaseModel):
                 f'data-subjects="{int(row.n_subjects)}" '
                 f'data-timelines="{int(row.n_timelines)}" '
                 f'data-hours="{float(row.n_hours)}" '
+                f'data-size="{_size_attr(row.size_bytes)}" '
                 f'data-frequency="{float(row.frequency) if pd.notna(row.frequency) else 0}" '
                 f'data-channels="{_channel_count(row.data_shape)}" '
                 f'data-requirements="{escape(_data_list(row.requirements))}">'
@@ -564,6 +596,7 @@ class StudyInfoSummaries(ns.BaseModel):
                 f'<td class="num">{int(row.n_subjects):,}</td>',
                 f'<td class="num">{int(row.n_timelines):,}</td>',
                 f'<td class="num">{escape(_format_number(float(row.n_hours)))}</td>',
+                f'<td class="num">{escape(_format_size(row.size_bytes))}</td>',
             ]
             cells.extend(
                 '<td class="tick">&#10003;</td>'
@@ -582,7 +615,8 @@ class StudyInfoSummaries(ns.BaseModel):
                 f'data-device="{escape(device)}" data-events="{escape(event_data)}" '
                 f'data-subjects="{int(row.n_subjects)}" '
                 f'data-timelines="{int(row.n_timelines)}" '
-                f'data-hours="{float(row.n_hours)}">' + "".join(cells) + "</tr>"
+                f'data-hours="{float(row.n_hours)}" '
+                f'data-size="{_size_attr(row.size_bytes)}">' + "".join(cells) + "</tr>"
             )
         return (
             '<div class="table-wrap"><table>'
@@ -1377,11 +1411,27 @@ _JS = """
     return value.toFixed(2);
   }
 
+  function formatBytes(value) {
+    if (!Number.isFinite(value) || value <= 0) {
+      return "—"; // em dash
+    }
+    const units = ["B", "KB", "MB", "GB", "TB", "PB"];
+    let size = value;
+    let index = 0;
+    while (size >= 1024 && index < units.length - 1) {
+      size /= 1024;
+      index += 1;
+    }
+    const precision = size >= 100 || index === 0 ? 0 : 1;
+    return `${size.toFixed(precision)} ${units[index]}`;
+  }
+
   function updateSummary() {
     let studies = 0;
     let subjects = 0;
     let timelines = 0;
     let hours = 0;
+    let size = 0;
     root.querySelectorAll(".study-row").forEach((row) => {
       if (row.hasAttribute("hidden")) {
         return;
@@ -1393,11 +1443,16 @@ _JS = """
       if (Number.isFinite(rowHours)) {
         hours += rowHours;
       }
+      const rowSize = Number(row.dataset.size || 0);
+      if (Number.isFinite(rowSize)) {
+        size += rowSize;
+      }
     });
     root.querySelector("#summary-studies").textContent = studies.toLocaleString();
     root.querySelector("#summary-subjects").textContent = subjects.toLocaleString();
     root.querySelector("#summary-timelines").textContent = timelines.toLocaleString();
     root.querySelector("#summary-hours").textContent = formatNumber(hours);
+    root.querySelector("#summary-size").textContent = formatBytes(size);
   }
 
   function setForName(name) {
@@ -1488,6 +1543,7 @@ _JS = """
     const subjects = Number(target.dataset.subjects || 0);
     const timelines = Number(target.dataset.timelines || 0);
     const hours = Number(target.dataset.hours || 0);
+    const size = Number(target.dataset.size || 0);
     const frequency = Number(target.dataset.frequency || 0);
     const channels = Number(target.dataset.channels || 0);
     const neuro = target.dataset.neuro || target.dataset.device || "";
@@ -1503,6 +1559,9 @@ _JS = """
     }
     if (Number.isFinite(hours) && hours > 0) {
       stats.push(["Est. hours", formatNumber(hours)]);
+    }
+    if (Number.isFinite(size) && size > 0) {
+      stats.push(["Size", formatBytes(size)]);
     }
     if (channels > 0) {
       stats.push(["Channels", channels.toLocaleString()]);

--- a/docs/scripts/fetch_dataset_sizes.py
+++ b/docs/scripts/fetch_dataset_sizes.py
@@ -1,0 +1,133 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""One-off helper to seed ``StudyInfo.size_bytes`` from dataset host APIs.
+
+Scans ``neuralfetch/studies/*.py`` for OpenNeuro accessions, queries the
+OpenNeuro GraphQL API for each dataset's on-disk size, and prints the numbers
+together with a ready-to-paste ``size_bytes=...`` line per study.
+
+This is a developer convenience, not part of the docs build. OpenNeuro reports
+the on-disk size of the latest snapshot in bytes (``latestSnapshot.size``),
+which matches the "on-disk after extraction" semantics of ``size_bytes``.
+Hosts without a uniform size API (Zenodo, Figshare, OSF, S3) are listed as
+``unresolved`` for manual follow-up.
+
+Usage::
+
+    python docs/scripts/fetch_dataset_sizes.py
+    python docs/scripts/fetch_dataset_sizes.py --studies-dir path/to/studies
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+_OPENNEURO_GRAPHQL = "https://openneuro.org/crn/graphql"
+
+# Matches OpenNeuro accessions in any of the forms used across study files:
+#   download.Openneuro("ds004212", ...)
+#   https://openneuro.org/datasets/ds004212/versions/2.0.0
+#   github.com/OpenNeuroDatasets/ds004192.git
+_OPENNEURO_RE = re.compile(r"(?:Openneuro\(\"|datasets/|OpenNeuroDatasets/)(ds\d{6,})")
+
+# Hosts we cannot resolve to a single size with a uniform API call; surfaced so
+# the maintainer knows which studies still need a manual or per-host number.
+_OTHER_HOST_RE = re.compile(r"zenodo|figshare|osf\.io|s3://|datalad", re.IGNORECASE)
+
+
+def _find_studies(studies_dir: Path) -> list[Path]:
+    return sorted(path for path in studies_dir.glob("*.py") if path.name != "__init__.py")
+
+
+def _openneuro_size(accession: str) -> int | None:
+    """Return the latest-snapshot on-disk size in bytes, or ``None`` on failure."""
+    query = "query($id: ID!) { dataset(id: $id) { latestSnapshot { size } } }"
+    payload = json.dumps({"query": query, "variables": {"id": accession}}).encode()
+    request = urllib.request.Request(
+        _OPENNEURO_GRAPHQL,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            body = json.loads(response.read().decode())
+    except Exception as exc:  # noqa: BLE001 - one-off script, report and move on
+        print(f"  ! {accession}: request failed ({exc})", file=sys.stderr)
+        return None
+    snapshot = (body.get("data") or {}).get("dataset") or {}
+    size = (snapshot.get("latestSnapshot") or {}).get("size")
+    return int(size) if size else None
+
+
+def _format_size(value: int | None) -> str:
+    if not value:
+        return "—"
+    size = float(value)
+    for unit in ["B", "KB", "MB", "GB", "TB", "PB"]:
+        if size < 1024 or unit == "PB":
+            precision = 0 if size >= 100 or unit == "B" else 1
+            return f"{size:.{precision}f} {unit}"
+        size /= 1024
+    return f"{value} B"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    default_dir = (
+        Path(__file__).resolve().parents[2]
+        / "neuralfetch-repo"
+        / "neuralfetch"
+        / "studies"
+    )
+    parser.add_argument(
+        "--studies-dir",
+        type=Path,
+        default=default_dir,
+        help="Directory containing the per-study modules.",
+    )
+    args = parser.parse_args()
+
+    if not args.studies_dir.is_dir():
+        parser.error(f"studies dir not found: {args.studies_dir}")
+
+    # One row per (file, accession): a single file may host several study
+    # classes (e.g. THINGS MEG + fMRI), each with its own dataset and size, so
+    # we never sum across accessions — that mapping is the maintainer's call.
+    resolved: list[tuple[str, str, int]] = []
+    unresolved: list[str] = []
+    for path in _find_studies(args.studies_dir):
+        text = path.read_text(encoding="utf8")
+        accessions = sorted(set(_OPENNEURO_RE.findall(text)))
+        if accessions:
+            for accession in accessions:
+                size = _openneuro_size(accession)
+                print(f"  {path.name}: {accession} -> {_format_size(size)}")
+                if size:
+                    resolved.append((path.name, accession, size))
+        elif _OTHER_HOST_RE.search(text):
+            unresolved.append(path.name)
+
+    print("\n=== size_bytes (paste into the matching StudyInfo) ===")
+    for name, accession, size in resolved:
+        print(f"# {name}  ({accession}, {_format_size(size)})")
+        print(f"size_bytes={size},")
+
+    if unresolved:
+        print("\n=== unresolved (non-OpenNeuro host; measure manually) ===")
+        for name in unresolved:
+            print(f"  {name}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/neuralfetch-repo/neuralfetch/studies/bel2026petit.py
+++ b/neuralfetch-repo/neuralfetch/studies/bel2026petit.py
@@ -237,6 +237,7 @@ class Bel2026PetitListen(_Bel2026PetitBase):
     _info: tp.ClassVar[study.StudyInfo] = study.StudyInfo(
         num_timelines=516,
         num_subjects=58,
+        size_bytes=477_619_624_443,  # OpenNeuro ds007523, on-disk
         num_events_in_query=1775,
         event_types_in_query={"Meg", "Audio", "Word", "Text", "Sentence"},
         data_shape=(306, 623000),
@@ -410,6 +411,7 @@ class Bel2026PetitRead(_Bel2026PetitBase):
     _info: tp.ClassVar[study.StudyInfo] = study.StudyInfo(
         num_timelines=450,
         num_subjects=50,
+        size_bytes=320_573_795_975,  # OpenNeuro ds007524, on-disk
         num_events_in_query=1589,
         event_types_in_query={"Meg", "Word", "MissedWord", "Text", "Sentence"},
         data_shape=(306, 512_000),

--- a/neuralfetch-repo/neuralfetch/studies/chang2019bold5000.py
+++ b/neuralfetch-repo/neuralfetch/studies/chang2019bold5000.py
@@ -83,6 +83,7 @@ class Chang2019Bold5000(study.Study):
     _info: tp.ClassVar[study.StudyInfo] = study.StudyInfo(
         num_timelines=510,
         num_subjects=4,
+        size_bytes=82_971_498_972,  # OpenNeuro ds001499, on-disk
         num_events_in_query=38,
         event_types_in_query={"Fmri", "Image"},
         data_shape=(77, 94, 80, 194),

--- a/neuralfetch-repo/neuralfetch/studies/grootswagers2022human.py
+++ b/neuralfetch-repo/neuralfetch/studies/grootswagers2022human.py
@@ -88,6 +88,7 @@ class Grootswagers2022Human(study.Study):
     _info: tp.ClassVar[study.StudyInfo] = study.StudyInfo(
         num_timelines=50,
         num_subjects=50,
+        size_bytes=44_258_973_478,  # OpenNeuro ds003825, on-disk
         num_events_in_query=22249,
         event_types_in_query={"Eeg", "Image"},
         data_shape=(63, 3035740),

--- a/neuralfetch-repo/neuralfetch/studies/hebart2023things.py
+++ b/neuralfetch-repo/neuralfetch/studies/hebart2023things.py
@@ -174,6 +174,7 @@ class Hebart2023ThingsMeg(_Hebart2023Things):
     _info: tp.ClassVar[study.StudyInfo] = study.StudyInfo(
         num_timelines=480,
         num_subjects=4,
+        size_bytes=255_218_599_475,  # OpenNeuro ds004212 (THINGS-MEG), on-disk
         num_events_in_query=207,
         event_types_in_query={"Meg", "Image"},
         data_shape=(300, 417600),
@@ -361,6 +362,7 @@ class Hebart2023ThingsBold(_Hebart2023Things):
     _info: tp.ClassVar[study.StudyInfo] = study.StudyInfo(
         num_timelines=359,
         num_subjects=3,
+        size_bytes=105_794_162_895,  # OpenNeuro ds004192 (THINGS-fMRI), on-disk
         num_events_in_query=83,
         event_types_in_query={"Fmri", "Image"},
         data_shape=(77, 94, 80, 284),

--- a/neuralfetch-repo/neuralfetch/studies/li2022petit.py
+++ b/neuralfetch-repo/neuralfetch/studies/li2022petit.py
@@ -95,6 +95,7 @@ class Li2022Petit(study.Study):
     _info: tp.ClassVar[study.StudyInfo] = study.StudyInfo(
         num_timelines=1008,
         num_subjects=112,
+        size_bytes=154_553_907_605,  # OpenNeuro ds003643, on-disk
         num_events_in_query=1757,
         event_types_in_query={"Fmri", "Audio", "Word", "Text"},
         data_shape=(73, 90, 74, 283),

--- a/neuralfetch-repo/neuralfetch/studies/miltiadous2023dice.py
+++ b/neuralfetch-repo/neuralfetch/studies/miltiadous2023dice.py
@@ -79,6 +79,7 @@ class Miltiadous2023Dice(study.Study):
     _info: tp.ClassVar[study.StudyInfo] = study.StudyInfo(
         num_timelines=88,
         num_subjects=88,
+        size_bytes=2_829_897_704,  # OpenNeuro ds004504, on-disk
         num_events_in_query=1,
         event_types_in_query={"Eeg"},
         data_shape=(19, 299900),

--- a/neuralfetch-repo/neuralfetch/studies/shirazi2024hbn.py
+++ b/neuralfetch-repo/neuralfetch/studies/shirazi2024hbn.py
@@ -98,6 +98,7 @@ class Shirazi2024Hbn(study.Study):
     _info: tp.ClassVar[study.StudyInfo] = study.StudyInfo(
         num_timelines=26615,
         num_subjects=3146,
+        size_bytes=235_310_606_952,  # OpenNeuro ds005516, on-disk
         num_events_in_query=1,
         event_types_in_query={"Eeg"},
         data_shape=(129, 86151),

--- a/neuralset-repo/neuralset/events/study.py
+++ b/neuralset-repo/neuralset/events/study.py
@@ -180,6 +180,11 @@ class StudyInfo(base.BaseModel):
         The expected sampling frequency of the data, in Hz.
     fmri_spaces : tuple of str
         (fMRI only) The expected spatial reference spaces for the data.
+    size_bytes : int or None
+        Approximate on-disk size of the dataset after extraction, in bytes.
+        ``None`` (the default) means the size has not been measured yet, so
+        studies can be populated incrementally. Stored as raw bytes; formatted
+        to human-readable units (e.g. GB) only at render time.
     """
 
     model_config = pydantic.ConfigDict(extra="forbid")
@@ -193,6 +198,8 @@ class StudyInfo(base.BaseModel):
     frequency: float = 0.0
     # for FMRI only
     fmri_spaces: tuple[str, ...] | set[str] = ()
+    # on-disk size after extraction, in bytes; None = not yet measured
+    size_bytes: int | None = None
 
 
 # Lives here (not in transforms/) to avoid circular import: events → transforms → extractors


### PR DESCRIPTION
Closes #144.

## What

Adds an optional `size_bytes: int | None = None` field to `StudyInfo` and renders dataset size in the [Explore Brain Datasets](https://facebookresearch.github.io/neuroai/neuralfetch/index.html) explorer, so users can tell a laptop-friendly dataset from a multi-hundred-GB one before downloading.

## Changes

- **Data model** (`neuralset/events/study.py`): new `size_bytes` field — on-disk size after extraction, in bytes; `None` (default) means not yet measured. `extra="forbid"` is preserved and existing `_info` definitions are untouched.
- **Docs explorer** (`docs/scripts/build_study_explorer.py`): a "Size" column and a "total size" summary stat, byte→human formatting in both Python (`_format_size`) and JS (`formatBytes`), `data-size` attributes on table rows and scatter points, and a Size row in the study details panel. Unmeasured studies render as an em dash.
- **Seed batch** (`neuralfetch/studies/*.py`): populated the 9 OpenNeuro-backed datasets. Sizes come from the OpenNeuro GraphQL `latestSnapshot.size` (on-disk, matching the field's semantics). `*Sample` subclasses are left unmeasured.
- **Helper** (`docs/scripts/fetch_dataset_sizes.py`): a one-off script that scans the study modules for OpenNeuro accessions, queries their sizes, and prints paste-ready `size_bytes=` lines. Non-OpenNeuro hosts (Zenodo/Figshare/OSF/S3) are reported as unresolved for manual follow-up.

## Seeded values

| Study | OpenNeuro | Size |
|---|---|---|
| Bel2026PetitListen | ds007523 | 445 GB |
| Bel2026PetitRead | ds007524 | 299 GB |
| Chang2019Bold5000 | ds001499 | 77.3 GB |
| Grootswagers2022Human | ds003825 | 41.2 GB |
| Hebart2023ThingsBold | ds004192 | 98.5 GB |
| Hebart2023ThingsMeg | ds004212 | 238 GB |
| Li2022Petit | ds003643 | 144 GB |
| Miltiadous2023Dice | ds004504 | 2.6 GB |
| Shirazi2024Hbn | ds005516 | 219 GB |

## Open question for maintainers

This intentionally seeds only the OpenNeuro datasets, which have an authoritative size API. For the remaining hosts (Zenodo/Figshare/OSF/S3 — no uniform size endpoint), I'd appreciate guidance: query each host's file-listing API (compressed download size), or use `du` numbers from a benchmark run (on-disk). The scaffolding lands the column now; the rest can be filled in incrementally since the field defaults to `None`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)