### PR TITLE
Don't create MOABB study directory at construction

### DIFF
--- a/neuralfetch-repo/neuralfetch/studies/moabb2025.py
+++ b/neuralfetch-repo/neuralfetch/studies/moabb2025.py
@@ -215,8 +215,9 @@ class _BaseMoabb(studies.Study):
                 parent = self.path
             self.path = parent / "moabb" / study_name
 
-            self.path.mkdir(parents=True, exist_ok=True)
-            # Update the STUDY_PATHS registry with the corrected path
+            # Settle the path here (must happen before exca freezes the
+            # instance); creating the directory is download()'s job, not the
+            # constructor's.
             STUDY_PATHS[self.__class__.__name__] = self.path
             logger.debug("Updated MOABB path to: %s", self.path)
 

--- a/neuralfetch-repo/neuralfetch/test_moabb2025.py
+++ b/neuralfetch-repo/neuralfetch/test_moabb2025.py
@@ -10,6 +10,8 @@ import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from neuralfetch.studies import moabb2025
 from neuralfetch.studies.moabb2025 import Tangermann2012Review
 
@@ -59,3 +61,24 @@ def test_basemoabb_disables_processpool(tmp_path: Path) -> None:
         infra_timelines={"cluster": "processpool"},  # type: ignore[arg-type]
     )
     assert study_pp.infra_timelines.cluster is None
+
+
+def test_construction_creates_no_directories(tmp_path: Path) -> None:
+    """Constructing a MOABB study must not touch the filesystem.
+
+    Regression: ``_BaseMoabb.model_post_init`` used to ``mkdir`` the study leaf
+    at construction. That made ``self.path.exists()`` return True for
+    never-downloaded studies (defeating the base "run study.download() first"
+    guard) and littered empty directories for any study merely instantiated.
+    """
+    study = Tangermann2012Review(path=tmp_path)
+    assert study.path == tmp_path / "moabb" / "Tangermann2012Review"
+    assert not study.path.exists()
+    assert not (tmp_path / "moabb").exists()
+
+
+def test_undownloaded_study_raises_actionable_error(tmp_path: Path) -> None:
+    """An undownloaded study surfaces the base download guidance, not a raw read error."""
+    study = Tangermann2012Review(path=tmp_path)
+    with pytest.raises(RuntimeError, match=r"study\.download\(\) first"):
+        study._run()


### PR DESCRIPTION
## Summary

MOABB studies that haven't been downloaded fail with a raw `FileNotFoundError` on `timelines.csv` instead of the actionable "run `study.download()` first" message that every other study gives. The root cause is that `_BaseMoabb` created its study directory at construction time, which defeated the base-class guard. This removes that side effect.

## Problem

Constructing any MOABB study without downloading — e.g. `Cho2017Supporting(path=...)` — and reading its events produced:

```
[Errno 2] No such file or directory: '.../moabb/Cho2017Supporting/timelines.csv'
```

while equivalent native studies correctly produced:

```
For Cho2017Supporting, you may need to run study.download() first as ... does not exist.
```

This affected the entire MOABB family (~100 studies).

## Root cause

`Study._run()` converts "data missing" into the actionable message only when the study directory does not exist:

```python
if not timelines and not self.path.exists():
    raise RuntimeError(f"For {name}, you may need to run study.download() first ...")
```

`_BaseMoabb.model_post_init` called `self.path.mkdir(parents=True, exist_ok=True)` at construction. That made `self.path.exists()` return `True` before any download, so the guard never fired and the raw `pd.read_csv` error from `_timelines_df` leaked instead. As a side effect, merely instantiating a study (listing studies, building the registry, tests) littered empty directories on disk.

## Fix

Remove the `mkdir` from `model_post_init`. Path resolution stays there — it must be settled before exca freezes the instance — but directory creation is `download()`'s responsibility, which already creates the folder: `Study.download()` mkdirs `self.path`, and `_BaseMoabb._download()` mkdirs the `download/` subfolder (with `parents=True`). No code path depends on the directory existing before download. With this change, undownloaded MOABB studies hit the same base-class guard as every other study.

## Tests

Two regression tests added to `test_moabb2025.py`:

- `test_construction_creates_no_directories` — constructing a study resolves `self.path` to `<root>/moabb/<Name>` but creates nothing on disk. This locks the invariant that construction has no filesystem side effects (the actual defect, not just the symptom).
- `test_undownloaded_study_raises_actionable_error` — an undownloaded study raises the actionable "run `study.download()` first" message.

Verification: `test_moabb2025.py` — 4 passed; `test_studies.py` and `neuralset/events/test_study.py` — 42 passed, 137 skipped, 0 regressions.

## Scope

This fixes the "not downloaded" case. Partial or corrupt downloads (a present-but-incomplete folder) remain a separate failure surfaced by the loaders, and are intentionally out of scope.

## Follow-up (separate PR)

The base guard infers "not downloaded" from a `self.path.exists()` proxy, and the same "run download first" check is hand-rolled across ~6 backends. A follow-up will introduce a first-class `Study.is_available()` (default: folder exists and is non-empty; backends override with their sentinel, e.g. MOABB → `timelines.csv`), called once in `_run()`, and migrate the existing ad-hoc guards onto it. Raised here for visibility; not part of this change.