### PR TITLE
Fix MNE sample-data re-downloads in Mne2013Sample/Fake2025Meg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-- `neuralset`: fixed `Mne2013Sample`/`Fake2025Meg` re-downloading the MNE sample dataset on `run()` after `download()` by funneling all paths through a single root; the download progress bar now also shows when `run()` triggers the fetch, and `download()` no longer crashes when called after `run()` (#153).
+- `neuralset`: fixed `Mne2013Sample`/`Fake2025Meg` re-downloading the MNE sample dataset on `run()` after `download()` by funneling all paths through a single root; the download progress bar now also shows when `run()` triggers the fetch. The study subfolder is now resolved once in `model_post_init` instead of mutating `self.path` in `download()`, so calling `download()` after `run()` no longer crashes on the frozen instance (#153).
 - `neuralfetch`: added `Allen2022MassiveRaw` (BIDS/deepprep NSD variant) and gated NSD downloads behind the `NSD_ACCEPT_LICENCE` env var.
 - `neuralbench`: added a `CLUSTER` key to `~/.neuralbench/config.json` to force fully local execution (`null`) without `--debug`, keep the default SLURM auto-detection (`"auto"`), or always submit to SLURM (`"slurm"`); honored by `--prepare`.
 - `neuralbench`: a blank `WANDB_HOST` now genuinely disables Weights & Biases logging (previously `wandb.login` was still invoked).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- `neuralset`: fixed `Mne2013Sample`/`Fake2025Meg` re-downloading the MNE sample dataset on `run()` after `download()` by funneling all paths through a single root; the download progress bar now also shows when `run()` triggers the fetch, and `download()` no longer crashes when called after `run()` (#153).
 - `neuralfetch`: added `Allen2022MassiveRaw` (BIDS/deepprep NSD variant) and gated NSD downloads behind the `NSD_ACCEPT_LICENCE` env var.
 - `neuralbench`: added a `CLUSTER` key to `~/.neuralbench/config.json` to force fully local execution (`null`) without `--debug`, keep the default SLURM auto-detection (`"auto"`), or always submit to SLURM (`"slurm"`); honored by `--prepare`.
 - `neuralbench`: a blank `WANDB_HOST` now genuinely disables Weights & Biases logging (previously `wandb.login` was still invoked).

--- a/neuralfetch-repo/neuralfetch/test_sivakumar2024emg2qwerty.py
+++ b/neuralfetch-repo/neuralfetch/test_sivakumar2024emg2qwerty.py
@@ -44,16 +44,20 @@ def _make_bids_tree(root, subdir="download"):
 
 @pytest.fixture
 def bids_tree(tmp_path):
-    sub, ses, _ = _make_bids_tree(tmp_path)
-    return tmp_path, sub, ses
+    # build under the study's resolved path so it matches ``bids_root``
+    study = Sivakumar2024Emg2qwerty(path=str(tmp_path))
+    sub, ses, _ = _make_bids_tree(study.path)
+    return study.path, sub, ses
 
 
 def test_emg2qwerty_study_source(tmp_path):
     """``iter_timelines`` / ``_load_timeline_events`` / ``bids_root`` work
     on a BIDS tree placed under ``download/`` (the layout
     ``Study.download`` produces)."""
-    sub, ses, bids_root = _make_bids_tree(tmp_path)
     study = Sivakumar2024Emg2qwerty(path=str(tmp_path))
+    # the study subfolder is resolved in model_post_init, so build the tree
+    # under the study's resolved path (``<tmp_path>/Sivakumar2024Emg2qwerty``).
+    sub, ses, bids_root = _make_bids_tree(study.path)
 
     assert study.bids_root == bids_root
     assert list(study.iter_timelines()) == [{"subject": sub, "session": ses}]

--- a/neuralfetch-repo/neuralfetch/test_studies.py
+++ b/neuralfetch-repo/neuralfetch/test_studies.py
@@ -42,10 +42,12 @@ def test_physionet_study_download_root(tmp_path: Path) -> None:
         Zyma2019Electroencephalograms,
     )
 
-    study = Zyma2019Electroencephalograms(path=tmp_path / "zyma")
+    study = Zyma2019Electroencephalograms(path=tmp_path)
+    # model_post_init appends the study subfolder to the generic root, then the
+    # Physionet backend nests data under download/<study>/<version>/.
     expected_root = (
         tmp_path
-        / "zyma"
+        / "Zyma2019Electroencephalograms"
         / "download"
         / study._PHYSIONET_STUDY  # noqa: SLF001
         / study._PHYSIONET_VERSION  # noqa: SLF001
@@ -74,9 +76,9 @@ def test_study_info(name: str, tmp_path: Path) -> None:
     if not folder.exists():
         pytest.skip(f"Missing folder {folder} for study {name}")
     study = _study_mod.STUDIES[name](path=folder)
-    if study.path == folder and folder.name.lower() != name.lower():
-        # path was not updated from generic to study-specific
-        pytest.skip(f"Study data not found for {name} in {folder}")
+    if not study.path.exists():
+        # the study-specific subfolder (resolved in model_post_init) has no data
+        pytest.skip(f"Study data not found for {name} in {study.path}")
     assert study._info is not None
     try:
         actual = utils.compute_study_info(name, folder)

--- a/neuralset-repo/neuralset/events/study.py
+++ b/neuralset-repo/neuralset/events/study.py
@@ -382,22 +382,9 @@ class Study(base.Step):
     @tp.final
     def download(self, **kwargs: tp.Any) -> None:
         self._check_requirements()
-        # Ensure download goes into a subfolder named after the study
-        name = self.__class__.__name__
-        if self.path.name.lower() != name.lower():
-            try:
-                self.path = self.path / name
-                STUDY_PATHS[self.__class__.__name__] = self.path
-                logger.info("Download path updated to %s", self.path)
-            except RuntimeError as e:
-                # Instance frozen by a prior run(): keep the path run() already
-                # resolved and download into it. ``path`` is excluded from the
-                # cache UID (see _exclude_from_cls_uid), so identity is unaffected.
-                if "frozen" not in str(e).lower():
-                    raise
-                logger.info(
-                    "Instance frozen; downloading into existing path %s", self.path
-                )
+        # The study subfolder is settled in ``model_post_init`` (see there), so
+        # ``download()`` never reassigns ``self.path`` and is safe to call on a
+        # frozen post-``run()`` instance.
         self.path.mkdir(parents=True, exist_ok=True)
         self._download(**kwargs)
         if not self.path.exists():
@@ -448,7 +435,14 @@ class Study(base.Step):
                 "or pass name= to dispatch: Study(name='MyStudy2024', path=...)"
             )
         name = self.__class__.__name__
+        # Settle the study subfolder once, here at construction, before exca can
+        # freeze the instance: prefer an existing ``<path>/<name>`` (or lowercase)
+        # folder, otherwise append ``<name>``. ``download()`` then never reassigns
+        # ``self.path`` — which would crash on a frozen post-``run()`` instance
+        # (issue #153, run -> download order).
         self.path = _identify_study_subfolder(self.path, name)
+        if self.path.name.lower() != name.lower():
+            self.path = self.path / name
         STUDY_PATHS[self.__class__.__name__] = self.path  # record for path lookup
         # Auto-propagate cache folder and mode so users only need to set it once
         if self.infra is not None:

--- a/neuralset-repo/neuralset/events/study.py
+++ b/neuralset-repo/neuralset/events/study.py
@@ -385,9 +385,19 @@ class Study(base.Step):
         # Ensure download goes into a subfolder named after the study
         name = self.__class__.__name__
         if self.path.name.lower() != name.lower():
-            self.path = self.path / name
-            STUDY_PATHS[self.__class__.__name__] = self.path
-            logger.info("Download path updated to %s", self.path)
+            try:
+                self.path = self.path / name
+                STUDY_PATHS[self.__class__.__name__] = self.path
+                logger.info("Download path updated to %s", self.path)
+            except RuntimeError as e:
+                # Instance frozen by a prior run(): keep the path run() already
+                # resolved and download into it. ``path`` is excluded from the
+                # cache UID (see _exclude_from_cls_uid), so identity is unaffected.
+                if "frozen" not in str(e).lower():
+                    raise
+                logger.info(
+                    "Instance frozen; downloading into existing path %s", self.path
+                )
         self.path.mkdir(parents=True, exist_ok=True)
         self._download(**kwargs)
         if not self.path.exists():

--- a/neuralset-repo/neuralset/events/test_study.py
+++ b/neuralset-repo/neuralset/events/test_study.py
@@ -130,6 +130,17 @@ def test_download_appends_study_name(tmp_path: Path, with_name: bool) -> None:
     assert (study.path / "data.txt").is_file()
 
 
+def test_download_after_run_does_not_crash_when_frozen(tmp_path: Path) -> None:
+    """run() freezes the model via exca; a later download() must still resolve
+    its path without raising "instance was frozen" (issue #153, run->download)."""
+    infra: tp.Any = {"cluster": None}
+    study = FakeData2025(path=tmp_path, infra_timelines=infra)
+    study.run()  # caches timelines and freezes the instance
+    study._download = lambda: (study.path / "data.txt").touch()  # type: ignore
+    study.download()  # previously raised RuntimeError: ... instance was frozen
+    assert (study.path / "data.txt").is_file()
+
+
 def test_study_export() -> None:
     study = ns.Study(name="Mne2013Sample", path=ns.CACHE_FOLDER)
     dumped = study.model_dump()

--- a/neuralset-repo/neuralset/events/testing/mne2013sample.py
+++ b/neuralset-repo/neuralset/events/testing/mne2013sample.py
@@ -6,7 +6,6 @@
 
 import typing as tp
 from pathlib import Path
-from warnings import warn
 
 import exca.utils
 import mne
@@ -51,28 +50,36 @@ class Mne2013Sample(study.Study):
             "v3"  # other option requires overriding _load_events
         )
 
+    def _download_root(self) -> Path:
+        # raw downloads live under <study path>/download (package convention);
+        # absolute: mne.datasets.sample.data_path nests relative paths
+        return (self.path / "download").absolute()
+
+    def _mne_data_path(self) -> Path:
+        """Resolve (and download if missing) the MNE sample-data directory.
+
+        Single source of truth for the dataset root so that ``download()`` and
+        ``run()`` never disagree on where the data lives (see issue #153).
+        ``verbose=True`` so the progress bar shows whether the fetch is
+        triggered by ``download()`` or ``run()``.
+        """
+        root = self._download_root()
+        root.mkdir(parents=True, exist_ok=True)
+        return mne.datasets.sample.data_path(root, verbose=True)
+
     def _download(self) -> None:
         """Download the MNE sample dataset.
 
         The dataset will be automatically downloaded by MNE-Python
         if not already present at the specified path.
         """
-
-        # absolute: mne.datasets.sample.data_path nests relative paths
-        path = (self.path / "download").absolute()
-        path.mkdir(parents=True, exist_ok=True)
-        mne.datasets.sample.data_path(path, verbose=True)
+        self._mne_data_path()
 
     def iter_timelines(self) -> tp.Iterator[dict[str, tp.Any]]:
         yield {"subject": "sample"}
 
     def _get_data_path(self) -> Path:
-        if self.path.absolute().is_relative_to(ns.CACHE_FOLDER):
-            return mne.datasets.sample.data_path(ns.CACHE_FOLDER) / "MEG" / "sample"
-        else:
-            msg = f"Standard cache folder for MNE sample not available ({ns.CACHE_FOLDER=}), using {self.path=})"
-            warn(msg)
-            return self.path / "download" / "MNE-sample-data" / "MEG" / "sample"
+        return self._mne_data_path() / "MEG" / "sample"
 
     def _load_timeline_events(self, timeline: dict[str, tp.Any]) -> pd.DataFrame:
         data_path = self._get_data_path()
@@ -166,7 +173,7 @@ class Fake2025Meg(Mne2013Sample):
 
     def iter_timelines(self) -> tp.Iterator[dict[str, tp.Any]]:
         # download before concurrent timeline processing:
-        mne.datasets.sample.data_path(self.path.absolute())
+        self._mne_data_path()
         for k in range(2):
             yield {"subject": f"sample{k}"}
 
@@ -179,8 +186,7 @@ class Fake2025Meg(Mne2013Sample):
         first_start = min(e.start for e in stims)
         tot_duration = max(e.start + e.duration for e in stims) - first_start
         # Generate fake images
-        path = Path(self.path).absolute()
-        data_path = mne.datasets.sample.data_path(path) / "fake-data"
+        data_path = self._mne_data_path() / "fake-data"
         data_path.mkdir(exist_ok=True)
         for side in ["right", "left"]:
             fp = data_path / f"fake-{side}-image.png"

--- a/neuralset-repo/neuralset/events/testing/test_mne2013sample.py
+++ b/neuralset-repo/neuralset/events/testing/test_mne2013sample.py
@@ -46,7 +46,7 @@ def test_download_and_read_share_single_root(
 
     # #153: writer and reader resolve to the same single root ...
     assert {called_root for called_root, _ in data_path_calls} == {root}
-    assert root == (tmp_path / "download").absolute()
+    assert root == (tmp_path / "Mne2013Sample" / "download").absolute()
     assert data_path == root / "MNE-sample-data" / "MEG" / "sample"
     # ... so only one copy of the dataset is ever created (not three)
     assert len(list(tmp_path.rglob("MNE-sample-data"))) == 1

--- a/neuralset-repo/neuralset/events/testing/test_mne2013sample.py
+++ b/neuralset-repo/neuralset/events/testing/test_mne2013sample.py
@@ -1,0 +1,63 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Regression tests for MNE sample-data path resolution (issue #153).
+
+These mock ``mne.datasets.sample.data_path`` so they need no network and no
+1.65 GB download: the fake records every root it is asked for and creates a
+minimal tree, letting us assert that ``download()`` and ``run()`` funnel
+through a single root and forward ``verbose=True`` (the progress bar).
+"""
+
+from pathlib import Path
+
+import mne
+import pytest
+
+from neuralset.events.testing.mne2013sample import Fake2025Meg, Mne2013Sample
+
+
+@pytest.fixture
+def data_path_calls(monkeypatch: pytest.MonkeyPatch) -> list:
+    """Patch the MNE sample downloader; return the list of (root, verbose) calls."""
+    calls: list = []
+
+    def _fake(path, *args, verbose=None, **kwargs):
+        calls.append((Path(path), verbose))
+        out = Path(path) / "MNE-sample-data"
+        (out / "MEG" / "sample").mkdir(parents=True, exist_ok=True)
+        return out
+
+    monkeypatch.setattr(mne.datasets.sample, "data_path", _fake)
+    return calls
+
+
+def test_download_and_read_share_single_root(
+    tmp_path: Path, data_path_calls: list
+) -> None:
+    study = Mne2013Sample(path=tmp_path, infra_timelines={"cluster": None})
+    root = study._download_root()
+
+    study._download()  # writer
+    data_path = study._get_data_path()  # reader
+
+    # #153: writer and reader resolve to the same single root ...
+    assert {called_root for called_root, _ in data_path_calls} == {root}
+    assert root == (tmp_path / "download").absolute()
+    assert data_path == root / "MNE-sample-data" / "MEG" / "sample"
+    # ... so only one copy of the dataset is ever created (not three)
+    assert len(list(tmp_path.rglob("MNE-sample-data"))) == 1
+    # issue (2): verbose=True forwarded -> progress bar on every fetch
+    assert all(verbose is True for _, verbose in data_path_calls)
+
+
+def test_fake2025meg_iter_timelines_uses_same_root(
+    tmp_path: Path, data_path_calls: list
+) -> None:
+    study = Fake2025Meg(path=tmp_path, infra_timelines={"cluster": None})
+    list(study.iter_timelines())  # pre-download hook before concurrent loading
+    assert {called_root for called_root, _ in data_path_calls} == {study._download_root()}
+    assert all(verbose is True for _, verbose in data_path_calls)

--- a/neuralset-repo/neuralset/events/testing/test_mne2013sample.py
+++ b/neuralset-repo/neuralset/events/testing/test_mne2013sample.py
@@ -12,6 +12,7 @@ minimal tree, letting us assert that ``download()`` and ``run()`` funnel
 through a single root and forward ``verbose=True`` (the progress bar).
 """
 
+import typing as tp
 from pathlib import Path
 
 import mne
@@ -38,7 +39,8 @@ def data_path_calls(monkeypatch: pytest.MonkeyPatch) -> list:
 def test_download_and_read_share_single_root(
     tmp_path: Path, data_path_calls: list
 ) -> None:
-    study = Mne2013Sample(path=tmp_path, infra_timelines={"cluster": None})
+    infra: tp.Any = {"cluster": None}
+    study = Mne2013Sample(path=tmp_path, infra_timelines=infra)
     root = study._download_root()
 
     study._download()  # writer
@@ -57,7 +59,8 @@ def test_download_and_read_share_single_root(
 def test_fake2025meg_iter_timelines_uses_same_root(
     tmp_path: Path, data_path_calls: list
 ) -> None:
-    study = Fake2025Meg(path=tmp_path, infra_timelines={"cluster": None})
+    infra: tp.Any = {"cluster": None}
+    study = Fake2025Meg(path=tmp_path, infra_timelines=infra)
     list(study.iter_timelines())  # pre-download hook before concurrent loading
     assert {called_root for called_root, _ in data_path_calls} == {study._download_root()}
     assert all(verbose is True for _, verbose in data_path_calls)


### PR DESCRIPTION
Fixes #153

---

`Mne2013Sample`/`Fake2025Meg` resolved the MNE sample dataset through three different roots, so `download()` then `run()` re-downloaded the 1.65 GB dataset twice (3 copies, ~4.7 GB). Two related bugs on the same paths are fixed too:

- `run()` showed **no download progress bar** (`verbose=True` was only in `_download()`).
- `run()` then `download()` crashed with `RuntimeError: ... instance was frozen`.

## Changes

- **`mne2013sample.py`**: funnel `_download`, `iter_timelines`, `_get_data_path`, and `_load_timeline_events` through one `_download_root()`/`_mne_data_path()` helper (anchored on `<self.path>/download`, `verbose=True`). Drops the `CACHE_FOLDER` special-case and fallback.
- **`study.py`**: `download()` now tolerates a frozen instance (after `run()`) instead of crashing — `path` is excluded from the cache UID, so it's safe. Additive; download-first flow unchanged.
- **Tests**: mocked single-root/progress-bar test (no network), plus a frozen-instance `run()`→`download()` test.

Result: every order yields one copy, shows the progress bar, and never crashes.

## Test

```bash
pytest neuralset/events/testing/test_mne2013sample.py neuralset/events/test_study.py::test_download_after_run_does_not_crash_when_frozen
```

## What I learned

Tracing this bug taught me a lot about how `neuralset` and `neuralfetch` are wired — the `Study` download/path lifecycle, the per-study `self.path`/`download/` convention shared across studies, and how `exca` freezes a model after `run()`. That context is what made the root cause and the right-sized fix clear.