### PR TITLE
Implement logging for missing extract_features

### DIFF
--- a/neuralset-repo/neuralset/extractors/audio.py
+++ b/neuralset-repo/neuralset/extractors/audio.py
@@ -422,7 +422,9 @@ class HuggingFaceAudio(BaseAudio, HuggingFaceMixin):
         elif self.layer_type == "convolution":
             out = outputs.get("extract_features")
             if out is None:
-                logger.warning("No extract_features found, using first hidden_states instead")
+                logger.warning(
+                    "No extract_features found, using first hidden_states instead"
+                )
                 out = outputs.get("hidden_states")[0]
         else:
             raise ValueError(f"Unknown layer type: {self.layer_type}")

--- a/neuralset-repo/neuralset/extractors/audio.py
+++ b/neuralset-repo/neuralset/extractors/audio.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 """All the supported audio extractors."""
 
+import logging
 import typing as tp
 import warnings
 from abc import abstractmethod
@@ -24,6 +25,8 @@ from .base import BaseExtractor
 from .hf import HuggingFaceConfig, HuggingFaceMixin
 
 # pylint: disable=import-outside-toplevel
+
+logger = logging.getLogger(__name__)
 
 
 class BaseAudio(BaseExtractor):
@@ -418,6 +421,9 @@ class HuggingFaceAudio(BaseAudio, HuggingFaceMixin):
             out: tp.Any = outputs.get("hidden_states")
         elif self.layer_type == "convolution":
             out = outputs.get("extract_features")
+            if out is None:
+                logger.warning("No extract_features found, using first hidden_states instead")
+                out = outputs.get("hidden_states")[0]
         else:
             raise ValueError(f"Unknown layer type: {self.layer_type}")
         if isinstance(out, tuple):


### PR DESCRIPTION
## What does this PR do?

Added logging to warn when no extract_features are found.
Some audio models (e.g. Whisper) do not output `extract_features`.
The `hidden_states` stack starts after the convolutions and includes all the output of the transformer layers. In this case, using the first `hidden_states` works.