### PR TITLE
ci: pull CPU-only torch wheels on GPU-less runners

### DIFF
--- a/.github/actions/setup-python-env/action.yml
+++ b/.github/actions/setup-python-env/action.yml
@@ -62,6 +62,12 @@ runs:
       shell: bash
       # All editables in a single resolution pass. transformers pinned
       # because neuralset's tests target 4.41.0 (pyproject leaves it open).
+      env:
+        # GPU-less runners: fetch CPU-only torch/torchvision/torchaudio wheels
+        # instead of the default CUDA builds (~5 GB of unused CUDA libs that also
+        # inflate every monthly .venv cache upload/restore). Scoped to CI here,
+        # not the pyprojects, so GPU users (neuralbench sm_60) are unaffected.
+        UV_TORCH_BACKEND: cpu
       run: |
         source .venv/bin/activate
         uv pip install \


### PR DESCRIPTION
## What

Add `UV_TORCH_BACKEND: cpu` to the `Install / sync packages` step in `.github/actions/setup-python-env/action.yml` so CI installs CPU-only `torch`/`torchvision`/`torchaudio`.

## Why

CI installs torch via `uv` on **GPU-less** `8-core-ubuntu` runners with no CPU pin. torch comes from the sub-project pyprojects (`torch>=2.5.1` in neuralset/neuraltrain, the `all` extra adding torchvision/torchaudio; `torch==2.6` in neuralbench). With no backend hint, `uv` resolves the **CUDA** builds and pulls ~5 GB of CUDA libraries that never run. The cost is paid twice: on every install, and again on every monthly `.venv` cache upload/restore (already 5-6 GB).

## Fix

The composite action's install step is the single chokepoint — every env-using job (`test-neuralset`, `test-downstream`, `typecheck`, `build-docs`) calls it. One env var fixes all four.

Scoped to CI, **not** the pyprojects: `neuralbench` pins torch for `CUDA capability sm_60`, so GPU users must stay on CUDA builds. The env var only affects this workflow.

## Notes

`UV_TORCH_BACKEND` requires `uv >= 0.6.0`. `setup-uv@v4` is unpinned and defaults to latest, so this works today; pinning `uv < 0.6.0` would silently no-op it.

YAML validated; no change to local/GPU installs.