### PR TITLE
chore: hoist core stdlib imports to module level

### DIFF
--- a/neuralbench-repo/neuralbench/cli.py
+++ b/neuralbench-repo/neuralbench/cli.py
@@ -14,6 +14,7 @@ config assembly are delegated to :mod:`neuralbench.registry` and
 
 import argparse
 import logging
+import os
 import sys
 import traceback
 import typing as tp
@@ -196,8 +197,6 @@ def run_benchmark(
         return []
 
     if plot_cached:
-        import os
-
         os.environ["CUDA_VISIBLE_DEVICES"] = ""
 
     from neuralbench.main import BenchmarkAggregator

--- a/neuralbench-repo/neuralbench/config_manager.py
+++ b/neuralbench-repo/neuralbench/config_manager.py
@@ -8,6 +8,7 @@ import getpass
 import json
 import os
 import sys
+import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -144,8 +145,6 @@ def setup_config(config_path: Path | None = None) -> dict[str, Any]:
 
 def _default_config() -> dict[str, Any]:
     """Return a minimal config with temporary paths for non-interactive use."""
-    import tempfile
-
     base = Path(tempfile.gettempdir()) / "neuralbench"
     username = getpass.getuser()
     config = {

--- a/neuralbench-repo/neuralbench/experiment_config.py
+++ b/neuralbench-repo/neuralbench/experiment_config.py
@@ -11,6 +11,8 @@ configs ready for ``BenchmarkAggregator``.
 """
 
 import logging
+import os
+import shutil
 from itertools import product
 from pathlib import Path
 from warnings import warn
@@ -264,9 +266,6 @@ def _warn_slurm_partition(
     warning surfaces the resolved config path, honoring the
     ``NEURALBENCH_CONFIG`` environment variable.
     """
-    import os
-    import shutil
-
     from neuralbench.config_manager import get_default_config_path
 
     if debug or prepare or download:

--- a/neuralfetch-repo/neuralfetch/download.py
+++ b/neuralfetch-repo/neuralfetch/download.py
@@ -750,8 +750,6 @@ class Dryad(BaseDownload):
         return files_resp.get("_embedded", {}).get("stash:files", [])
 
     def _download(self) -> None:
-        import tempfile
-        import zipfile
         from urllib.parse import quote
 
         import requests as req

--- a/neuralfetch-repo/neuralfetch/test_utils.py
+++ b/neuralfetch-repo/neuralfetch/test_utils.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 
+import os
 from pathlib import Path
 
 import pandas as pd
@@ -44,8 +45,6 @@ def test_add_sentences() -> None:
 
 def test_download_things_images_missing_password_raises(tmp_path: Path) -> None:
     """download_things_images raises RuntimeError when images absent and no password."""
-    import os
-
     from neuralfetch.utils import download_things_images
 
     old_val = os.environ.pop("NEURALFETCH_THINGS_PASSWORD", None)

--- a/neuraltrain-repo/neuraltrain/models/base.py
+++ b/neuraltrain-repo/neuraltrain/models/base.py
@@ -6,6 +6,7 @@
 
 """Pydantic configurations for models."""
 
+import importlib
 import typing as tp
 
 import pydantic
@@ -65,8 +66,6 @@ class BaseBrainDecodeModel(BaseModelConfig):
             raise RuntimeError(
                 f"{cls.__name__} has neither `_MODEL_CLASS` nor `_MODEL_CLASS_PATH` set."
             )
-        import importlib
-
         module_name, attr = cls._MODEL_CLASS_PATH.rsplit(".", 1)
         cls._MODEL_CLASS = getattr(importlib.import_module(module_name), attr)
 


### PR DESCRIPTION
Ref: https://github.com/facebookresearch/neuroai/pull/148#discussion_r3405652116

---

Moves a handful of stdlib imports (`os`, `shutil`, `tempfile`, `zipfile`, `importlib`) from inside function bodies up to module level, following the review note that core dependencies belong at the top. These are stdlib modules with no import cost, side effects, or circular-import risk, so deferring them bought nothing. In `download.py`, `tempfile`/`zipfile` were already imported at the top — the inline versions were just redundant re-imports.

Deliberate lazy imports (heavy/optional deps like torch and plotly, circular-import breakers, and the debug-only `pdb` import) are left as-is.
