### PR TITLE
Remove incorrect "32-channel EEG" comments on MEG/fMRI data_shape

### DIFF
--- a/neuralset-repo/neuralset/events/testing/mne2013sample.py
+++ b/neuralset-repo/neuralset/events/testing/mne2013sample.py
@@ -41,7 +41,7 @@ class Mne2013Sample(study.Study):
         num_subjects=1,
         num_events_in_query=289,
         event_types_in_query={"Meg", "Stimulus"},
-        data_shape=(306, 41700),  # 32-channel EEG
+        data_shape=(306, 41700),
         frequency=150.15,
     )
 
@@ -110,7 +110,7 @@ class Mne2013SampleEeg(Mne2013Sample):
         num_subjects=1,
         num_events_in_query=289,
         event_types_in_query={"Eeg", "Stimulus"},
-        data_shape=(60, 41700),  # 32-channel EEG
+        data_shape=(60, 41700),
         frequency=150.15,
     )
 
@@ -160,7 +160,7 @@ class Fake2025Meg(Mne2013Sample):
             "Word",
             "Sentence",
         },
-        data_shape=(306, 41700),  # 32-channel EEG
+        data_shape=(306, 41700),
         frequency=150.15,
     )
 

--- a/neuralset-repo/neuralset/events/testing/test2023fmri.py
+++ b/neuralset-repo/neuralset/events/testing/test2023fmri.py
@@ -26,7 +26,7 @@ class Test2023Fmri(study.Study):
         num_subjects=3,
         num_events_in_query=11,
         event_types_in_query={"Fmri", "Word"},
-        data_shape=(20, 20, 20, 10),  # 32-channel EEG
+        data_shape=(20, 20, 20, 10),
         frequency=0.5,
         fmri_spaces=("custom",),
     )
@@ -105,7 +105,7 @@ class Fake2025Fmri(study.Study):
         num_subjects=2,
         num_events_in_query=22,
         event_types_in_query={"Fmri", "Image", "Audio", "Text", "Word"},
-        data_shape=(91, 109, 91, 80),  # 32-channel EEG
+        data_shape=(91, 109, 91, 80),
         frequency=2,
         fmri_spaces=("custom",),
     )


### PR DESCRIPTION
## What

Removes a copy-paste comment artifact: `# 32-channel EEG` was attached to 5 `data_shape` declarations in `neuralset/events/testing/` where the data is **not** 32-channel EEG.

| File | `data_shape` | Actual modality |
|------|-------------|-----------------|
| `mne2013sample.py` (`Mne2013Sample`) | `(306, 41700)` | 306 MEG sensors × time |
| `mne2013sample.py` (`Mne2013SampleEeg`) | `(60, 41700)` | 60 EEG channels × time |
| `mne2013sample.py` (`Fake2025Meg`) | `(306, 41700)` | 306 MEG sensors × time |
| `test2023fmri.py` (`Test2023Fmri`) | `(20, 20, 20, 10)` | 4D fMRI volume |
| `test2023fmri.py` (`Fake2025Fmri`) | `(91, 109, 91, 80)` | 4D fMRI volume |

## Why remove rather than rewrite the comments

- `data_shape` is already the verified source of truth — `test_study_info` loads each study and asserts the computed shape matches the declared value. The comment carries no information the test doesn't already guarantee, which is exactly why it was free to drift into being wrong.
- The bare tuple is the project's de-facto convention: of 138 `data_shape=` lines, only 6 carry a trailing comment — and 5 of those are this artifact. Removing them aligns with the existing 132 uncommented lines.

## Scope

The one **correct** occurrence — `neuralfetch/studies/chen2023large.py` (genuinely 32-channel EEG) — is intentionally left untouched; it's in a different package and the comment is accurate.