### PR TITLE
feat(neuralfetch): allow downloading a subject subset for MOABB studies

### DIFF
--- a/neuralfetch-repo/neuralfetch/studies/moabb2025.py
+++ b/neuralfetch-repo/neuralfetch/studies/moabb2025.py
@@ -232,12 +232,19 @@ class _BaseMoabb(studies.Study):
         return df
 
     # Populate subclass-level metadata
-    def _download(self) -> None:
+    def _download(self, subjects: list[int] | None = None) -> None:
         """
         Download MoABB dataset and write timelines as a csv.
 
         (Timelines needed to avoid 'moabb.datasets.studies.get_data()' in self.iter_timelines, which loads ALL raw data.)
 
+        Parameters
+        ----------
+        subjects : list[int] or None
+            Subset of subjects to download (e.g. ``[1]`` for a quick smoke
+            test). When ``None`` (the default), all subjects in the dataset's
+            ``subject_list`` are downloaded. Pass via
+            ``study.download(subjects=[1])``.
         """
         from moabb.datasets.base import CacheConfig
 
@@ -251,9 +258,19 @@ class _BaseMoabb(studies.Study):
                 with temp_mne_data(dl_path, clear_dataset_configs=True):
                     logger.info(f"MNE_DATA set to: {dl_path}")
                     ds = self._get_dataset()
+                    if subjects is None:
+                        subject_list = ds.subject_list
+                    else:
+                        unknown = sorted(set(subjects) - set(ds.subject_list))
+                        if unknown:
+                            raise ValueError(
+                                f"Unknown subject(s) {unknown} for "
+                                f"{self.aliases[0]}; available: {ds.subject_list}"
+                            )
+                        subject_list = list(subjects)
                     rows: list[dict[str, tp.Any]] = []
                     failed_subjects: list[tp.Any] = []
-                    for subject in ds.subject_list:
+                    for subject in subject_list:
                         try:
                             subj_data = ds.get_data(
                                 subjects=[subject],

--- a/neuralfetch-repo/neuralfetch/studies/moabb2025.py
+++ b/neuralfetch-repo/neuralfetch/studies/moabb2025.py
@@ -3217,8 +3217,13 @@ class Romani2025Brainform(_BaseMoabb):
         labels = [s for s in labels if s not in self._EXCLUDE_SUBJECTS]
         return {i: s for i, s in enumerate(labels)}
 
-    def _download(self) -> None:
-        """Build timelines.csv by scanning BIDS directory (no mne_bids needed)."""
+    def _download(self, subjects: list[int] | None = None) -> None:
+        """Build timelines.csv by scanning BIDS directory (no mne_bids needed).
+
+        ``subjects`` selects a subset of subject indices (as keyed by
+        :meth:`_subject_map`); ``None`` (the default) builds timelines for
+        all subjects.
+        """
         timeline_path = Path(self.path) / "timelines.csv"
         if timeline_path.exists():
             return
@@ -3230,6 +3235,13 @@ class Romani2025Brainform(_BaseMoabb):
             )
 
         subj_map = self._subject_map()
+        if subjects is not None:
+            unknown = sorted(set(subjects) - set(subj_map))
+            if unknown:
+                raise ValueError(
+                    f"Unknown subject(s) {unknown}; available: {sorted(subj_map)}"
+                )
+            subj_map = {i: s for i, s in subj_map.items() if i in set(subjects)}
         rows: list[dict[str, tp.Any]] = []
         for idx, label in subj_map.items():
             subj_dir = bids / f"sub-{label}"

--- a/neuralfetch-repo/neuralfetch/test_moabb2025.py
+++ b/neuralfetch-repo/neuralfetch/test_moabb2025.py
@@ -10,6 +10,8 @@ import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from neuralfetch.studies import moabb2025
 from neuralfetch.studies.moabb2025 import Tangermann2012Review
 
@@ -59,3 +61,61 @@ def test_basemoabb_disables_processpool(tmp_path: Path) -> None:
         infra_timelines={"cluster": "processpool"},  # type: ignore[arg-type]
     )
     assert study_pp.infra_timelines.cluster is None
+
+
+def test_download_subjects_subset(tmp_path: Path) -> None:
+    """``download(subjects=[1])`` downloads only the requested subject."""
+    study = Tangermann2012Review(path=tmp_path)
+
+    mock_ds = MagicMock()
+    mock_ds.subject_list = [1, 2, 3]
+    mock_ds.get_data.return_value = {1: {"ses": {"run": "raw"}}}
+
+    with (
+        patch.dict(
+            sys.modules,
+            {
+                "moabb": MagicMock(),
+                "moabb.datasets": MagicMock(),
+                "moabb.datasets.base": MagicMock(),
+            },
+        ),
+        patch.object(moabb2025, "find_dataset_in_moabb", return_value=mock_ds),
+        patch.object(moabb2025, "temp_mne_data") as mock_ctx,
+    ):
+        mock_ctx.return_value.__enter__ = MagicMock()
+        mock_ctx.return_value.__exit__ = MagicMock(return_value=False)
+
+        study._download(subjects=[1])
+
+    # Only subject 1 was fetched; subjects 2 and 3 were skipped.
+    called_subjects = [c.kwargs["subjects"] for c in mock_ds.get_data.call_args_list]
+    assert called_subjects == [[1]]
+
+
+def test_download_unknown_subject_raises(tmp_path: Path) -> None:
+    """``download(subjects=[...])`` rejects subjects absent from the dataset."""
+    study = Tangermann2012Review(path=tmp_path)
+
+    mock_ds = MagicMock()
+    mock_ds.subject_list = [1, 2, 3]
+
+    with (
+        patch.dict(
+            sys.modules,
+            {
+                "moabb": MagicMock(),
+                "moabb.datasets": MagicMock(),
+                "moabb.datasets.base": MagicMock(),
+            },
+        ),
+        patch.object(moabb2025, "find_dataset_in_moabb", return_value=mock_ds),
+        patch.object(moabb2025, "temp_mne_data") as mock_ctx,
+    ):
+        mock_ctx.return_value.__enter__ = MagicMock()
+        mock_ctx.return_value.__exit__ = MagicMock(return_value=False)
+
+        with pytest.raises(ValueError, match="Unknown subject"):
+            study._download(subjects=[99])
+
+    mock_ds.get_data.assert_not_called()


### PR DESCRIPTION
## What

`_BaseMoabb._download` now accepts an optional `subjects` kwarg to download a single subject (or any subset):

```python
ns.Study(name="Stieger2021Continuous", path="/data").download(subjects=[1])
```

## Why

There was no public way to limit which subjects download — `_download` hardcoded the full `subject_list`, forcing a monkeypatch of `_get_dataset`. Painful for smoke tests, CI, and local dev.

## How

- Rides the existing `download(**kwargs) → _download(**kwargs)` path; mirrors the `overwrite=` kwarg other studies use.
- Defaults to `None` (all subjects) — backward-compatible.
- Validates against `subject_list`, raising `ValueError` on unknown ids.
- Adds tests for the subset and error paths.