### PR TITLE
fix(neuralset): merge spaCy contraction splits in TextWordMatcher

### DIFF
--- a/neuralset-repo/neuralset/events/transforms/test_transforms.py
+++ b/neuralset-repo/neuralset/events/transforms/test_transforms.py
@@ -474,6 +474,26 @@ def test_contraction_before_homograph() -> None:
     assert all(i for i in info)
 
 
+def test_french_elision_before_homograph() -> None:
+    """French elisions split by spaCy must not steal the following homograph."""
+    text = "s'il dit il souvent."
+    words = ["s'il", "dit", "il", "souvent"]
+    info = _tutils.TextWordMatcher(text, language="french").match(words)
+    assert info[0]["text_char"] == text.index("s'il")
+    assert info[0]["sentence_char"] == 0
+    assert info[2]["text_char"] == text.index("il", text.index("dit") + len("dit"))
+    assert all(i for i in info)
+
+
+def test_french_elision_word() -> None:
+    text = "froid d'hiver"
+    words = ["froid", "d'hiver"]
+    info = _tutils.TextWordMatcher(text, language="french").match(words)
+    assert info[1]["text_char"] == text.index("d'hiver")
+    assert info[1]["sentence_char"] == 6
+    assert all(i for i in info)
+
+
 def test_duplicate_full_pipeline(recwarn: pytest.WarningsRecorder) -> None:
     # try full pipeline as one transform:
     df = _make_test_dataframe(duplicate=2)

--- a/neuralset-repo/neuralset/events/transforms/test_transforms.py
+++ b/neuralset-repo/neuralset/events/transforms/test_transforms.py
@@ -449,6 +449,31 @@ def test_gap_punctuated_word_offset() -> None:
     assert info[2].get("text_char") == 11
 
 
+def test_contraction_before_homograph() -> None:
+    """Contractions split by spaCy must not steal the following homograph."""
+    text = "take my advice: examine him carefully. don't do it before us."
+    words = [
+        "take",
+        "my",
+        "advice",
+        "examine",
+        "him",
+        "carefully",
+        "don't",
+        "do",
+        "it",
+        "before",
+        "us",
+    ]
+    info = _tutils.TextWordMatcher(text, language="english").match(words)
+    assert info[6]["text_char"] == text.index("don't")
+    assert info[6]["sentence"] == "don't do it before us."
+    assert info[6]["sentence_char"] == 0
+    assert info[7]["text_char"] == text.index("do", text.index("don't") + 1)
+    assert info[7]["sentence_char"] == 9
+    assert all(i for i in info)
+
+
 def test_duplicate_full_pipeline(recwarn: pytest.WarningsRecorder) -> None:
     # try full pipeline as one transform:
     df = _make_test_dataframe(duplicate=2)

--- a/neuralset-repo/neuralset/events/transforms/test_transforms.py
+++ b/neuralset-repo/neuralset/events/transforms/test_transforms.py
@@ -470,27 +470,7 @@ def test_contraction_before_homograph() -> None:
     assert info[6]["sentence"] == "don't do it before us."
     assert info[6]["sentence_char"] == 0
     assert info[7]["text_char"] == text.index("do", text.index("don't") + 1)
-    assert info[7]["sentence_char"] == 9
-    assert all(i for i in info)
-
-
-def test_french_elision_before_homograph() -> None:
-    """French elisions split by spaCy must not steal the following homograph."""
-    text = "s'il dit il souvent."
-    words = ["s'il", "dit", "il", "souvent"]
-    info = _tutils.TextWordMatcher(text, language="french").match(words)
-    assert info[0]["text_char"] == text.index("s'il")
-    assert info[0]["sentence_char"] == 0
-    assert info[2]["text_char"] == text.index("il", text.index("dit") + len("dit"))
-    assert all(i for i in info)
-
-
-def test_french_elision_word() -> None:
-    text = "froid d'hiver"
-    words = ["froid", "d'hiver"]
-    info = _tutils.TextWordMatcher(text, language="french").match(words)
-    assert info[1]["text_char"] == text.index("d'hiver")
-    assert info[1]["sentence_char"] == 6
+    assert info[7]["sentence_char"] == 6
     assert all(i for i in info)
 
 

--- a/neuralset-repo/neuralset/events/transforms/utils.py
+++ b/neuralset-repo/neuralset/events/transforms/utils.py
@@ -101,6 +101,13 @@ def _normalize_with_positions(text: str) -> tuple[str, list[int]]:
     return "".join(out), orig
 
 
+@dataclass(frozen=True)
+class _TokenSpan:
+    text: str
+    idx: int
+    sent: tp.Any
+
+
 class TextWordMatcher:
     """Match annotated words to character positions in a spaCy-parsed text.
 
@@ -114,11 +121,37 @@ class TextWordMatcher:
     """
 
     _PUNCT_RE = re.compile(r"^[\W_]+|[\W_]+$", re.UNICODE)
+    _CONTRACTION_SUFFIX_RE = re.compile(r"^(?:n't|'re|'ve|'ll|'d|'m)$")
 
     def __init__(self, text: str, language: str = "") -> None:
         self.doc = parse_text(text, language=language)
         self.text = text
-        self.tokens: list[tp.Any] = [tok for sent in self.doc.sents for tok in sent]
+        self.tokens = self._merge_contraction_tokens(
+            [tok for sent in self.doc.sents for tok in sent]
+        )
+
+    @classmethod
+    def _merge_contraction_tokens(cls, tokens: list[tp.Any]) -> list[tp.Any]:
+        """Merge spaCy splits like ``do`` + ``n't`` into a single ``don't`` token."""
+        if not tokens:
+            return tokens
+        merged: list[tp.Any] = []
+        i = 0
+        while i < len(tokens):
+            tok = tokens[i]
+            if (
+                i + 1 < len(tokens)
+                and cls._CONTRACTION_SUFFIX_RE.match(tokens[i + 1].text)
+            ):
+                nxt = tokens[i + 1]
+                merged.append(
+                    _TokenSpan(text=tok.text + nxt.text, idx=tok.idx, sent=tok.sent)
+                )
+                i += 2
+            else:
+                merged.append(tok)
+                i += 1
+        return merged
 
     @staticmethod
     def normalize(word: str) -> str:

--- a/neuralset-repo/neuralset/events/transforms/utils.py
+++ b/neuralset-repo/neuralset/events/transforms/utils.py
@@ -155,17 +155,13 @@ class TextWordMatcher:
                 nxt = tokens[i + 1]
                 if "en" in kinds and self._CONTRACTION_SUFFIX_RE.match(nxt.text):
                     merged.append(
-                        _TokenSpan(
-                            text=tok.text + nxt.text, idx=tok.idx, sent=tok.sent
-                        )
+                        _TokenSpan(text=tok.text + nxt.text, idx=tok.idx, sent=tok.sent)
                     )
                     i += 2
                     continue
                 if "fr" in kinds and self._FR_ELISION_PREFIX_RE.match(tok.text):
                     merged.append(
-                        _TokenSpan(
-                            text=tok.text + nxt.text, idx=tok.idx, sent=tok.sent
-                        )
+                        _TokenSpan(text=tok.text + nxt.text, idx=tok.idx, sent=tok.sent)
                     )
                     i += 2
                     continue

--- a/neuralset-repo/neuralset/events/transforms/utils.py
+++ b/neuralset-repo/neuralset/events/transforms/utils.py
@@ -122,35 +122,55 @@ class TextWordMatcher:
 
     _PUNCT_RE = re.compile(r"^[\W_]+|[\W_]+$", re.UNICODE)
     _CONTRACTION_SUFFIX_RE = re.compile(r"^(?:n't|'re|'ve|'ll|'d|'m)$")
+    _FR_ELISION_PREFIX_RE = re.compile(r"^(?:qu|[jldsmntc])'$", re.IGNORECASE)
 
     def __init__(self, text: str, language: str = "") -> None:
+        self.language = language
         self.doc = parse_text(text, language=language)
         self.text = text
         self.tokens = self._merge_contraction_tokens(
             [tok for sent in self.doc.sents for tok in sent]
         )
 
-    @classmethod
-    def _merge_contraction_tokens(cls, tokens: list[tp.Any]) -> list[tp.Any]:
-        """Merge spaCy splits like ``do`` + ``n't`` into a single ``don't`` token."""
+    def _apostrophe_merge_kinds(self) -> frozenset[str]:
+        lang = self.language.lower()
+        if lang in ("french", "fr"):
+            return frozenset({"fr"})
+        return frozenset({"en"})
+
+    def _merge_contraction_tokens(self, tokens: list[tp.Any]) -> list[tp.Any]:
+        """Merge spaCy apostrophe splits before token alignment.
+
+        English: suffix tokens such as ``do`` + ``n't`` → ``don't``.
+        French: elision prefixes such as ``d'`` + ``hiver`` → ``d'hiver``.
+        """
         if not tokens:
             return tokens
+        kinds = self._apostrophe_merge_kinds()
         merged: list[tp.Any] = []
         i = 0
         while i < len(tokens):
             tok = tokens[i]
-            if (
-                i + 1 < len(tokens)
-                and cls._CONTRACTION_SUFFIX_RE.match(tokens[i + 1].text)
-            ):
+            if i + 1 < len(tokens):
                 nxt = tokens[i + 1]
-                merged.append(
-                    _TokenSpan(text=tok.text + nxt.text, idx=tok.idx, sent=tok.sent)
-                )
-                i += 2
-            else:
-                merged.append(tok)
-                i += 1
+                if "en" in kinds and self._CONTRACTION_SUFFIX_RE.match(nxt.text):
+                    merged.append(
+                        _TokenSpan(
+                            text=tok.text + nxt.text, idx=tok.idx, sent=tok.sent
+                        )
+                    )
+                    i += 2
+                    continue
+                if "fr" in kinds and self._FR_ELISION_PREFIX_RE.match(tok.text):
+                    merged.append(
+                        _TokenSpan(
+                            text=tok.text + nxt.text, idx=tok.idx, sent=tok.sent
+                        )
+                    )
+                    i += 2
+                    continue
+            merged.append(tok)
+            i += 1
         return merged
 
     @staticmethod


### PR DESCRIPTION
## Summary

Fixes #139.

SpaCy splits apostrophe-bearing words into multiple tokens, which breaks token-level alignment in `TextWordMatcher` when the stem is also a standalone word (e.g. English `don't` + `do`, French `s'` + `il`).

This PR merges those splits **before** alignment, scoped by language as discussed on the issue:

- **English** (`language="english"` / default): suffix tokens (`n't`, `'re`, `'ve`, `'ll`, `'d`, `'m`) merged with the preceding token.
- **French** (`language="french"`): elision prefixes (`l'`, `d'`, `s'`, `j'`, `m'`, `t'`, `n'`, `c'`, `qu'`) merged with the following token.

## Test plan

- [x] `test_contraction_before_homograph` — reproducer from #139 (`don't do`)