### PR TITLE
Make OpenNeuro downloads block under a running event loop (Jupyter/Colab)

### DIFF
--- a/neuralfetch-repo/neuralfetch/download.py
+++ b/neuralfetch-repo/neuralfetch/download.py
@@ -1108,14 +1108,29 @@ class Openneuro(BaseDownload):
     nworkers: int = 5
 
     def _download(self) -> None:
+        from concurrent.futures import ThreadPoolExecutor
+
         import openneuro as on
 
-        on.download(
-            dataset=self.study,
-            target_dir=self._dl_dir,
-            include=self.include,
-            max_concurrent_downloads=self.nworkers,
-        )
+        # openneuro-py's ``download`` only blocks when no event loop is running
+        # (it falls back to ``asyncio.run``). Under an already-running loop --
+        # e.g. inside Jupyter/Colab -- it schedules the transfer with
+        # ``loop.create_task`` and returns *before any file is written*, so the
+        # caller wrongly sees a finished download over an empty directory and
+        # ``study.run()`` races a half-downloaded tree. A coroutine cannot be
+        # awaited synchronously from within its own loop's thread, so drive
+        # ``download`` on a separate thread -- which has no running loop, taking
+        # openneuro's blocking branch. ``result()`` waits for completion and
+        # re-raises any error on the caller, restoring the synchronous contract
+        # the other backends already honor.
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            pool.submit(
+                on.download,
+                dataset=self.study,
+                target_dir=self._dl_dir,
+                include=self.include,
+                max_concurrent_downloads=self.nworkers,
+            ).result()
 
 
 class Osf(BaseDownload):

--- a/neuralfetch-repo/neuralfetch/test_download.py
+++ b/neuralfetch-repo/neuralfetch/test_download.py
@@ -6,7 +6,10 @@
 
 """Offline tests for download backends — no network access required."""
 
+import asyncio
 import os
+import sys
+import types
 import typing as tp
 from pathlib import Path
 from unittest.mock import patch
@@ -316,3 +319,71 @@ def test_nsd_data_access_agreement(tmp_path: Path, study_name: str) -> None:
             url = mock_browser.call_args[0][0]
             assert "__other_option__" in url
             assert "Researcher" in url
+
+
+def _fake_openneuro_module() -> types.ModuleType:
+    """Stand-in ``openneuro`` module mirroring openneuro-py's event-loop branch.
+
+    Under a running loop it fires the transfer via ``create_task`` and returns
+    immediately (the Jupyter footgun); with no loop it blocks via ``asyncio.run``.
+    """
+
+    def download(  # noqa: ANN001, ANN201
+        *, dataset, target_dir, include=None, max_concurrent_downloads=5
+    ):
+        target = Path(target_dir)
+
+        async def _coro() -> None:
+            target.mkdir(parents=True, exist_ok=True)
+            (target / "participants.tsv").write_text("ok")
+
+        try:
+            loop = asyncio.get_running_loop()
+            loop.create_task(_coro())  # running loop: scheduled, never awaited
+        except RuntimeError:
+            asyncio.run(_coro())  # no running loop: blocks until written
+
+    mod = types.ModuleType("openneuro")
+    mod.download = download  # type: ignore[attr-defined]
+    return mod
+
+
+def test_openneuro_download_blocks_under_running_loop(tmp_path: Path) -> None:
+    """``Openneuro._download`` completes synchronously even under a running loop.
+
+    In a notebook a loop is already running, so openneuro-py's bare ``download``
+    would fire-and-forget and return before any file lands. The worker-thread
+    wrapper must force openneuro's blocking branch so the directory is populated
+    by the time ``_download`` returns.
+    """
+    client = download.Openneuro(folder="", study="ds999999", dset_dir=tmp_path / "study")
+    marker = client._dl_dir / "participants.tsv"
+
+    async def _in_notebook() -> bool:
+        # Mimics a synchronous notebook cell executing under the kernel's loop.
+        client._download()
+        return marker.exists()
+
+    with patch.dict(sys.modules, {"openneuro": _fake_openneuro_module()}):
+        completed = asyncio.run(_in_notebook())
+
+    assert completed, (
+        "openneuro download did not finish before _download() returned under a "
+        "running event loop — the worker-thread wrapper is not blocking"
+    )
+
+
+def test_openneuro_download_propagates_worker_errors(tmp_path: Path) -> None:
+    """An error inside the worker thread is re-raised on the caller."""
+    client = download.Openneuro(folder="", study="ds999999", dset_dir=tmp_path / "study")
+
+    def _boom(**kwargs: tp.Any) -> None:
+        raise RuntimeError("download failed")
+
+    fake = types.ModuleType("openneuro")
+    fake.download = _boom  # type: ignore[attr-defined]
+    with (
+        patch.dict(sys.modules, {"openneuro": fake}),
+        pytest.raises(RuntimeError, match="download failed"),
+    ):
+        client._download()


### PR DESCRIPTION
## Problem

Downloading any OpenNeuro-backed study from a notebook (Jupyter/Colab) reports success but leaves the dataset only partially downloaded. `study.run()` then fails with `FileNotFoundError` (e.g. `participants.tsv`) or `Dataset ... is corrupted, expected N timelines but found M`.

## Root cause

Upstream in openneuro-py, surfaced through our backend. Its `download()` only blocks when no event loop is running:

```python
try:
    loop = asyncio.get_running_loop()
    loop.create_task(coroutine)   # running loop (Jupyter): scheduled, never awaited → returns immediately
except RuntimeError:
    asyncio.run(coroutine)        # no loop (script/CLI): blocks
```

Under a notebook's running loop it returns *before any file is written* (then prints `Finished downloading`). `Openneuro` trusts it to be synchronous, so the success marker is written and `study.download()` logs success over an essentially empty directory — and `study.run()` races the still-downloading tree. CI never caught it because the tests don't download and pytest has no running loop, so openneuro always takes the blocking branch there.

## Fix

Run `on.download` on a worker thread, which has no running loop and so takes openneuro's blocking branch; the call returns only once the download is actually complete — matching the synchronous contract every other backend already honors. Public API only; no private internals or `nest_asyncio`.

## Scope & testing

- Fixes all OpenNeuro studies (7 studies / 12 call sites). No change to script/CLI/cluster paths, which already block.
- New offline regression tests: download completes synchronously under a running loop, and worker-thread errors propagate to the caller. Full `test_download.py`: 28 passed, ruff clean.