### PR TITLE
Fix Brennan2019Hierarchical loading for the v2 (`bn999738r`) release

### DIFF
--- a/neuralfetch-repo/neuralfetch/studies/brennan2019hierarchical.py
+++ b/neuralfetch-repo/neuralfetch/studies/brennan2019hierarchical.py
@@ -98,33 +98,56 @@ class Brennan2019Hierarchical(study.Study):
             collection_id="cc387c09-b0e5-422b-a384-0d96e7ffdc73",
         ).download()
 
-        with success_writer(dl_dir / "success_extract") as already_done:
+        # Bumped from "success_extract": the v1 marker predates proc.zip
+        # extraction, so existing caches must re-extract to get the .mat files.
+        with success_writer(dl_dir / "success_extract_v2") as already_done:
             if not already_done:
-                print(f"Extracting `brennan2019` audio to {dl_dir}/audio...")
-                with zipfile.ZipFile(str(dl_dir / "audio.zip"), "r") as zip_:
-                    zip_.extractall(str(dl_dir))
+                # audio.zip -> audio/*.wav, proc.zip -> timelock-preprocessing/*.mat
+                for archive in ("audio.zip", "proc.zip"):
+                    print(f"Extracting `brennan2019` {archive} to {dl_dir}...")
+                    with zipfile.ZipFile(str(dl_dir / archive), "r") as zip_:
+                        members = [
+                            m for m in zip_.namelist() if not m.startswith("__MACOSX")
+                        ]
+                        zip_.extractall(str(dl_dir), members=members)
 
     def iter_timelines(self) -> tp.Iterator[dict[str, tp.Any]]:
         """Returns a generator of all recordings"""
-        # S49 excluded: no corresponding timelock-preprocessing .mat file
-        all_subjects = {f"S{i:02d}" for i in range(1, 49)}
-        # FIXME retrieve bad subjects?
-        # S02: bad trl?
-        bads = {"S02", "S24", "S26", "S27", "S30", "S32", "S34", "S35", "S36"}
-        for subject in sorted(all_subjects - bads):
+        # 49 subjects were recorded (S01-S49); 33 remain after the exclusions below.
+        all_subjects = {f"S{i:02d}" for i in range(1, 50)}
+        # No timelock-preprocessing .mat file ships for these subjects.
+        no_proc = {"S28", "S29", "S31", "S33", "S46", "S47", "S49"}
+        # Excluded for data quality (bad trials / rejected channels).
+        bad_quality = {"S02", "S24", "S26", "S27", "S30", "S32", "S34", "S35", "S36"}
+        for subject in sorted(all_subjects - no_proc - bad_quality):
             yield dict(subject=subject)
 
     def _load_raw(self, timeline: dict[str, tp.Any]) -> mne.io.RawArray:
         dl_dir = self.path / "download"
         vhdr_file = dl_dir / f"{timeline['subject']}.vhdr"
-        raw = mne.io.read_raw_brainvision(vhdr_file, eog=["VEOG"], misc=["Aux5"])
-        raw.set_montage(mne.channels.make_standard_montage("easycap-M10"))
+        raw = mne.io.read_raw_brainvision(vhdr_file)
+        montage = mne.channels.make_standard_montage("easycap-M10")
+        montage_chs = set(montage.ch_names)
+        # The auxiliary (non-scalp) channel is named inconsistently across the
+        # v2 release -- "Aux5" for some subjects, "AUD" for others -- alongside
+        # the "VEOG" EOG channel. Type every channel absent from the montage so
+        # set_montage positions only the scalp electrodes.
+        non_scalp = {
+            ch: ("eog" if "EOG" in ch.upper() else "misc")
+            for ch in raw.ch_names
+            if ch not in montage_chs
+        }
+        # on_unit_change="ignore": aux channels go from V (EEG) to NA (misc),
+        # which is expected here and would otherwise warn once per subject.
+        raw.set_channel_types(non_scalp, on_unit_change="ignore")
+        raw.set_montage(montage)
         subject_id = timeline["subject"]
         raw.info["subject_info"] = dict(his_id=subject_id, id=int(subject_id[1:]))
         if raw.info["sfreq"] != SFREQ:
             raise RuntimeError(f"Expected sfreq {SFREQ}, got {raw.info['sfreq']}")
-        if len(raw.ch_names) != 62:
-            raise RuntimeError(f"Expected 62 channels, got {len(raw.ch_names)}")
+        n_eeg = len(mne.pick_types(raw.info, eeg=True))
+        if n_eeg != 60:
+            raise RuntimeError(f"Expected 60 EEG channels, got {n_eeg}")
         return raw
 
     def _load_timeline_events(self, timeline: dict[str, tp.Any]) -> pd.DataFrame:

--- a/neuralfetch-repo/neuralfetch/test_studies.py
+++ b/neuralfetch-repo/neuralfetch/test_studies.py
@@ -208,3 +208,21 @@ def test_update_source_info(tmp_path: Path) -> None:
     finally:
         _study_mod.STUDIES.pop("DummyUpdateTest2099", None)
         sys.modules.pop("dummy_study", None)
+
+
+def test_brennan2019_timeline_count(tmp_path: Path) -> None:
+    """Brennan2019Hierarchical must enumerate exactly its 33 declared subjects.
+
+    ``iter_timelines`` is pure subject-set arithmetic (no disk access), so this
+    guards the count against drifting from ``_info.num_timelines`` without
+    needing the dataset.  Six in-range subjects ship no timelock-preprocessing
+    ``.mat`` file and must stay excluded.
+    """
+    from neuralfetch.studies.brennan2019hierarchical import Brennan2019Hierarchical
+
+    study = Brennan2019Hierarchical(path=tmp_path)
+    timelines = list(study.iter_timelines())
+    assert len(timelines) == study._info.num_timelines == 33  # noqa: SLF001
+    subjects = {t["subject"] for t in timelines}
+    no_proc = {"S28", "S29", "S31", "S33", "S46", "S47", "S49"}
+    assert subjects.isdisjoint(no_proc)


### PR DESCRIPTION
Fixes #172

`Brennan2019Hierarchical` targeted the v2 Deep Blue record but the reader still assumed the v1 layout and channel naming, so `study.run()` failed on a fresh download. #172 reports the `len(meta) != 2129` crash — it's the deepest of four migration breakages, three of which block loading before you reach it. Fixes:

1. **`_download`** now extracts `proc.zip` (the `timelock-preprocessing/*.mat` files) in addition to `audio.zip`, skipping `__MACOSX` entries. The extract-success marker is bumped to `success_extract_v2` so existing caches re-extract — they'd otherwise keep the old marker and never pick up the `.mat` files.
2. **`iter_timelines`** now excludes the 6 in-range subjects with no `.mat` (`S28, S29, S31, S33, S46, S47`) alongside the 9 incomplete-trial subjects (1973–1987 trials vs 2129 — the existing `# FIXME … bad trl?` set), yielding the 33 already declared by `_info`/docstring.
3. **`_load_raw`** types any channel absent from the `easycap-M10` montage (`EOG`→eog, else misc) before `set_montage`, handling v2's `AUD` (a few subjects keep `Aux5`). The channel assertion changes from "62 total" to "60 scalp EEG" (matches `data_shape`), since the aux name/count varies per subject.

This resolves #172's crash by excluding the incomplete subjects (the drop path — matching the paper's 33-subject cohort), rather than recovering them via a fixed alignment for the `meta.join(story)` index join. That recovery is a separate, larger decision — see the #172 discussion.

Adds a dataset-free regression test pinning `len(iter_timelines()) == 33`.

## Verification

`study.run()` loads all 33 subjects; `compute_study_info` matches `_info` exactly (33 timelines/subjects, 2226 events, `data_shape=(60, 366525)`, 500 Hz). `ruff check`/`ruff format` and `pytest neuralfetch/test_studies.py` are green locally.

## Notes for review

I worked through this independently from the tutorials — debugging down the stack to all four breakages — and only found #172 and @hubertjb's comment when raising this PR. @hubertjb, since you flagged taking it this week, it's entirely yours to take over, modify, or close; I'm opening it in case it saves the time. 