### PR TITLE
Cap numpy<2.5 in neuralset/neuraltrain to fix eegdash co-install (#170)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- `neuralset` / `neuraltrain`: capped `numpy<2.5` so a fresh co-install with `eegdash` on Python 3.12 no longer backtracks to the unbuildable `numba==0.53.1` / `llvmlite==0.36.0`; nothing needs numpy 2.5 and the cap lets the resolver settle on `numba==0.65.1` / `llvmlite==0.47.0` (#170).
 - `neuralset`: fixed `Mne2013Sample`/`Fake2025Meg` re-downloading the MNE sample dataset on `run()` after `download()` by funneling all paths through a single root; the download progress bar now also shows when `run()` triggers the fetch. The study subfolder is now resolved once in `model_post_init` instead of mutating `self.path` in `download()`, so calling `download()` after `run()` no longer crashes on the frozen instance (#153).
 - `neuralfetch`: added `Allen2022MassiveRaw` (BIDS/deepprep NSD variant) and gated NSD downloads behind the `NSD_ACCEPT_LICENCE` env var.
 - `neuralbench`: added a `CLUSTER` key to `~/.neuralbench/config.json` to force fully local execution (`null`) without `--debug`, keep the default SLURM auto-detection (`"auto"`), or always submit to SLURM (`"slurm"`); honored by `--prepare`.

--- a/neuralset-repo/pyproject.toml
+++ b/neuralset-repo/pyproject.toml
@@ -10,7 +10,7 @@ version = "0.2.2"
 
 dependencies = [
   "pandas>=2.2.2",
-  "numpy>=2.1",
+  "numpy>=2.1,<2.5",  # <2.5 until numba/llvmlite ship a release supporting numpy 2.5 (#170)
   "pyarrow>=17.0.0",
   "mne>=1.10.2",
   "scikit-learn>=0.21.2",

--- a/neuraltrain-repo/pyproject.toml
+++ b/neuraltrain-repo/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 
 dependencies = [
   "pandas>=2.0.1",
-  "numpy>=2.1",
+  "numpy>=2.1,<2.5",  # <2.5 until numba/llvmlite ship a release supporting numpy 2.5 (#170)
   "scikit-learn>=0.21.2",
   "torch>=2.5.1",
   "torchvision>=0.20.1",


### PR DESCRIPTION
Fixes #170.

`neuralset` and `neuraltrain` declare `numpy>=2.1` with no ceiling, so a fresh co-install with `eegdash` on Python 3.12 can resolve `numpy==2.5.0`. No numba supports numpy that new, so it backtracks to `numba==0.53.1` → `llvmlite==0.36.0`, which refuses Python ≥3.10 and fails to build.

Capping `numpy<2.5` drops 2.5.0 from the solution space; the resolver then settles on `numba==0.65.1` / `llvmlite==0.47.0`. Capping numpy (not numba) since neither package depends on numba directly.

Verified with uv 0.11.23: cap resolves cleanly even under `--resolution highest`. Metadata-only, no code change.