### PR TITLE
Bug Fix: 'numpy.ndarray' object has no attribute 'cpu'

### DIFF
--- a/neuralset-repo/neuralset/extractors/hf.py
+++ b/neuralset-repo/neuralset/extractors/hf.py
@@ -331,6 +331,8 @@ class HuggingFaceMixin(base.BaseModel):
             else:
                 return latents[layer_indices[0]]
         else:  # aggregate
+            if isinstance(latents, torch.Tensor):
+                latents = latents.cpu()
             latents = np.asarray(latents)  # ContiguousMemmap must be loaded first
             if self.layer_aggregation == "mean":
                 return latents[layer_indices].mean(0)  # type: ignore

--- a/neuralset-repo/neuralset/extractors/image.py
+++ b/neuralset-repo/neuralset/extractors/image.py
@@ -183,10 +183,10 @@ class HuggingFaceImage(extractor_base.BaseStatic, hf.HuggingFaceMixin):
                     # notes: - aggregating with a batch would be slightly more efficient
                     # but code would be messier
                     # - aggregating in cuda avoids transferring too much data to cpu
-                    latent = self._aggregate_tokens(latent)
+                    latent = self._aggregate_tokens(latent).cpu().numpy()
                     if aggregate_layers:
                         latent = self._aggregate_layers(latent)
-                    yield latent.cpu().numpy()
+                    yield latent
 
     @infra.apply(
         item_uid=_huggingface_image_event_uid,

--- a/neuralset-repo/neuralset/extractors/image.py
+++ b/neuralset-repo/neuralset/extractors/image.py
@@ -183,10 +183,10 @@ class HuggingFaceImage(extractor_base.BaseStatic, hf.HuggingFaceMixin):
                     # notes: - aggregating with a batch would be slightly more efficient
                     # but code would be messier
                     # - aggregating in cuda avoids transferring too much data to cpu
-                    latent = self._aggregate_tokens(latent).cpu().numpy()
+                    latent = self._aggregate_tokens(latent)
                     if aggregate_layers:
                         latent = self._aggregate_layers(latent)
-                    yield latent
+                    yield latent.cpu().numpy() if isinstance(latent, torch.Tensor) else latent
 
     @infra.apply(
         item_uid=_huggingface_image_event_uid,

--- a/neuralset-repo/neuralset/extractors/test_image.py
+++ b/neuralset-repo/neuralset/extractors/test_image.py
@@ -227,21 +227,33 @@ def test_openai_clip_layer(
     else:
         assert out.shape == (768,)
 
-def test_bug_dinov2(cat_event: etypes.Image) -> None:
+@pytest.mark.parametrize("device", ['cpu', 'cuda'])
+@pytest.mark.parametrize('layers', ['all', 1, [0,1]])
+@pytest.mark.parametrize('layer_aggregation', [None, 'mean'])
+def test_bug_dinov2(cat_event: etypes.Image, device: str, layers: tp.Union[str, int, list], layer_aggregation: tp.Optional[str]) -> None:
     # Test: AttributeError when applying .cpu() to numpy array
     # Happens with layers='all' and layer_aggregation=None
+    if device == 'cuda' and not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    
     extractor = ns.extractors.HuggingFaceImage(
         model_name="facebook/dinov2-base",
-        device="cpu",
-        layers="all",
-        layer_aggregation=None,
+        device=device,
+        layers=layers,
+        layer_aggregation=layer_aggregation,
     )
     latent = next(iter(extractor._get_data([cat_event])))
     assert isinstance(latent, np.ndarray)
-    # layer_aggregation=None + token_aggregation='mean' -> (n_layers, embed_dim)
-    assert latent.ndim == 2
-    n_layers, embed_dim = latent.shape
-    assert n_layers > 1, "Expected all layers to be returned"
+
+    # When layer_aggregation is 'mean', the output is 1D (embed_dim,)
+    # When layer_aggregation is None, the output is 2D (n_layers, embed_dim)
+    if layer_aggregation == 'mean':
+        assert latent.ndim == 1, f"Expected 1D array with layer_aggregation='mean', got shape {latent.shape}"
+        embed_dim = latent.shape[0]
+    else:
+        assert latent.ndim == 2, f"Expected 2D array with layer_aggregation=None, got shape {latent.shape}"
+        n_layers, embed_dim = latent.shape
+    
     assert embed_dim == 768  
     assert np.isfinite(latent).all()
 

--- a/neuralset-repo/neuralset/extractors/test_image.py
+++ b/neuralset-repo/neuralset/extractors/test_image.py
@@ -227,6 +227,24 @@ def test_openai_clip_layer(
     else:
         assert out.shape == (768,)
 
+def test_bug_dinov2(cat_event: etypes.Image) -> None:
+    # Test: AttributeError when applying .cpu() to numpy array
+    # Happens with layers='all' and layer_aggregation=None
+    extractor = ns.extractors.HuggingFaceImage(
+        model_name="facebook/dinov2-base",
+        device="cpu",
+        layers="all",
+        layer_aggregation=None,
+    )
+    latent = next(iter(extractor._get_data([cat_event])))
+    assert isinstance(latent, np.ndarray)
+    # layer_aggregation=None + token_aggregation='mean' -> (n_layers, embed_dim)
+    assert latent.ndim == 2
+    n_layers, embed_dim = latent.shape
+    assert n_layers > 1, "Expected all layers to be returned"
+    assert embed_dim == 768  
+    assert np.isfinite(latent).all()
+
 
 def test_hf_dinov2(cat_event: etypes.Image) -> None:
     extractor = ns.extractors.HuggingFaceImage(


### PR DESCRIPTION
## Bug
1. When extracting DINO image embeddings from all layers with layer_aggregation=None, iterating over the extracted embeddings raises:

`AttributeError: 'numpy.ndarray' object has no attribute 'cpu'`

This can be reproduced by simply iterating over the extractor 

```
extractor = ns.extractors.HuggingFaceImage(
    model_name="facebook/dinov2-base",
    device="cpu",
    layers="all",
    layer_aggregation=None,
)
latent = next(iter(extractor._get_data([cat_event])))
```

The root is in HuggingFaceMixin._aggregate_layers: when len(layer_indices) > 1, the tensor gets converted to a numpy array. But in HuggingFaceImage._iter_image_latents, the code unconditionally calls .cpu().numpy() on the result, which fails since it's already a numpy array:

```
latent = self._aggregate_tokens(latent)
if aggregate_layers:
    latent = self._aggregate_layers(latent)
yield latent.cpu().numpy()
       ^^^^^^^^^^
AttributeError: 'numpy.ndarray' object has no attribute 'cpu'
```

2. Another related issue that appears arises when device="cuda", this time from HuggingFaceMixin._aggregate_layers, since latests is being converted to numpy before being passed to cpu:

```
latents = np.asarray(latents)  # ContiguousMemmap must be loaded first
          ^^^^^^^^^^^^^^^^^^^
TypeError: can't convert cuda:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.
```

## Fix

1. HuggingFaceImage._iter_image_latents: only call .cpu().numpy() if latent is still a torch.Tensor
2. HuggingFaceMixin._aggregate_layers: move tensors to CPU before converting to numpy if necessary

## Checks

- Pytest added and passing 