### PR TITLE
Refactor model constructor selection logic

### DIFF
--- a/neuralset-repo/neuralset/extractors/hf.py
+++ b/neuralset-repo/neuralset/extractors/hf.py
@@ -284,7 +284,10 @@ class HuggingFaceMixin(base.BaseModel):
                 self.model_name,
                 **config_kwargs,
             )
-            constructor = getattr(Model, "from_config", Model._from_config)  # type: ignore[attr-defined]
+            if hasattr(Model, "from_config"):
+                constructor = Model.from_config
+            else:
+                constructor = Model._from_config  # type: ignore[attr-defined]
             model = constructor(config, **(hf_config.model_kwargs or {}))
             if isinstance(self.dtype, str) and self.dtype != "auto":
                 model.to(dtype=getattr(torch, self.dtype))


### PR DESCRIPTION
## What does this PR do?

In the `load_model` function, if `pretrained=False`, it raises an issue for model that are not specified in `hf_config`.
In `transformers`, the `AutoModel` class does not have the method `_from_config` but it is still evaluated in `getattr`.