### PR TITLE
[doc] Fix Code Builder video extractor kwargs and stale API references

### DIFF
--- a/docs/_data/code-builder-data.yaml
+++ b/docs/_data/code-builder-data.yaml
@@ -221,13 +221,15 @@ axes:
         pip_packages: ["transformers", "torchvision", "julius", "moviepy"]
         event_type: Video
         is_classification: false
-        # Default model: MCG-NJU/videomae-base. Tied to upstream transformers'
-        # ImagesKwargs validation; covered by L0/L1/L2 — L3 skipped via
-        # `l3_skip` until the kwargs validator settles upstream.
+        # Default model: MCG-NJU/videomae-base, a native video model that
+        # encodes `num_frames` frames per clip (16 matches the model config).
+        # Tied to upstream transformers' ImagesKwargs validation; covered by
+        # L0/L1/L2 — L3 skipped via `l3_skip` until the kwargs validator
+        # settles upstream.
         l3_skip: "videomae+transformers ImagesKwargs(text=) compat — upstream"
         kwargs:
           - 'frequency="native"'
-          - "use_audio=False"
+          - "num_frames=16"
           - 'aggregation="trigger"'
 
       classification:

--- a/docs/_static/code-builder-data.js
+++ b/docs/_static/code-builder-data.js
@@ -262,7 +262,7 @@ window.CB_DATA = {
           "l3_skip": "videomae+transformers ImagesKwargs(text=) compat \u2014 upstream",
           "kwargs": [
             "frequency=\"native\"",
-            "use_audio=False",
+            "num_frames=16",
             "aggregation=\"trigger\""
           ]
         },

--- a/docs/neuralbench/tasks/eeg/typing.rst
+++ b/docs/neuralbench/tasks/eeg/typing.rst
@@ -28,7 +28,7 @@ The typing decoding task involves decoding the characters that were typed on a c
 Dataset Notes
 ~~~~~~~~~~~~~
 
-* [TO BE UPDATED] Train/test splits are created by clustering similar sentences together into the same split to avoid data leakage (see `neuralset.splitting.SimilaritySplitter`).
+* [TO BE UPDATED] Train/test splits are created by clustering similar sentences together into the same split to avoid data leakage (see `neuralset.events.transforms.SimilaritySplitter`).
 
 References
 ~~~~~~~~~~

--- a/docs/neuralbench/tasks/meg/typing.rst
+++ b/docs/neuralbench/tasks/meg/typing.rst
@@ -28,7 +28,7 @@ The typing decoding task involves decoding the characters that were typed on a c
 Dataset Notes
 ~~~~~~~~~~~~~
 
-* Train/test splits are created by clustering similar sentences together into the same split to avoid data leakage (see `neuralset.splitting.SimilaritySplitter`).
+* Train/test splits are created by clustering similar sentences together into the same split to avoid data leakage (see `neuralset.events.transforms.SimilaritySplitter`).
 
 References
 ~~~~~~~~~~

--- a/docs/neuralset/walkthrough/04_extractors.py
+++ b/docs/neuralset/walkthrough/04_extractors.py
@@ -258,7 +258,7 @@ print(f"fMRI shape: {fmri_sample.shape}  (x, y, z, time)")
 # to provide surrounding context for each word.
 #
 # Layer and token aggregation are configurable via
-# :class:`~neuralset.extractors.base.HuggingFaceMixin`:
+# :class:`~neuralset.extractors.hf.HuggingFaceMixin`:
 #
 # .. code-block:: python
 #


### PR DESCRIPTION
## What does this PR do?

Fixes docs drift against the current `neuralset` API, found while reproducing a `ValidationError` from the interactive Code Builder.

**Code Builder — video stimulus.** The `HuggingFaceVideo` snippet used the old API and raised a `pydantic.ValidationError` (`use_audio` no longer accepted; `num_frames` now required). Dropped `use_audio=False`, added `num_frames=16` (matches the default `MCG-NJU/videomae-base` config), regenerated the JS artifact.

**Stale cross-references** (from auditing all package-rooted symbols in the docs):
- `extractors.base.HuggingFaceMixin` → `extractors.hf.HuggingFaceMixin`
- `neuralset.splitting.SimilaritySplitter` → `neuralset.events.transforms.SimilaritySplitter` (2 files)

## Files changed
- `docs/_data/code-builder-data.yaml` + `docs/_static/code-builder-data.js` (regenerated)
- `docs/neuralset/walkthrough/04_extractors.py`
- `docs/neuralbench/tasks/{eeg,meg}/typing.rst`
