### PR TITLE
Support image events in HuggingFaceVideo

### DIFF
--- a/neuralset-repo/neuralset/extractors/test_video.py
+++ b/neuralset-repo/neuralset/extractors/test_video.py
@@ -101,7 +101,7 @@ def test_huggingface_video_static_image_clip(tmp_path: Path) -> None:
     filepath = tmp_path / "image.png"
     frame = np.random.randint(0, 256, (64, 64, 3), dtype=np.uint8)
     PIL.Image.fromarray(frame).save(filepath)
-    event = etypes.Image(start=1.0, duration=0.5, filepath=filepath, timeline="foo")
+    event = etypes.Image(start=1.0, duration=3.0, filepath=filepath, timeline="foo")
     infra: tp.Any = {"folder": tmp_path / "cache", "cluster": None}
     extractor = vid.HuggingFaceVideo(
         event_types=("Image", "Video"),
@@ -111,10 +111,10 @@ def test_huggingface_video_static_image_clip(tmp_path: Path) -> None:
         device="cpu",
     )
 
-    out = extractor(event, start=1.0, duration=0.5)
+    out = extractor(event, start=1.0, duration=3.0)
 
     assert isinstance(out, torch.Tensor)
-    assert out.shape == (768, 1)
+    assert out.shape == (768, 3)
     assert torch.isfinite(out).all()
 
 

--- a/neuralset-repo/neuralset/extractors/test_video.py
+++ b/neuralset-repo/neuralset/extractors/test_video.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
-import contextlib
 import logging
 import os
 import typing as tp
@@ -96,18 +95,7 @@ def test_video_image(video_event: etypes.Video) -> None:
     assert vi.filepath.endswith("random_video_6s.mp4:12345.123")
 
 
-@pytest.mark.parametrize(
-    "event_types,expected_warning",
-    [
-        ("Image", True),
-        (("Image", "Video"), False),
-    ],
-)
-def test_huggingface_video_static_image_clip(
-    tmp_path: Path,
-    event_types: tp.Any,
-    expected_warning: bool,
-) -> None:
+def test_huggingface_video_static_image_clip(tmp_path: Path) -> None:
     if "IN_GITHUB_ACTION" in os.environ:
         pytest.skip("Run locally; image events use the full video model path.")
     filepath = tmp_path / "image.png"
@@ -115,19 +103,13 @@ def test_huggingface_video_static_image_clip(
     PIL.Image.fromarray(frame).save(filepath)
     event = etypes.Image(start=1.0, duration=0.5, filepath=filepath, timeline="foo")
     infra: tp.Any = {"folder": tmp_path / "cache", "cluster": None}
-    warning_context = (
-        pytest.warns(UserWarning, match="event_types='Image'")
-        if expected_warning
-        else contextlib.nullcontext()
+    extractor = vid.HuggingFaceVideo(
+        event_types=("Image", "Video"),
+        infra=infra,
+        max_imsize=64,
+        num_frames=16,
+        device="cpu",
     )
-    with warning_context:
-        extractor = vid.HuggingFaceVideo(
-            event_types=event_types,
-            infra=infra,
-            max_imsize=64,
-            num_frames=16,
-            device="cpu",
-        )
 
     out = extractor(event, start=1.0, duration=0.5)
 

--- a/neuralset-repo/neuralset/extractors/test_video.py
+++ b/neuralset-repo/neuralset/extractors/test_video.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
+import contextlib
 import logging
 import os
 import typing as tp
@@ -96,16 +97,16 @@ def test_video_image(video_event: etypes.Video) -> None:
 
 
 @pytest.mark.parametrize(
-    "kwargs,expected_shape",
+    "event_types,expected_warning",
     [
-        ({"event_types": "Image", "frequency": "native"}, (768,)),
-        ({"event_types": ("Image", "Video")}, (768, 1)),
+        ("Image", True),
+        (("Image", "Video"), False),
     ],
 )
 def test_huggingface_video_static_image_clip(
     tmp_path: Path,
-    kwargs: dict[str, tp.Any],
-    expected_shape: tuple[int, ...],
+    event_types: tp.Any,
+    expected_warning: bool,
 ) -> None:
     if "IN_GITHUB_ACTION" in os.environ:
         pytest.skip("Run locally; image events use the full video model path.")
@@ -114,18 +115,24 @@ def test_huggingface_video_static_image_clip(
     PIL.Image.fromarray(frame).save(filepath)
     event = etypes.Image(start=1.0, duration=0.5, filepath=filepath, timeline="foo")
     infra: tp.Any = {"folder": tmp_path / "cache", "cluster": None}
-    extractor = vid.HuggingFaceVideo(
-        infra=infra,
-        max_imsize=64,
-        num_frames=16,
-        device="cpu",
-        **kwargs,
+    warning_context = (
+        pytest.warns(UserWarning, match="event_types='Image'")
+        if expected_warning
+        else contextlib.nullcontext()
     )
+    with warning_context:
+        extractor = vid.HuggingFaceVideo(
+            event_types=event_types,
+            infra=infra,
+            max_imsize=64,
+            num_frames=16,
+            device="cpu",
+        )
 
     out = extractor(event, start=1.0, duration=0.5)
 
     assert isinstance(out, torch.Tensor)
-    assert out.shape == expected_shape
+    assert out.shape == (768, 1)
     assert torch.isfinite(out).all()
 
 

--- a/neuralset-repo/neuralset/extractors/test_video.py
+++ b/neuralset-repo/neuralset/extractors/test_video.py
@@ -95,7 +95,19 @@ def test_video_image(video_event: etypes.Video) -> None:
     assert vi.filepath.endswith("random_video_6s.mp4:12345.123")
 
 
-def test_huggingface_video_static_image_clip(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "event_types,frequency,expected_shape",
+    [
+        ("Image", 0.0, (768,)),
+        (("Image", "Video"), 0.5, (768, 1)),
+    ],
+)
+def test_huggingface_video_static_image_clip(
+    tmp_path: Path,
+    event_types: tp.Any,
+    frequency: float,
+    expected_shape: tuple[int, ...],
+) -> None:
     if "IN_GITHUB_ACTION" in os.environ:
         pytest.skip("Run locally; image events use the full video model path.")
     filepath = tmp_path / "image.png"
@@ -104,7 +116,8 @@ def test_huggingface_video_static_image_clip(tmp_path: Path) -> None:
     event = etypes.Image(start=1.0, duration=0.5, filepath=filepath, timeline="foo")
     infra: tp.Any = {"folder": tmp_path / "cache", "cluster": None}
     extractor = vid.HuggingFaceVideo(
-        event_types="Image",
+        event_types=event_types,
+        frequency=frequency,
         infra=infra,
         max_imsize=64,
         num_frames=16,
@@ -114,7 +127,7 @@ def test_huggingface_video_static_image_clip(tmp_path: Path) -> None:
     out = extractor(event, start=1.0, duration=0.5)
 
     assert isinstance(out, torch.Tensor)
-    assert out.shape == (768,)
+    assert out.shape == expected_shape
     assert torch.isfinite(out).all()
 
 

--- a/neuralset-repo/neuralset/extractors/test_video.py
+++ b/neuralset-repo/neuralset/extractors/test_video.py
@@ -96,16 +96,15 @@ def test_video_image(video_event: etypes.Video) -> None:
 
 
 @pytest.mark.parametrize(
-    "event_types,frequency,expected_shape",
+    "kwargs,expected_shape",
     [
-        ("Image", 0.0, (768,)),
-        (("Image", "Video"), 0.5, (768, 1)),
+        ({"event_types": "Image", "frequency": "native"}, (768,)),
+        ({"event_types": ("Image", "Video")}, (768, 1)),
     ],
 )
 def test_huggingface_video_static_image_clip(
     tmp_path: Path,
-    event_types: tp.Any,
-    frequency: float,
+    kwargs: dict[str, tp.Any],
     expected_shape: tuple[int, ...],
 ) -> None:
     if "IN_GITHUB_ACTION" in os.environ:
@@ -116,12 +115,11 @@ def test_huggingface_video_static_image_clip(
     event = etypes.Image(start=1.0, duration=0.5, filepath=filepath, timeline="foo")
     infra: tp.Any = {"folder": tmp_path / "cache", "cluster": None}
     extractor = vid.HuggingFaceVideo(
-        event_types=event_types,
-        frequency=frequency,
         infra=infra,
         max_imsize=64,
         num_frames=16,
         device="cpu",
+        **kwargs,
     )
 
     out = extractor(event, start=1.0, duration=0.5)

--- a/neuralset-repo/neuralset/extractors/test_video.py
+++ b/neuralset-repo/neuralset/extractors/test_video.py
@@ -95,48 +95,27 @@ def test_video_image(video_event: etypes.Video) -> None:
     assert vi.filepath.endswith("random_video_6s.mp4:12345.123")
 
 
-def test_huggingface_video_static_image_clip(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_huggingface_video_static_image_clip(tmp_path: Path) -> None:
+    if "IN_GITHUB_ACTION" in os.environ:
+        pytest.skip("Run locally; image events use the full video model path.")
     filepath = tmp_path / "image.png"
-    frame = np.arange(4 * 5 * 3, dtype=np.uint8).reshape(4, 5, 3)
+    frame = np.random.randint(0, 256, (64, 64, 3), dtype=np.uint8)
     PIL.Image.fromarray(frame).save(filepath)
     event = etypes.Image(start=1.0, duration=0.5, filepath=filepath, timeline="foo")
-    clips = []
-
-    def predict_hidden_states(
-        self: vid.HuggingFaceVideo, clip: np.ndarray
-    ) -> torch.Tensor:
-        clips.append(clip)
-        return torch.arange(24, dtype=torch.float32).reshape(1, 3, 2, 4)
-
-    monkeypatch.setattr(
-        vid.hf.HuggingFaceMixin,
-        "_download_huggingface_snapshot",
-        lambda self: None,
-    )
-    monkeypatch.setattr(
-        vid.HuggingFaceVideo,
-        "_warn_if_config_num_frames_mismatch",
-        lambda self: None,
-    )
-    monkeypatch.setattr(
-        vid.HuggingFaceVideo, "_predict_hidden_states", predict_hidden_states
-    )
     infra: tp.Any = {"folder": tmp_path / "cache", "cluster": None}
     extractor = vid.HuggingFaceVideo(
         event_types="Image",
         infra=infra,
-        num_frames=4,
+        max_imsize=64,
+        num_frames=16,
         device="cpu",
     )
 
     out = extractor(event, start=1.0, duration=0.5)
 
-    assert out.shape == (4,)
-    assert len(clips) == 1
-    assert clips[0].shape == (4, 4, 5, 3)
-    assert all(np.array_equal(clip_frame, frame) for clip_frame in clips[0])
+    assert isinstance(out, torch.Tensor)
+    assert out.shape == (768,)
+    assert torch.isfinite(out).all()
 
 
 def test_video(video_event: etypes.Video, tmp_path: Path) -> None:

--- a/neuralset-repo/neuralset/extractors/test_video.py
+++ b/neuralset-repo/neuralset/extractors/test_video.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
+import PIL.Image
 import pytest
 import torch
 
@@ -92,6 +93,50 @@ def test_video_image(video_event: etypes.Video) -> None:
     movie = video_event.read()
     vi = _VideoImage(video=movie, time=12345.12345)
     assert vi.filepath.endswith("random_video_6s.mp4:12345.123")
+
+
+def test_huggingface_video_static_image_clip(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    filepath = tmp_path / "image.png"
+    frame = np.arange(4 * 5 * 3, dtype=np.uint8).reshape(4, 5, 3)
+    PIL.Image.fromarray(frame).save(filepath)
+    event = etypes.Image(start=1.0, duration=0.5, filepath=filepath, timeline="foo")
+    clips = []
+
+    def predict_hidden_states(
+        self: vid.HuggingFaceVideo, clip: np.ndarray
+    ) -> torch.Tensor:
+        clips.append(clip)
+        return torch.arange(24, dtype=torch.float32).reshape(1, 3, 2, 4)
+
+    monkeypatch.setattr(
+        vid.hf.HuggingFaceMixin,
+        "_download_huggingface_snapshot",
+        lambda self: None,
+    )
+    monkeypatch.setattr(
+        vid.HuggingFaceVideo,
+        "_warn_if_config_num_frames_mismatch",
+        lambda self: None,
+    )
+    monkeypatch.setattr(
+        vid.HuggingFaceVideo, "_predict_hidden_states", predict_hidden_states
+    )
+    infra: tp.Any = {"folder": tmp_path / "cache", "cluster": None}
+    extractor = vid.HuggingFaceVideo(
+        event_types="Image",
+        infra=infra,
+        num_frames=4,
+        device="cpu",
+    )
+
+    out = extractor(event, start=1.0, duration=0.5)
+
+    assert out.shape == (4,)
+    assert len(clips) == 1
+    assert clips[0].shape == (4, 4, 5, 3)
+    assert all(np.array_equal(clip_frame, frame) for clip_frame in clips[0])
 
 
 def test_video(video_event: etypes.Video, tmp_path: Path) -> None:

--- a/neuralset-repo/neuralset/extractors/video.py
+++ b/neuralset-repo/neuralset/extractors/video.py
@@ -16,7 +16,6 @@ from exca import MapInfra
 from tqdm import tqdm
 
 from neuralset import base as nsbase
-from neuralset.events import EventTypesHelper
 from neuralset.events import etypes as evts
 
 from . import base as extractor_base
@@ -108,6 +107,7 @@ class HuggingFaceVideo(extractor_base.BaseExtractor, hf.HuggingFaceMixin):
     )
     model_name: str = "MCG-NJU/videomae-base"
     hf_config: HuggingFaceVideoConfig = HuggingFaceVideoConfig()
+    frequency: float | tp.Literal["native"] = 1.0
     clip_duration: float | None = None
     max_imsize: int | None = None
     num_frames: int
@@ -153,33 +153,6 @@ class HuggingFaceVideo(extractor_base.BaseExtractor, hf.HuggingFaceMixin):
         return extractor_base.BaseExtractor._exclude_from_cache_uid(
             self
         ) + hf.HuggingFaceMixin._exclude_from_cache_uid(self)
-
-    def model_post_init(self, log__: tp.Any) -> None:
-        if self._uses_only_image_events() and self.frequency == 0:
-            self._event_types_helper = EventTypesHelper(self.event_types)
-            hf.HuggingFaceMixin.model_post_init(self, log__)
-            return
-        super().model_post_init(log__)
-        if self._supports_image_events() and not self._supports_video_events():
-            if self.frequency == "native":
-                return
-            msg = "HuggingFaceVideo requires frequency=0 or 'native' for Image events."
-            raise ValueError(msg)
-
-    def _supports_image_events(self) -> bool:
-        event_types = (
-            (self.event_types,) if isinstance(self.event_types, str) else self.event_types
-        )
-        return "Image" in event_types
-
-    def _supports_video_events(self) -> bool:
-        event_types = (
-            (self.event_types,) if isinstance(self.event_types, str) else self.event_types
-        )
-        return "Video" in event_types
-
-    def _uses_only_image_events(self) -> bool:
-        return self._supports_image_events() and not self._supports_video_events()
 
     def _get_timed_arrays(
         self,

--- a/neuralset-repo/neuralset/extractors/video.py
+++ b/neuralset-repo/neuralset/extractors/video.py
@@ -157,37 +157,16 @@ class HuggingFaceVideo(extractor_base.BaseExtractor, hf.HuggingFaceMixin):
             self
         ) + hf.HuggingFaceMixin._exclude_from_cache_uid(self)
 
-    def model_post_init(self, log__: tp.Any) -> None:
-        super().model_post_init(log__)
-        if self.event_types == "Image":
-            warnings.warn(
-                "HuggingFaceVideo with event_types='Image' applies a video model "
-                "to repeated static image frames. Consider HuggingFaceImage for "
-                "image-only features.",
-                stacklevel=2,
-            )
-
     def _get_timed_arrays(
         self,
         events: list[evts.Image | evts.Video],
         start: float,
         duration: float,
     ) -> tp.Iterable[nsbase.TimedArray]:
-        for event, data in zip(events, self._get_data(events)):
-            if event.type == "Image":
-                data = np.asarray(data)
-                if self.cache_n_layers is not None:
-                    data = self._aggregate_layers(data)
-                yield nsbase.TimedArray(
-                    frequency=0,
-                    duration=event.duration,
-                    start=event.start,
-                    data=data,
-                )
-                continue
-            sub = data.with_start(event.start).overlap(  # type: ignore[union-attr]
-                start=start, duration=duration
-            )
+        for event, ta in zip(events, self._get_data(events)):
+            sub = ta
+            if sub.frequency:
+                sub = sub.with_start(event.start).overlap(start=start, duration=duration)
             if self.cache_n_layers is not None:
                 sub.data = self._aggregate_layers(sub.data)
             yield sub
@@ -198,7 +177,7 @@ class HuggingFaceVideo(extractor_base.BaseExtractor, hf.HuggingFaceMixin):
     )
     def _get_data(
         self, events: tp.Sequence[evts.Image | evts.Video]
-    ) -> tp.Iterator[np.ndarray | nsbase.TimedArray]:
+    ) -> tp.Iterator[nsbase.TimedArray]:
         # read all media events
         logging.getLogger("neuralset").setLevel(logging.DEBUG)
         self._warn_if_config_num_frames_mismatch()
@@ -206,7 +185,12 @@ class HuggingFaceVideo(extractor_base.BaseExtractor, hf.HuggingFaceMixin):
         subtimes = [k / self.num_frames * T for k in reversed(range(self.num_frames))]
         for event in events:
             if event.type == "Image":
-                yield self._get_image_data(event)  # type: ignore[arg-type]
+                yield nsbase.TimedArray(
+                    data=self._get_image_data(event),  # type: ignore[arg-type]
+                    frequency=0,
+                    start=event.start,
+                    duration=event.duration,
+                )
                 continue
             video = event.read()
 

--- a/neuralset-repo/neuralset/extractors/video.py
+++ b/neuralset-repo/neuralset/extractors/video.py
@@ -32,7 +32,10 @@ _VideoImage = image_extractors._VideoImage
 def _huggingface_video_event_uid(event: evts.Image | evts.Video) -> str:
     if event.type == "Video":
         return tp.cast(evts.Video, event)._splittable_event_uid()
-    return str(event.study_relative_path())
+    elif event.type == "Image":
+        return str(event.study_relative_path())
+    else:
+        raise ValueError(f"Incorrect event type for video extractor: {event.type}")
 
 
 def resamp_first_dim(data: torch.Tensor, new_first_dim: int) -> torch.Tensor:

--- a/neuralset-repo/neuralset/extractors/video.py
+++ b/neuralset-repo/neuralset/extractors/video.py
@@ -184,13 +184,17 @@ class HuggingFaceVideo(extractor_base.BaseExtractor, hf.HuggingFaceMixin):
                     start=event.start,
                     data=data,
                 )
-                continue
-            sub = data.with_start(event.start).overlap(  # type: ignore[union-attr]
-                start=start, duration=duration
-            )
-            if self.cache_n_layers is not None:
-                sub.data = self._aggregate_layers(sub.data)
-            yield sub
+            elif event.type == "Video":
+                sub = data.with_start(event.start).overlap(  # type: ignore[union-attr]
+                    start=start, duration=duration
+                )
+                if self.cache_n_layers is not None:
+                    sub.data = self._aggregate_layers(sub.data)
+                yield sub
+            else:
+                raise ValueError(
+                    f"Incorrect event type for video extractor: {event.type}"
+                )
 
     @infra.apply(
         item_uid=_huggingface_video_event_uid,
@@ -207,41 +211,49 @@ class HuggingFaceVideo(extractor_base.BaseExtractor, hf.HuggingFaceMixin):
         for event in events:
             if event.type == "Image":
                 yield self._get_image_data(event)  # type: ignore[arg-type]
-                continue
-            video = event.read()
+            elif event.type == "Video":
+                video = event.read()
 
-            expect_frames = nsbase.Frequency(self.frequency).to_ind(event.duration)
-            logger.debug(
-                "Loaded Video (duration %ss at %sfps, shape %s):\n%s",
-                video.duration,
-                video.fps,
-                tuple(video.size),
-                event.filepath,
-            )
-            # time at end of sample:
-            times = np.linspace(0, video.duration, expect_frames + 1)[1:]
-            # samples the frames in-between the main frequency
-            output = np.array([])
-            # pylint: disable=protected-access
-            for k, t in tqdm(enumerate(times), total=len(times), desc="Encoding video"):
-                ims = [_VideoImage(video=video, time=max(0, t - t2)) for t2 in subtimes]
-                pil_imgs = [i.read() for i in ims]
-                pil_imgs = self._resize_pil_images(pil_imgs)
-                data = np.array([np.array(pi) for pi in pil_imgs])
-                embd = self._embed_clip(data)
-                if not output.size:
-                    output = np.zeros((len(times),) + embd.shape)
-                    logger.debug("Created Tensor with size %s", output.shape)
-                output[k] = embd
-            video.close()
-            # set first (time) dim to last
-            output = output.transpose(list(range(1, output.ndim)) + [0])
-            yield nsbase.TimedArray(
-                data=output.astype(np.float32),
-                frequency=self.frequency,
-                start=nsbase._UNSET_START,
-                duration=event.duration,
-            )
+                expect_frames = nsbase.Frequency(self.frequency).to_ind(event.duration)
+                logger.debug(
+                    "Loaded Video (duration %ss at %sfps, shape %s):\n%s",
+                    video.duration,
+                    video.fps,
+                    tuple(video.size),
+                    event.filepath,
+                )
+                # time at end of sample:
+                times = np.linspace(0, video.duration, expect_frames + 1)[1:]
+                # samples the frames in-between the main frequency
+                output = np.array([])
+                # pylint: disable=protected-access
+                for k, t in tqdm(
+                    enumerate(times), total=len(times), desc="Encoding video"
+                ):
+                    ims = [
+                        _VideoImage(video=video, time=max(0, t - t2)) for t2 in subtimes
+                    ]
+                    pil_imgs = [i.read() for i in ims]
+                    pil_imgs = self._resize_pil_images(pil_imgs)
+                    data = np.array([np.array(pi) for pi in pil_imgs])
+                    embd = self._embed_clip(data)
+                    if not output.size:
+                        output = np.zeros((len(times),) + embd.shape)
+                        logger.debug("Created Tensor with size %s", output.shape)
+                    output[k] = embd
+                video.close()
+                # set first (time) dim to last
+                output = output.transpose(list(range(1, output.ndim)) + [0])
+                yield nsbase.TimedArray(
+                    data=output.astype(np.float32),
+                    frequency=self.frequency,
+                    start=nsbase._UNSET_START,
+                    duration=event.duration,
+                )
+            else:
+                raise ValueError(
+                    f"Incorrect event type for video extractor: {event.type}"
+                )
 
     def _get_image_data(self, event: evts.Image) -> np.ndarray:
         pil_img = event.read()

--- a/neuralset-repo/neuralset/extractors/video.py
+++ b/neuralset-repo/neuralset/extractors/video.py
@@ -31,8 +31,8 @@ _VideoImage = image_extractors._VideoImage
 
 
 def _huggingface_video_event_uid(event: evts.Image | evts.Video) -> str:
-    if isinstance(event, evts.Video):
-        return event._splittable_event_uid()
+    if event.type == "Video":
+        return tp.cast(evts.Video, event)._splittable_event_uid()
     return str(event.study_relative_path())
 
 
@@ -73,8 +73,8 @@ class HuggingFaceVideo(extractor_base.BaseExtractor, hf.HuggingFaceMixin):
     Videos are divided into clips of `clip_duration` seconds at the specified
     frequency. Each clip is processed by the video model, and features are
     aggregated over layers/tokens using the HuggingFace extractor options.
-    When `event_types="Image"`, each image is repeated into a static
-    `num_frames`-frame clip and returned as a static embedding.
+    Image events are repeated into static `num_frames`-frame clips and
+    returned as static embeddings.
 
     Parameters
     ----------
@@ -91,7 +91,9 @@ class HuggingFaceVideo(extractor_base.BaseExtractor, hf.HuggingFaceMixin):
         Number of frames to pass to the video model per clip.
     """
 
-    event_types: tp.Literal["Image", "Video"] = "Video"
+    event_types: (
+        tp.Literal["Image", "Video"] | tuple[tp.Literal["Image", "Video"], ...]
+    ) = "Video"
     SUPPORTED_MODELS: tp.ClassVar[tuple[str, ...]] = (
         "vjepa2",
         "videomae",
@@ -153,14 +155,31 @@ class HuggingFaceVideo(extractor_base.BaseExtractor, hf.HuggingFaceMixin):
         ) + hf.HuggingFaceMixin._exclude_from_cache_uid(self)
 
     def model_post_init(self, log__: tp.Any) -> None:
-        if self.event_types == "Image" and self.frequency == 0:
+        if self._uses_only_image_events() and self.frequency == 0:
             self._event_types_helper = EventTypesHelper(self.event_types)
             hf.HuggingFaceMixin.model_post_init(self, log__)
             return
         super().model_post_init(log__)
-        if self.event_types == "Image" and self.frequency != "native":
+        if self._supports_image_events() and not self._supports_video_events():
+            if self.frequency == "native":
+                return
             msg = "HuggingFaceVideo requires frequency=0 or 'native' for Image events."
             raise ValueError(msg)
+
+    def _supports_image_events(self) -> bool:
+        event_types = (
+            (self.event_types,) if isinstance(self.event_types, str) else self.event_types
+        )
+        return "Image" in event_types
+
+    def _supports_video_events(self) -> bool:
+        event_types = (
+            (self.event_types,) if isinstance(self.event_types, str) else self.event_types
+        )
+        return "Video" in event_types
+
+    def _uses_only_image_events(self) -> bool:
+        return self._supports_image_events() and not self._supports_video_events()
 
     def _get_timed_arrays(
         self,
@@ -168,10 +187,9 @@ class HuggingFaceVideo(extractor_base.BaseExtractor, hf.HuggingFaceMixin):
         start: float,
         duration: float,
     ) -> tp.Iterable[nsbase.TimedArray]:
-        if self.event_types == "Image":
-            image_events = tp.cast(list[evts.Image], events)
-            image_data = tp.cast(tp.Iterator[np.ndarray], self._get_data(image_events))
-            for image_event, data in zip(image_events, image_data):
+        for event, data in zip(events, self._get_data(events)):
+            if event.type == "Image":
+                image_event = tp.cast(evts.Image, event)
                 data = np.asarray(data)
                 if self.cache_n_layers is not None:
                     data = self._aggregate_layers(data)
@@ -181,10 +199,9 @@ class HuggingFaceVideo(extractor_base.BaseExtractor, hf.HuggingFaceMixin):
                     start=image_event.start,
                     data=data,
                 )
-            return
-        video_events = tp.cast(list[evts.Video], events)
-        video_data = tp.cast(tp.Iterator[nsbase.TimedArray], self._get_data(video_events))
-        for video_event, ta in zip(video_events, video_data):
+                continue
+            video_event = tp.cast(evts.Video, event)
+            ta = tp.cast(nsbase.TimedArray, data)
             sub = ta.with_start(video_event.start).overlap(start=start, duration=duration)
             if self.cache_n_layers is not None:
                 sub.data = self._aggregate_layers(sub.data)
@@ -200,14 +217,21 @@ class HuggingFaceVideo(extractor_base.BaseExtractor, hf.HuggingFaceMixin):
         # read all media events
         logging.getLogger("neuralset").setLevel(logging.DEBUG)
         self._warn_if_config_num_frames_mismatch()
-        if self.event_types == "Image":
-            yield from self._get_image_data(tp.cast(list[evts.Image], events))
-            return
-        video_events = tp.cast(list[evts.Video], events)
-        freq = video_events[0].frequency if self.frequency == "native" else self.frequency
-        T = 1 / freq if self.clip_duration is None else self.clip_duration
-        subtimes = [k / self.num_frames * T for k in reversed(range(self.num_frames))]
-        for event in video_events:
+        video_events = [event for event in events if event.type == "Video"]
+        subtimes: list[float] = []
+        if video_events:
+            freq = (
+                video_events[0].frequency
+                if self.frequency == "native"
+                else self.frequency
+            )
+            T = 1 / freq if self.clip_duration is None else self.clip_duration
+            subtimes = [k / self.num_frames * T for k in reversed(range(self.num_frames))]
+        for event in events:
+            if event.type == "Image":
+                yield self._get_image_data(tp.cast(evts.Image, event))
+                continue
+            event = tp.cast(evts.Video, event)
             video = event.read()
 
             freq = self.frequency if self.frequency != "native" else event.frequency
@@ -244,13 +268,12 @@ class HuggingFaceVideo(extractor_base.BaseExtractor, hf.HuggingFaceMixin):
                 duration=event.duration,
             )
 
-    def _get_image_data(self, events: list[evts.Image]) -> tp.Iterator[np.ndarray]:
-        for event in events:
-            pil_img = event.read()
-            pil_imgs = [pil_img.copy() for _ in range(self.num_frames)]
-            pil_imgs = self._resize_pil_images(pil_imgs)
-            data = np.array([np.array(pi) for pi in pil_imgs])
-            yield self._embed_clip(data)
+    def _get_image_data(self, event: evts.Image) -> np.ndarray:
+        pil_img = event.read()
+        pil_imgs = [pil_img.copy() for _ in range(self.num_frames)]
+        pil_imgs = self._resize_pil_images(pil_imgs)
+        data = np.array([np.array(pi) for pi in pil_imgs])
+        return self._embed_clip(data)
 
     def _resize_pil_images(self, pil_imgs: list[tp.Any]) -> list[tp.Any]:
         # resize if images are too big

--- a/neuralset-repo/neuralset/extractors/video.py
+++ b/neuralset-repo/neuralset/extractors/video.py
@@ -16,6 +16,7 @@ from exca import MapInfra
 from tqdm import tqdm
 
 from neuralset import base as nsbase
+from neuralset.events import EventTypesHelper
 from neuralset.events import etypes as evts
 
 from . import base as extractor_base
@@ -27,6 +28,12 @@ logger = logging.getLogger(__name__)
 # logging.getLogger("neuralset").setLevel(logging.DEBUG)
 
 _VideoImage = image_extractors._VideoImage
+
+
+def _huggingface_video_event_uid(event: evts.Image | evts.Video) -> str:
+    if isinstance(event, evts.Video):
+        return event._splittable_event_uid()
+    return str(event.study_relative_path())
 
 
 def resamp_first_dim(data: torch.Tensor, new_first_dim: int) -> torch.Tensor:
@@ -66,6 +73,8 @@ class HuggingFaceVideo(extractor_base.BaseExtractor, hf.HuggingFaceMixin):
     Videos are divided into clips of `clip_duration` seconds at the specified
     frequency. Each clip is processed by the video model, and features are
     aggregated over layers/tokens using the HuggingFace extractor options.
+    When `event_types="Image"`, each image is repeated into a static
+    `num_frames`-frame clip and returned as a static embedding.
 
     Parameters
     ----------
@@ -82,7 +91,7 @@ class HuggingFaceVideo(extractor_base.BaseExtractor, hf.HuggingFaceMixin):
         Number of frames to pass to the video model per clip.
     """
 
-    event_types: tp.Literal["Video"] = "Video"
+    event_types: tp.Literal["Image", "Video"] = "Video"
     SUPPORTED_MODELS: tp.ClassVar[tuple[str, ...]] = (
         "vjepa2",
         "videomae",
@@ -93,6 +102,7 @@ class HuggingFaceVideo(extractor_base.BaseExtractor, hf.HuggingFaceMixin):
     requirements: tp.ClassVar[tuple[str, ...]] = (
         "torchvision>=0.15.2",
         "julius>=0.2.7",
+        "pillow>=9.2.0",
     )
     model_name: str = "MCG-NJU/videomae-base"
     hf_config: HuggingFaceVideoConfig = HuggingFaceVideoConfig()
@@ -142,27 +152,62 @@ class HuggingFaceVideo(extractor_base.BaseExtractor, hf.HuggingFaceMixin):
             self
         ) + hf.HuggingFaceMixin._exclude_from_cache_uid(self)
 
+    def model_post_init(self, log__: tp.Any) -> None:
+        if self.event_types == "Image" and self.frequency == 0:
+            self._event_types_helper = EventTypesHelper(self.event_types)
+            hf.HuggingFaceMixin.model_post_init(self, log__)
+            return
+        super().model_post_init(log__)
+        if self.event_types == "Image" and self.frequency != "native":
+            msg = "HuggingFaceVideo requires frequency=0 or 'native' for Image events."
+            raise ValueError(msg)
+
     def _get_timed_arrays(
-        self, events: list[evts.Video], start: float, duration: float
+        self,
+        events: list[evts.Image | evts.Video],
+        start: float,
+        duration: float,
     ) -> tp.Iterable[nsbase.TimedArray]:
-        for event, ta in zip(events, self._get_data(events)):
-            sub = ta.with_start(event.start).overlap(start=start, duration=duration)
+        if self.event_types == "Image":
+            image_events = tp.cast(list[evts.Image], events)
+            image_data = tp.cast(tp.Iterator[np.ndarray], self._get_data(image_events))
+            for image_event, data in zip(image_events, image_data):
+                data = np.asarray(data)
+                if self.cache_n_layers is not None:
+                    data = self._aggregate_layers(data)
+                yield nsbase.TimedArray(
+                    frequency=0,
+                    duration=image_event.duration,
+                    start=image_event.start,
+                    data=data,
+                )
+            return
+        video_events = tp.cast(list[evts.Video], events)
+        video_data = tp.cast(tp.Iterator[nsbase.TimedArray], self._get_data(video_events))
+        for video_event, ta in zip(video_events, video_data):
+            sub = ta.with_start(video_event.start).overlap(start=start, duration=duration)
             if self.cache_n_layers is not None:
                 sub.data = self._aggregate_layers(sub.data)
             yield sub
 
     @infra.apply(
-        item_uid=lambda e: e._splittable_event_uid(),
+        item_uid=_huggingface_video_event_uid,
         exclude_from_cache_uid="method:_exclude_from_cache_uid",
     )
-    def _get_data(self, events: list[evts.Video]) -> tp.Iterator[nsbase.TimedArray]:
-        # read all videos of the events
+    def _get_data(
+        self, events: tp.Sequence[evts.Image | evts.Video]
+    ) -> tp.Iterator[np.ndarray | nsbase.TimedArray]:
+        # read all media events
         logging.getLogger("neuralset").setLevel(logging.DEBUG)
         self._warn_if_config_num_frames_mismatch()
-        freq = events[0].frequency if self.frequency == "native" else self.frequency
+        if self.event_types == "Image":
+            yield from self._get_image_data(tp.cast(list[evts.Image], events))
+            return
+        video_events = tp.cast(list[evts.Video], events)
+        freq = video_events[0].frequency if self.frequency == "native" else self.frequency
         T = 1 / freq if self.clip_duration is None else self.clip_duration
         subtimes = [k / self.num_frames * T for k in reversed(range(self.num_frames))]
-        for event in events:
+        for event in video_events:
             video = event.read()
 
             freq = self.frequency if self.frequency != "native" else event.frequency
@@ -182,20 +227,9 @@ class HuggingFaceVideo(extractor_base.BaseExtractor, hf.HuggingFaceMixin):
             for k, t in tqdm(enumerate(times), total=len(times), desc="Encoding video"):
                 ims = [_VideoImage(video=video, time=max(0, t - t2)) for t2 in subtimes]
                 pil_imgs = [i.read() for i in ims]
-                # resize if images are too big
-                if pil_imgs and self.max_imsize is not None:
-                    factor = max(pil_imgs[0].size) / self.max_imsize
-                    if factor > 1:
-                        size = tuple(int(s / factor) for s in pil_imgs[0].size)
-                        pil_imgs = [pi.resize(size) for pi in pil_imgs]
+                pil_imgs = self._resize_pil_images(pil_imgs)
                 data = np.array([np.array(pi) for pi in pil_imgs])
-                t_embd = self._predict_hidden_states(data)
-                if t_embd.shape[0] != 1:
-                    raise RuntimeError(f"Found several batches: {t_embd.shape}")
-                t_embd = t_embd[0]  # aggregate_tokens works on non-batched-data
-                embd = self._aggregate_tokens(t_embd).cpu().numpy()
-                if self.cache_n_layers is None:
-                    embd = self._aggregate_layers(embd)
+                embd = self._embed_clip(data)
                 if not output.size:
                     output = np.zeros((len(times),) + embd.shape)
                     logger.debug("Created Tensor with size %s", output.shape)
@@ -209,6 +243,33 @@ class HuggingFaceVideo(extractor_base.BaseExtractor, hf.HuggingFaceMixin):
                 start=nsbase._UNSET_START,
                 duration=event.duration,
             )
+
+    def _get_image_data(self, events: list[evts.Image]) -> tp.Iterator[np.ndarray]:
+        for event in events:
+            pil_img = event.read()
+            pil_imgs = [pil_img.copy() for _ in range(self.num_frames)]
+            pil_imgs = self._resize_pil_images(pil_imgs)
+            data = np.array([np.array(pi) for pi in pil_imgs])
+            yield self._embed_clip(data)
+
+    def _resize_pil_images(self, pil_imgs: list[tp.Any]) -> list[tp.Any]:
+        # resize if images are too big
+        if pil_imgs and self.max_imsize is not None:
+            factor = max(pil_imgs[0].size) / self.max_imsize
+            if factor > 1:
+                size = tuple(int(s / factor) for s in pil_imgs[0].size)
+                pil_imgs = [pi.resize(size) for pi in pil_imgs]
+        return pil_imgs
+
+    def _embed_clip(self, data: np.ndarray) -> np.ndarray:
+        t_embd = self._predict_hidden_states(data)
+        if t_embd.shape[0] != 1:
+            raise RuntimeError(f"Found several batches: {t_embd.shape}")
+        t_embd = t_embd[0]  # aggregate_tokens works on non-batched-data
+        embd = self._aggregate_tokens(t_embd).cpu().numpy()
+        if self.cache_n_layers is None:
+            embd = self._aggregate_layers(embd)
+        return embd.astype(np.float32)
 
     def _predict_hidden_states(self, images: np.ndarray) -> torch.Tensor:
         kwargs: dict[str, tp.Any] = {

--- a/neuralset-repo/neuralset/extractors/video.py
+++ b/neuralset-repo/neuralset/extractors/video.py
@@ -31,7 +31,7 @@ _VideoImage = image_extractors._VideoImage
 
 def _huggingface_video_event_uid(event: evts.Image | evts.Video) -> str:
     if event.type == "Video":
-        return tp.cast(evts.Video, event)._splittable_event_uid()
+        return event._splittable_event_uid()  # type: ignore[union-attr]
     elif event.type == "Image":
         return str(event.study_relative_path())
     else:
@@ -175,20 +175,19 @@ class HuggingFaceVideo(extractor_base.BaseExtractor, hf.HuggingFaceMixin):
     ) -> tp.Iterable[nsbase.TimedArray]:
         for event, data in zip(events, self._get_data(events)):
             if event.type == "Image":
-                image_event = tp.cast(evts.Image, event)
                 data = np.asarray(data)
                 if self.cache_n_layers is not None:
                     data = self._aggregate_layers(data)
                 yield nsbase.TimedArray(
                     frequency=0,
-                    duration=image_event.duration,
-                    start=image_event.start,
+                    duration=event.duration,
+                    start=event.start,
                     data=data,
                 )
                 continue
-            video_event = tp.cast(evts.Video, event)
-            ta = tp.cast(nsbase.TimedArray, data)
-            sub = ta.with_start(video_event.start).overlap(start=start, duration=duration)
+            sub = data.with_start(event.start).overlap(  # type: ignore[union-attr]
+                start=start, duration=duration
+            )
             if self.cache_n_layers is not None:
                 sub.data = self._aggregate_layers(sub.data)
             yield sub
@@ -203,21 +202,15 @@ class HuggingFaceVideo(extractor_base.BaseExtractor, hf.HuggingFaceMixin):
         # read all media events
         logging.getLogger("neuralset").setLevel(logging.DEBUG)
         self._warn_if_config_num_frames_mismatch()
-        video_events = [event for event in events if event.type == "Video"]
-        subtimes: list[float] = []
-        if video_events:
-            freq = self.frequency
-            T = 1 / freq if self.clip_duration is None else self.clip_duration
-            subtimes = [k / self.num_frames * T for k in reversed(range(self.num_frames))]
+        T = 1 / self.frequency if self.clip_duration is None else self.clip_duration
+        subtimes = [k / self.num_frames * T for k in reversed(range(self.num_frames))]
         for event in events:
             if event.type == "Image":
-                yield self._get_image_data(tp.cast(evts.Image, event))
+                yield self._get_image_data(event)  # type: ignore[arg-type]
                 continue
-            event = tp.cast(evts.Video, event)
             video = event.read()
 
-            freq = self.frequency
-            expect_frames = nsbase.Frequency(freq).to_ind(event.duration)
+            expect_frames = nsbase.Frequency(self.frequency).to_ind(event.duration)
             logger.debug(
                 "Loaded Video (duration %ss at %sfps, shape %s):\n%s",
                 video.duration,
@@ -245,7 +238,7 @@ class HuggingFaceVideo(extractor_base.BaseExtractor, hf.HuggingFaceMixin):
             output = output.transpose(list(range(1, output.ndim)) + [0])
             yield nsbase.TimedArray(
                 data=output.astype(np.float32),
-                frequency=freq,
+                frequency=self.frequency,
                 start=nsbase._UNSET_START,
                 duration=event.duration,
             )

--- a/neuralset-repo/neuralset/extractors/video.py
+++ b/neuralset-repo/neuralset/extractors/video.py
@@ -107,7 +107,7 @@ class HuggingFaceVideo(extractor_base.BaseExtractor, hf.HuggingFaceMixin):
     )
     model_name: str = "MCG-NJU/videomae-base"
     hf_config: HuggingFaceVideoConfig = HuggingFaceVideoConfig()
-    frequency: float | tp.Literal["native"] = 1.0
+    frequency: float = 1.0
     clip_duration: float | None = None
     max_imsize: int | None = None
     num_frames: int
@@ -154,6 +154,16 @@ class HuggingFaceVideo(extractor_base.BaseExtractor, hf.HuggingFaceMixin):
             self
         ) + hf.HuggingFaceMixin._exclude_from_cache_uid(self)
 
+    def model_post_init(self, log__: tp.Any) -> None:
+        super().model_post_init(log__)
+        if self.event_types == "Image":
+            warnings.warn(
+                "HuggingFaceVideo with event_types='Image' applies a video model "
+                "to repeated static image frames. Consider HuggingFaceImage for "
+                "image-only features.",
+                stacklevel=2,
+            )
+
     def _get_timed_arrays(
         self,
         events: list[evts.Image | evts.Video],
@@ -193,11 +203,7 @@ class HuggingFaceVideo(extractor_base.BaseExtractor, hf.HuggingFaceMixin):
         video_events = [event for event in events if event.type == "Video"]
         subtimes: list[float] = []
         if video_events:
-            freq = (
-                video_events[0].frequency
-                if self.frequency == "native"
-                else self.frequency
-            )
+            freq = self.frequency
             T = 1 / freq if self.clip_duration is None else self.clip_duration
             subtimes = [k / self.num_frames * T for k in reversed(range(self.num_frames))]
         for event in events:
@@ -207,7 +213,7 @@ class HuggingFaceVideo(extractor_base.BaseExtractor, hf.HuggingFaceMixin):
             event = tp.cast(evts.Video, event)
             video = event.read()
 
-            freq = self.frequency if self.frequency != "native" else event.frequency
+            freq = self.frequency
             expect_frames = nsbase.Frequency(freq).to_ind(event.duration)
             logger.debug(
                 "Loaded Video (duration %ss at %sfps, shape %s):\n%s",

--- a/neuralset-repo/neuralset/extractors/video.py
+++ b/neuralset-repo/neuralset/extractors/video.py
@@ -164,9 +164,14 @@ class HuggingFaceVideo(extractor_base.BaseExtractor, hf.HuggingFaceMixin):
         duration: float,
     ) -> tp.Iterable[nsbase.TimedArray]:
         for event, ta in zip(events, self._get_data(events)):
-            sub = ta
-            if sub.frequency:
-                sub = sub.with_start(event.start).overlap(start=start, duration=duration)
+            if event.type == "Video":
+                sub = ta.with_start(event.start).overlap(start=start, duration=duration)
+            elif event.type == "Image":
+                sub = ta
+            else:
+                raise ValueError(
+                    f"Incorrect event type for video extractor: {event.type}"
+                )
             if self.cache_n_layers is not None:
                 sub.data = self._aggregate_layers(sub.data)
             yield sub

--- a/neuralset-repo/neuralset/extractors/video.py
+++ b/neuralset-repo/neuralset/extractors/video.py
@@ -184,17 +184,13 @@ class HuggingFaceVideo(extractor_base.BaseExtractor, hf.HuggingFaceMixin):
                     start=event.start,
                     data=data,
                 )
-            elif event.type == "Video":
-                sub = data.with_start(event.start).overlap(  # type: ignore[union-attr]
-                    start=start, duration=duration
-                )
-                if self.cache_n_layers is not None:
-                    sub.data = self._aggregate_layers(sub.data)
-                yield sub
-            else:
-                raise ValueError(
-                    f"Incorrect event type for video extractor: {event.type}"
-                )
+                continue
+            sub = data.with_start(event.start).overlap(  # type: ignore[union-attr]
+                start=start, duration=duration
+            )
+            if self.cache_n_layers is not None:
+                sub.data = self._aggregate_layers(sub.data)
+            yield sub
 
     @infra.apply(
         item_uid=_huggingface_video_event_uid,
@@ -211,49 +207,41 @@ class HuggingFaceVideo(extractor_base.BaseExtractor, hf.HuggingFaceMixin):
         for event in events:
             if event.type == "Image":
                 yield self._get_image_data(event)  # type: ignore[arg-type]
-            elif event.type == "Video":
-                video = event.read()
+                continue
+            video = event.read()
 
-                expect_frames = nsbase.Frequency(self.frequency).to_ind(event.duration)
-                logger.debug(
-                    "Loaded Video (duration %ss at %sfps, shape %s):\n%s",
-                    video.duration,
-                    video.fps,
-                    tuple(video.size),
-                    event.filepath,
-                )
-                # time at end of sample:
-                times = np.linspace(0, video.duration, expect_frames + 1)[1:]
-                # samples the frames in-between the main frequency
-                output = np.array([])
-                # pylint: disable=protected-access
-                for k, t in tqdm(
-                    enumerate(times), total=len(times), desc="Encoding video"
-                ):
-                    ims = [
-                        _VideoImage(video=video, time=max(0, t - t2)) for t2 in subtimes
-                    ]
-                    pil_imgs = [i.read() for i in ims]
-                    pil_imgs = self._resize_pil_images(pil_imgs)
-                    data = np.array([np.array(pi) for pi in pil_imgs])
-                    embd = self._embed_clip(data)
-                    if not output.size:
-                        output = np.zeros((len(times),) + embd.shape)
-                        logger.debug("Created Tensor with size %s", output.shape)
-                    output[k] = embd
-                video.close()
-                # set first (time) dim to last
-                output = output.transpose(list(range(1, output.ndim)) + [0])
-                yield nsbase.TimedArray(
-                    data=output.astype(np.float32),
-                    frequency=self.frequency,
-                    start=nsbase._UNSET_START,
-                    duration=event.duration,
-                )
-            else:
-                raise ValueError(
-                    f"Incorrect event type for video extractor: {event.type}"
-                )
+            expect_frames = nsbase.Frequency(self.frequency).to_ind(event.duration)
+            logger.debug(
+                "Loaded Video (duration %ss at %sfps, shape %s):\n%s",
+                video.duration,
+                video.fps,
+                tuple(video.size),
+                event.filepath,
+            )
+            # time at end of sample:
+            times = np.linspace(0, video.duration, expect_frames + 1)[1:]
+            # samples the frames in-between the main frequency
+            output = np.array([])
+            # pylint: disable=protected-access
+            for k, t in tqdm(enumerate(times), total=len(times), desc="Encoding video"):
+                ims = [_VideoImage(video=video, time=max(0, t - t2)) for t2 in subtimes]
+                pil_imgs = [i.read() for i in ims]
+                pil_imgs = self._resize_pil_images(pil_imgs)
+                data = np.array([np.array(pi) for pi in pil_imgs])
+                embd = self._embed_clip(data)
+                if not output.size:
+                    output = np.zeros((len(times),) + embd.shape)
+                    logger.debug("Created Tensor with size %s", output.shape)
+                output[k] = embd
+            video.close()
+            # set first (time) dim to last
+            output = output.transpose(list(range(1, output.ndim)) + [0])
+            yield nsbase.TimedArray(
+                data=output.astype(np.float32),
+                frequency=self.frequency,
+                start=nsbase._UNSET_START,
+                duration=event.duration,
+            )
 
     def _get_image_data(self, event: evts.Image) -> np.ndarray:
         pil_img = event.read()


### PR DESCRIPTION
## Summary
- Extends `HuggingFaceVideo` to accept `event_types="Image"` and encode each image as a static repeated-frame clip with `num_frames` frames.
- Reuses the existing native video model prediction, token aggregation, and layer aggregation path for both real video clips and static image clips.
- Adds image-aware cache keys and a focused non-network test that verifies repeated static clips are sent to the video model.

## Issue Addressed
`HuggingFaceVideo` previously only accepted `Video` events, so image stimuli could not be embedded with native HuggingFace video models. This change lets image events be passed through the same video model path by converting each image into a static clip.

## Usage Example
```python
extractor = neuralset.extractors.HuggingFaceVideo(
    event_types="Image",
    model_name="MCG-NJU/videomae-base",
    num_frames=16,
    device="cpu",
)
embedding = extractor(image_event, start=image_event.start, duration=image_event.duration)
```

## Test plan
- `../.venv/bin/python -m pytest neuralset/extractors/test_video.py::test_video_requirements neuralset/extractors/test_video.py::test_huggingface_video_static_image_clip`
- `../.venv/bin/python -m mypy neuralset/extractors/video.py` currently reaches an unrelated baseline error in `neuralset/segments.py:397`; no errors are reported in `video.py`.


Made with [Cursor](https://cursor.com)