### PR TITLE
fix(neuraltrain): declare tqdm as a runtime dependency

### DIFF
--- a/neuraltrain-repo/pyproject.toml
+++ b/neuraltrain-repo/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
   "packaging",
   "pydantic>=2.5.0",
   "torchmetrics>=1.1.2",
+  "tqdm>=4.65.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
neuraltrain imports tqdm unconditionally at package-import time: __init__.py loads models/__init__.py, which eagerly imports diffusion_prior, which does `from tqdm import tqdm`. But tqdm is not in [project.dependencies] — only the `types-tqdm` stubs are declared, under dev. So a standalone `pip install neuraltrain` followed by `import neuraltrain` fails with `ModuleNotFoundError: No module named 'tqdm'`.

Why CI didn't catch it: the monorepo's shared-venv install pulls tqdm in transitively via neuralset (which declares tqdm>=4.65.0), masking the broken standalone install — the same mechanism as the exca fix (#156).

Pin matches neuralset's tqdm>=4.65.0. Verified that, with tqdm added, a clean editable install of neuraltrain imports the full package (every submodule) with no errors.