### PR TITLE
Honor FmriCleaner.ensure_finite when other cleaning options are disabled

### DIFF
--- a/neuralset-repo/neuralset/extractors/neuro.py
+++ b/neuralset-repo/neuralset/extractors/neuro.py
@@ -1074,7 +1074,7 @@ class FmriCleaner(pydantic.BaseModel):
     filter: tp.Literal["butterworth", "cosine"] | None
         Filter to use: "butterworth" or "cosine".
     ensure_finite: bool
-        Whether to set nans to 0.
+        Whether to replace non-finite values (NaN, +/-Inf) with 0.
     """
 
     model_config = pydantic.ConfigDict(extra="forbid")
@@ -1089,6 +1089,7 @@ class FmriCleaner(pydantic.BaseModel):
         if (
             self.detrend
             or self.standardize
+            or self.ensure_finite
             or (self.high_pass is not None)
             or (self.low_pass is not None)
         ):

--- a/neuralset-repo/neuralset/extractors/test_neuro.py
+++ b/neuralset-repo/neuralset/extractors/test_neuro.py
@@ -1872,3 +1872,29 @@ def test_channel_positions_meg_2d_rejected() -> None:
         NotImplementedError, match="n_spatial_dims=2 is not supported for MEG"
     ):
         ns.extractors.ChannelPositions(neuro=meg, n_spatial_dims=2)
+
+
+# ---------------------------------------------------------------------------
+# FmriCleaner.ensure_finite is honored when other cleaning is disabled
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("ensure_finite", [True, False])
+def test_fmri_cleaner_ensure_finite(ensure_finite: bool) -> None:
+    """ensure_finite must apply even with detrend/standardize/filters all off."""
+    data = np.random.randn(3, 50).astype(np.float32)
+    data[0, 10] = np.nan
+    data[1, 20] = np.inf
+    data[2, 30] = -np.inf
+
+    cleaner = ns.extractors.FmriCleaner(
+        detrend=False, standardize=False, ensure_finite=ensure_finite
+    )
+    cleaned = cleaner.clean(data, t_r=1.0)
+
+    assert cleaned.shape == data.shape
+    assert cleaned.dtype == data.dtype
+    if ensure_finite:
+        assert np.isfinite(cleaned).all()
+    else:
+        assert not np.isfinite(cleaned).all()


### PR DESCRIPTION
## Summary

Fixes #130. `FmriCleaner.clean()` only applied `ensure_finite` inside the `nilearn.signal.clean()` call, which was skipped when `detrend`, `standardize`, and filters were all off. So `NaN`/`Inf` leaked through despite `ensure_finite=True`, silently corrupting downstream models.

## Change

- Add `ensure_finite` to the guard so it's honored independently. Routing through nilearn keeps the logic in one place.
- Fix the docstring (it also zeroes `±Inf`).
- Add a test covering both on/off behavior.

Defaults are unaffected. `ruff` clean; new test fails without the fix, passes with it.