### PR TITLE
Remove duplicate _get_max_length method in HuggingFaceText

### DIFF
--- a/neuralset-repo/neuralset/extractors/text.py
+++ b/neuralset-repo/neuralset/extractors/text.py
@@ -364,24 +364,6 @@ class HuggingFaceText(BaseStatic, HuggingFaceMixin):
                 return self._max_length
         return None
 
-    def _get_max_length(self) -> int | None:
-        """Token truncation limit, falling back to the model's positional capacity."""
-        if self._max_length is not None:
-            return self._max_length
-        tok_max = self.tokenizer.model_max_length
-        # HF "infinite" sentinel (~1e30) would disable truncation (overflows OPT)
-        if isinstance(tok_max, int) and tok_max < int(1e29):
-            self._max_length = tok_max
-            return self._max_length
-        # learned-position table is sized capacity + offset, so the offset cancels
-        config = self.model.config
-        for attr in ("max_position_embeddings", "n_positions", "n_ctx"):
-            value = getattr(config, attr, None)
-            if isinstance(value, int) and value > 0:
-                self._max_length = value
-                return self._max_length
-        return None
-
     def _get_timed_arrays(
         self,
         events: list[_ev.etypes.Word | _ev.etypes.Sentence],


### PR DESCRIPTION
## What

Removes a duplicated `_get_max_length` definition in `HuggingFaceText` (`neuralset-repo/neuralset/extractors/text.py`). The method was defined twice with byte-identical bodies.

## Why

Python keeps only the second definition, so the first was dead code. It slipped in via PR #147 and isn't caught by linting: ruff (F811) and pylint (E0102) both skip redefinitions of underscore-prefixed names by default.

## Change

- Deleted the first of the two identical definitions (18 lines).
- No behavior change: the surviving method is identical, and the sole call site (`_get_data`) is untouched.