### PR TITLE
fix(neuraltrain): declare exca as a runtime dependency

### DIFF
--- a/neuraltrain-repo/pyproject.toml
+++ b/neuraltrain-repo/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
   "scikit-learn>=0.21.2",
   "torch>=2.5.1",
   "torchvision>=0.20.1",
+  "exca>=0.5.20",
   "packaging",
   "pydantic>=2.5.0",
   "torchmetrics>=1.1.2",


### PR DESCRIPTION
## Problem

`neuraltrain` imports `exca` unconditionally at import time, but it's not declared in `neuraltrain-repo/pyproject.toml`. A standalone install is broken:

```bash
pip install 'neuraltrain[dev,lightning,models]'
python -c "import neuraltrain"
# ModuleNotFoundError: No module named 'exca'
```

This is what users following the [quickstart](https://facebookresearch.github.io/neuroai/neuraltrain/index.html) hit on a fresh env (e.g. Colab). exca is core, not optional — it backs `BaseLoss`, `BaseMetric`, `BaseOptimizer`, models, and `TaskInfra` (`losses/base.py`, `metrics/base.py`, `optimizers/base.py`, `models/base.py`, `utils.py`).

## Why CI didn't catch it

CI installs the whole workspace in one resolution pass, and `neuralset`'s `exca>=0.5.20` pulls exca into the shared venv. The wheel smoke test runs in that same populated venv, so `import neuraltrain` succeeds there too. The gap only shows when `neuraltrain` is installed alone.

## Fix

Declare `exca>=0.5.20` as a core dependency — matches neuralset's existing pin and stays above the `exca>=0.4.5` minimum already asserted in `neuraltrain/utils.py`.
