### PR TITLE
Use a Step infra for timelines in Study

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-- `neuralset`: fixed `Mne2013Sample`/`Fake2025Meg` re-downloading the MNE sample dataset on `run()` after `download()` by funneling all paths through a single root; the download progress bar now also shows when `run()` triggers the fetch. The study subfolder is now resolved once in `model_post_init` instead of mutating `self.path` in `download()`, so calling `download()` after `run()` no longer crashes on the frozen instance (#153).
-- `neuralfetch`: added `Allen2022MassiveRaw` (BIDS/deepprep NSD variant) and gated NSD downloads behind the `NSD_ACCEPT_LICENCE` env var.
-- `neuralbench`: added a `CLUSTER` key to `~/.neuralbench/config.json` to force fully local execution (`null`) without `--debug`, keep the default SLURM auto-detection (`"auto"`), or always submit to SLURM (`"slurm"`); honored by `--prepare`.
-- `neuralbench`: a blank `WANDB_HOST` now genuinely disables Weights & Biases logging (previously `wandb.login` was still invoked).
+- `neuralset`: `Study.version` is now a top-level field; `infra_timelines` → `timelines.infra` (Step syntax, defaults to `ProcessPool`). Requires exca ≥ 0.5.27. (#194)
+- `neuralset`: fixed `Mne2013Sample`/`Fake2025Meg` re-downloading MNE sample data on `run()` after `download()` (#157).
+- `neuralfetch`: added `Allen2022MassiveRaw` (BIDS/deepprep NSD variant) and gated NSD downloads behind `NSD_ACCEPT_LICENCE` (#105).
+- `neuralbench`: added `CLUSTER` key to `~/.neuralbench/config.json` (`null` = local, `"auto"` = SLURM auto-detect, `"slurm"` = always SLURM); honored by `--prepare` (#118).
+- `neuralbench`: blank `WANDB_HOST` now disables W&B logging (previously `wandb.login` was still called) (#118).
 
 ## [0.2.1] - 2026-05-13
 

--- a/neuralbench-repo/neuralbench/conftest.py
+++ b/neuralbench-repo/neuralbench/conftest.py
@@ -15,10 +15,6 @@ import pytest
 from . import config_manager
 from .data import Data
 
-# Bypass multiprocessing in the test sandbox; ``Test2024Eeg`` is tiny enough
-# that in-process execution is fast.
-_NO_CLUSTER: tp.Any = {"cluster": None}
-
 
 @pytest.fixture
 def patch_config(monkeypatch: pytest.MonkeyPatch) -> Callable[..., None]:
@@ -75,7 +71,6 @@ def build_data(
             study={
                 "name": "Test2024Eeg",
                 "path": test2024eeg_path,
-                "infra_timelines": _NO_CLUSTER,
             },
             neuro={"name": "MneRaw", "event_types": "Eeg"},
             target={

--- a/neuralfetch-repo/neuralfetch/studies/bel2026petit.py
+++ b/neuralfetch-repo/neuralfetch/studies/bel2026petit.py
@@ -83,7 +83,7 @@ class _Bel2026PetitBase(study.Study):
 
     def model_post_init(self, log__: tp.Any) -> None:
         super().model_post_init(log__)
-        self.infra_timelines.version = "v3"
+        self.version = "v3"
 
     def _download(self) -> None:
         raise NotImplementedError(

--- a/neuralfetch-repo/neuralfetch/studies/li2022petit.py
+++ b/neuralfetch-repo/neuralfetch/studies/li2022petit.py
@@ -104,7 +104,7 @@ class Li2022Petit(study.Study):
 
     def model_post_init(self, log__: tp.Any) -> None:
         super().model_post_init(log__)
-        self.infra_timelines.version = "v3"
+        self.version = "v3"
 
     def _download(self) -> None:
         """

--- a/neuralfetch-repo/neuralfetch/studies/moabb2025.py
+++ b/neuralfetch-repo/neuralfetch/studies/moabb2025.py
@@ -60,6 +60,7 @@ from pathlib import Path
 import mne
 import numpy as np
 import pandas as pd
+from exca.steps import backends
 from scipy.io import loadmat
 
 from neuralfetch.download import temp_mne_data
@@ -192,14 +193,12 @@ class _BaseMoabb(studies.Study):
         # It will transform /path -> /path/StudyName
         super().model_post_init(log__)
 
-        # Disable the processpool for MOABB datasets: some (e.g. ERP CORE)
+        # Force inline timeline loading for MOABB datasets: some (e.g. ERP CORE)
         # load via mne_bids which uses file locks that exhaust NFS NLM limits
         # when too many workers run in parallel (ENOLCK).  Timeline events are
         # cached on disk by exca, so sequential loading only costs on first run.
-        if self.infra_timelines.cluster == "processpool":
-            self.infra_timelines = self.infra_timelines.model_copy(
-                update={"cluster": None}
-            )
+        if isinstance(self.timelines.infra, backends.ProcessPool):
+            self.timelines.infra = self.timelines.infra.derive("Cached")
 
         # Now insert 'moabb' before the study name
         # self.path is now /path/StudyName, we want /path/moabb/StudyName

--- a/neuralfetch-repo/neuralfetch/test_moabb2025.py
+++ b/neuralfetch-repo/neuralfetch/test_moabb2025.py
@@ -10,6 +10,8 @@ import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+from exca.steps import backends
+
 from neuralfetch.studies import moabb2025
 from neuralfetch.studies.moabb2025 import Tangermann2012Review
 
@@ -51,11 +53,9 @@ def test_get_cached_moabb_data_lru(tmp_path: Path) -> None:
 
 
 def test_basemoabb_disables_processpool(tmp_path: Path) -> None:
-    study = Tangermann2012Review(path=tmp_path)
-    assert study.infra_timelines.cluster != "processpool"
-
-    study_pp = Tangermann2012Review(
+    # an explicit ProcessPool is downgraded to Cached (inline) to avoid ENOLCK
+    study = Tangermann2012Review(
         path=tmp_path,
-        infra_timelines={"cluster": "processpool"},  # type: ignore[arg-type]
+        timelines={"infra": {"backend": "ProcessPool"}},  # type: ignore[arg-type]
     )
-    assert study_pp.infra_timelines.cluster is None
+    assert isinstance(study.timelines.infra, backends.Cached)

--- a/neuralfetch-repo/neuralfetch/utils.py
+++ b/neuralfetch-repo/neuralfetch/utils.py
@@ -68,7 +68,6 @@ def compute_study_info(name: str, folder: str | Path) -> dict[str, tp.Any]:
     query = info.query if info is not None else default_query
     if query != default_query:
         study = ns.Study(name=name, path=folder, query=query)
-    study.infra_timelines.cluster = None  # avoid process pool startup
     cls._info = None  # bypass num_timelines check during loading
     try:
         summary = study.study_summary(apply_query=False)

--- a/neuralset-repo/neuralset/events/study.py
+++ b/neuralset-repo/neuralset/events/study.py
@@ -13,10 +13,9 @@ import warnings
 from pathlib import Path
 
 import exca
-import exca.steps
 import pandas as pd
 import pydantic
-import ujson
+from exca.steps import backends, patterns
 
 from neuralset import base
 
@@ -251,7 +250,19 @@ def _dict_to_kv(d: dict[str, tp.Any]) -> str:
     return ",".join(f"{k}={v}" for k, v in sorted(d.items()))
 
 
-class Study(base.Step):
+class TimelineLoader(base.Step):
+    """Per-timeline caching body for :class:`Study` (one cache entry per timeline)."""
+
+    CACHE_TYPE: tp.ClassVar[str | None] = "ValidatedParquet"  # preserves str dtypes
+
+    # Study.model_post_init reverts this to None when no cache folder resolves
+    infra: backends.Backend | None = backends.ProcessPool(keep_in_ram=True)
+
+    def _run(self, events: pd.DataFrame) -> pd.DataFrame:
+        return events
+
+
+class Study(patterns.Scatter, base.Step):  # type: ignore[misc]
     """Interface to an external dataset: loads :term:`events <event>` from raw recordings.
 
     Subclass ``Study`` to create an interface to a new dataset. Override
@@ -265,10 +276,12 @@ class Study(base.Step):
         ``path`` (e.g. ``path="/data"``): each study automatically
         resolves its own subfolder (e.g. ``/data/MyStudy``), so you
         only need to configure one path for your entire data store.
-    infra_timelines : MapInfra
-        Caching/compute backend for per-timeline event loading. Uses
-        multiprocessing by default (``cluster="processpool"``); set
-        ``cluster=None`` to disable (slower, but easier to debug).
+    timelines : TimelineLoader
+        Per-timeline loader; ``timelines.infra`` sets how loads are dispatched and
+        cached (default: a process pool). Disable the pool via ``infra=None``
+        (inline, uncached) or ``infra.derive("Cached")`` (cached, in-process).
+    version : str
+        Cache-busting key kept in the uid; bump when loading logic changes.
     query : Query or None
         Optional filter applied after loading (e.g. ``"timeline_index < 5"``).
 
@@ -297,11 +310,15 @@ class Study(base.Step):
     CACHE_TYPE: tp.ClassVar[str | None] = "ValidatedParquet"
 
     path: Path
-    infra_timelines: exca.MapInfra = exca.MapInfra(cluster="processpool")
+    timelines: TimelineLoader = TimelineLoader()
+    version: str = ""
     query: base.Query | None = None
 
     # internal
     _cls_string: str = ""  # cache
+    _timelines: list[dict[str, tp.Any]] | None = (
+        None  # iter_timelines() memo; dropped at pickle
+    )
 
     # Class level info
     _info: tp.ClassVar[None | StudyInfo] = None  # for easy testing
@@ -354,6 +371,48 @@ class Study(base.Step):
             _resolve_study(name)
         return super().__new__(cls, **kwargs)  # type: ignore[return-value]
 
+    @pydantic.model_validator(mode="before")
+    @classmethod
+    def _migrate_infra_timelines(cls, data: tp.Any) -> tp.Any:
+        # deprecated: most submitit knobs don't map cleanly to steps-backends.
+        if not isinstance(data, dict) or "infra_timelines" not in data:
+            return data
+        data = dict(data)
+        legacy = data.pop("infra_timelines")
+        if isinstance(legacy, exca.MapInfra):
+            # set fields only: defaults would falsely trip the error below
+            legacy = {k: getattr(legacy, k) for k in legacy.model_fields_set}
+        if isinstance(legacy, dict) and legacy == {"cluster": None}:
+            warnings.warn(
+                "infra_timelines={'cluster': None} is deprecated; pass "
+                "timelines={'infra': {'backend': 'Cached'}} (cached) or "
+                "timelines={'infra': None} (uncached) instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            # cluster=None was inline but cached: Cached with a folder, else None.
+            infra = data.get("infra")
+            if isinstance(infra, backends.Backend):
+                folder = infra.folder
+            elif isinstance(infra, dict):
+                folder = infra.get("folder")
+            else:
+                folder = None
+            downgrade = {"backend": "Cached"} if folder is not None else None
+            data.setdefault("timelines", {"infra": downgrade})
+            return data
+        raise ValueError(
+            f"infra_timelines={legacy!r} was removed; configure the per-timeline "
+            "loader via timelines={'infra': {...}}, e.g.\n"
+            "  infra_timelines={'cluster': 'slurm', 'folder': F, 'slurm_partition': P}"
+            "  # old\n"
+            "  timelines={'infra': {'backend': 'Slurm', 'folder': F, 'partition': P}}"
+            "  # new\n"
+            "cluster->backend: None->Cached (or infra=None to skip caching), "
+            "processpool->ProcessPool, slurm->Slurm, auto->Auto; "
+            "slurm_partition->partition."
+        )
+
     def iter_timelines(self) -> tp.Iterator[dict[str, tp.Any]]:
         raise NotImplementedError
         # # example:
@@ -404,7 +463,7 @@ class Study(base.Step):
         """Descriptor for the study instance parametrization"""
         cls_kwargs: tp.Any = self.model_dump(serialize_as_any=True, exclude_defaults=True)
         # Exclude standard fields from class kwargs
-        for p in ["infra", "infra_timelines", "path", "name", "query"]:
+        for p in ["infra", "timelines", "version", "path", "name", "query"]:
             cls_kwargs.pop(p, None)
         if cls_kwargs:
             # should the class parameter be part of the timeline? or does
@@ -425,7 +484,8 @@ class Study(base.Step):
 
     @classmethod
     def _exclude_from_cls_uid(cls) -> list[str]:
-        return super()._exclude_from_cls_uid() + ["path"]
+        # path locates data; timelines is a no-op caching body (load is in take)
+        return super()._exclude_from_cls_uid() + ["path", "timelines"]
 
     def model_post_init(self, log__: tp.Any) -> None:
         super().model_post_init(log__)
@@ -435,23 +495,15 @@ class Study(base.Step):
                 "or pass name= to dispatch: Study(name='MyStudy2024', path=...)"
             )
         name = self.__class__.__name__
-        # Settle the study subfolder once, here at construction, before exca can
-        # freeze the instance: prefer an existing ``<path>/<name>`` (or lowercase)
-        # folder, otherwise append ``<name>``. ``download()`` then never reassigns
-        # ``self.path`` — which would crash on a frozen post-``run()`` instance
-        # (issue #153, run -> download order).
+        # frozen post-run() -> download() can't reassign self.path; settle it here (#153)
         self.path = _identify_study_subfolder(self.path, name)
         if self.path.name.lower() != name.lower():
             self.path = self.path / name
         STUDY_PATHS[self.__class__.__name__] = self.path  # record for path lookup
-        # Auto-propagate cache folder and mode so users only need to set it once
-        if self.infra is not None:
-            if self.infra.folder is not None and self.infra_timelines.folder is None:
-                self.infra_timelines.folder = self.infra.folder
-            if "mode" in self.infra.model_fields_set:
-                if "mode" not in self.infra_timelines.model_fields_set:
-                    mode = self.infra.mode
-                    self.infra_timelines.mode = "cached" if mode == "retry" else mode
+
+        if "infra" not in self.timelines.model_fields_set:
+            if self.infra is None or self.infra.folder is None:
+                self.timelines.infra = None  # a backend needs a folder
 
     def __init_subclass__(cls, **kwargs: tp.Any) -> None:
         name = cls.__name__
@@ -465,11 +517,13 @@ class Study(base.Step):
                     f"cannot re-register to {cls.__module__}.{cls.__qualname__}"
                 )
             STUDIES[name] = cls
-        if hasattr(cls, "version"):
-            msg = (
-                f"{name}.version must be specified through {name}.infra_timelines.version"
-            )
-            raise RuntimeError(msg)
+
+    def __getstate__(self) -> dict[str, tp.Any]:
+        out = super().__getstate__()
+        private = out.get("__pydantic_private__")
+        if private is not None:
+            private["_timelines"] = None  # workers re-scan; don't ship the memo
+        return out
 
     def __setstate__(self, state: dict[str, tp.Any]) -> None:
         super().__setstate__(state)
@@ -479,95 +533,98 @@ class Study(base.Step):
         if "path" in self.__dict__:
             STUDY_PATHS[self.__class__.__name__] = self.path
 
-    @infra_timelines.apply(
-        item_uid=lambda x: ujson.dumps(x, sort_keys=True),
-        exclude_from_cache_uid=("query",),
-        cache_type="ValidatedParquet",  # preserves str dtypes (CSV doesn't)
-    )
-    def _load_timelines(
-        self, timelines: tp.Iterable[dict[str, tp.Any]]
-    ) -> tp.Iterator[pd.DataFrame]:
-        """Loads raw timelines and cache them"""
+    def _load_one(self, timeline: dict[str, tp.Any]) -> pd.DataFrame:
+        """Load and standardize one timeline's events."""
         cls_name = self.__class__.__name__
-        for timeline in timelines:
-            if "subject" not in timeline:
-                raise RuntimeError("timeline dict must contain 'subject' key")
-            out = self._load_timeline_events(timeline)
-            # Core columns are always overwritten
-            out.loc[:, "subject"] = f"{cls_name}/{timeline['subject']}"
-            out.loc[:, "timeline"] = self._to_timeline_string(timeline)
-            out.loc[:, "study"] = cls_name
-            # Extra columns from timeline dict: conflict-check then set
-            extra: dict[str, str] = {}
-            for key, value in timeline.items():
-                if key not in ("subject", "path", "timeline"):
-                    extra[key] = str(value)
-            for entity in utils.BIDS_ENTITIES:
-                if entity != "subject":
-                    extra.setdefault(entity, utils.BIDS_ENTITY_DEFAULT)
-            for col, value in extra.items():
-                if col not in out.columns:
-                    out.loc[:, col] = value
-                elif (out[col].astype(str) == value).all():
-                    warnings.warn(
-                        f"Column '{col}' from timeline dict already exists "
-                        f"in the events dataframe with matching values. "
-                        f"Remove it from _load_timeline_events to avoid "
-                        f"future errors.",
-                        FutureWarning,
-                    )
-                elif (
-                    col in utils.BIDS_ENTITIES
-                    and (out[col].astype(str) == utils.BIDS_ENTITY_DEFAULT).all()
-                ):
-                    out.loc[:, col] = value
-                else:
-                    raise ValueError(
-                        f"Column '{col}' from timeline dict already exists "
-                        f"in the events dataframe with different values."
-                    )
-            out = utils.standardize_events(out)
-            yield out
+        if "subject" not in timeline:
+            raise RuntimeError("timeline dict must contain 'subject' key")
+        out = self._load_timeline_events(timeline)
+        # Core columns are always overwritten
+        out.loc[:, "subject"] = f"{cls_name}/{timeline['subject']}"
+        out.loc[:, "timeline"] = self._to_timeline_string(timeline)
+        out.loc[:, "study"] = cls_name
+        # Extra columns from timeline dict: conflict-check then set
+        extra: dict[str, str] = {}
+        for key, value in timeline.items():
+            if key not in ("subject", "path", "timeline"):
+                extra[key] = str(value)
+        for entity in utils.BIDS_ENTITIES:
+            if entity != "subject":
+                extra.setdefault(entity, utils.BIDS_ENTITY_DEFAULT)
+        for col, value in extra.items():
+            if col not in out.columns:
+                out.loc[:, col] = value
+            elif (out[col].astype(str) == value).all():
+                warnings.warn(
+                    f"Column '{col}' from timeline dict already exists "
+                    f"in the events dataframe with matching values. "
+                    f"Remove it from _load_timeline_events to avoid "
+                    f"future errors.",
+                    FutureWarning,
+                )
+            elif (
+                col in utils.BIDS_ENTITIES
+                and (out[col].astype(str) == utils.BIDS_ENTITY_DEFAULT).all()
+            ):
+                out.loc[:, col] = value
+            else:
+                raise ValueError(
+                    f"Column '{col}' from timeline dict already exists "
+                    f"in the events dataframe with different values."
+                )
+        return utils.standardize_events(out)
 
-    def _run(self, events: pd.DataFrame | None = None) -> pd.DataFrame:
-        """Load study data and optionally concatenate with existing events."""
-        if events is not None:  # special case, concatenate
-            df = self._run()
-            return pd.concat([events, df], ignore_index=True).reset_index(drop=True)
+    def _branch_excludes(self) -> list[str]:
+        # query only selects which timelines run; the input is empty (a source).
+        # Neither defines a timeline.
+        return ["query", self._INPUT]
+
+    def _all_timelines(self) -> list[dict[str, tp.Any]]:
+        if self._timelines is not None:
+            return self._timelines
         name = self.__class__.__name__
-        timelines = []
-        # iterate 1 by 1 to provide explicit msg to different kinds of bugs
+        tls: list[dict[str, tp.Any]] = []
+        # accumulate (not list(...)) so the except can tell a first-item failure
         try:
             for tl in self.iter_timelines():
-                timelines.append(tl)
+                tls.append(tl)
         except Exception as e:
-            # for a bug on the first timeline with no folder, raise with more info,
-            if not timelines and not self.path.exists():
+            if not tls and not self.path.exists():  # almost surely not downloaded
                 msg = f"For {name}, you may need to run study.download() first "
                 msg += f"as {self.path} does not exist."
                 raise RuntimeError(msg) from e
             raise
-        if not timelines:
+        if not tls:
             raise RuntimeError(f"No timeline found for {name} in {self.path}")
-        # verify number of timelines in info
-        if self._info is not None:
-            tls = self._info.num_timelines
-            if tls != len(timelines):
-                msg = f"Dataset {name} is corrupted, expected {tls} timelines "
-                msg += f"but found {len(timelines)} (check/redownload dataset "
-                msg += f"folder {self.path} or update study class)"
-                raise RuntimeError(msg)
-        # filter through summary
-        if self.query is not None:
-            summ = self.study_summary(apply_query=True)
-            timelines = [timelines[k] for k in summ.index]
-        if not timelines:
+        if self._info is not None and self._info.num_timelines != len(tls):
+            msg = f"Dataset {name} is corrupted, expected {self._info.num_timelines} "
+            msg += f"timelines but found {len(tls)} (check/redownload dataset "
+            msg += f"folder {self.path} or update study class)"
+            raise RuntimeError(msg)
+        self._timelines = tls
+        return tls
+
+    def branches(self, item: tp.Any) -> list[dict[str, tp.Any]]:
+        """Query-selected timeline dicts to load, one per branch (``item`` is unused)."""
+        name = self.__class__.__name__
+        tls = self._all_timelines()
+        if self.query is None:
+            return tls
+        # study_summary reads the same memoized tls, so its index maps back to tls[k]
+        summ = self.study_summary(apply_query=True)
+        selected = [tls[k] for k in summ.index]
+        if not selected:
             msg = f"Did not find any timeline for {name}.query={self.query} "
             msg += f"with summary:\n{self.study_summary(apply_query=False)}"
             raise RuntimeError(msg)
-        # load and concatenate
-        timelines_events = list(self._load_timelines(timelines))
-        out = pd.concat(timelines_events).reset_index(drop=True)
+        return selected
+
+    def take(self, item: tp.Any, branch: dict[str, tp.Any]) -> pd.DataFrame:
+        return self._load_one(branch)
+
+    def gather(self, results: list[patterns.BranchResult]) -> pd.DataFrame:
+        """Concatenated per-timeline events."""
+        out = pd.concat([r.result for r in results]).reset_index(drop=True)
         return utils.standardize_events(out, auto_fill=False)
 
     def build(self) -> pd.DataFrame:
@@ -581,7 +638,7 @@ class Study(base.Step):
         Parameter
         ---------
         apply_query: bool
-            if False returns the full the summary, otherwise filter it
+            if False returns the full summary, otherwise filter it
             according to the query
 
         Virtual query columns
@@ -599,10 +656,8 @@ class Study(base.Step):
             (used for querying at most :code:`n` timelines per subjects)
         """
         name = self.__class__.__name__
-        tls = list(self.iter_timelines())
+        tls = self._all_timelines()
         out = pd.DataFrame(tls)
-        if out.empty:
-            raise RuntimeError(f"No timeline found for {self!r}")
         out["subject"] = out["subject"].apply(lambda x: f"{name}/{x}")
         out.loc[:, "timeline"] = [self._to_timeline_string(tl) for tl in tls]
         out = out.sort_values("subject", kind="stable")

--- a/neuralset-repo/neuralset/events/test_study.py
+++ b/neuralset-repo/neuralset/events/test_study.py
@@ -110,8 +110,7 @@ def test_loader_on_external_study(tmp_path: Path) -> None:
 
 
 def test_study_download(tmp_path: Path) -> None:
-    infra: tp.Any = {"cluster": None}
-    study = FakeData2025(path=tmp_path, infra_timelines=infra)
+    study = FakeData2025(path=tmp_path)
     study._download = lambda: (study.path / "data.txt").touch()  # type: ignore
     study.download()
     assert study.path.exists()
@@ -122,8 +121,7 @@ def test_study_download(tmp_path: Path) -> None:
 @pytest.mark.parametrize("with_name", [False, True])
 def test_download_appends_study_name(tmp_path: Path, with_name: bool) -> None:
     path = tmp_path / "FakeData2025" if with_name else tmp_path
-    infra: tp.Any = {"cluster": None}
-    study = FakeData2025(path=path, infra_timelines=infra)
+    study = FakeData2025(path=path)
     study._download = lambda: (study.path / "data.txt").touch()  # type: ignore
     study.download()
     assert study.path == tmp_path / "FakeData2025"
@@ -133,8 +131,8 @@ def test_download_appends_study_name(tmp_path: Path, with_name: bool) -> None:
 def test_download_after_run_does_not_crash_when_frozen(tmp_path: Path) -> None:
     """run() freezes the model via exca; a later download() must still resolve
     its path without raising "instance was frozen" (issue #153, run->download)."""
-    infra: tp.Any = {"cluster": None}
-    study = FakeData2025(path=tmp_path, infra_timelines=infra)
+    timelines: tp.Any = {"infra": None}
+    study = FakeData2025(path=tmp_path, timelines=timelines)
     study.run()  # caches timelines and freezes the instance
     study._download = lambda: (study.path / "data.txt").touch()  # type: ignore
     study.download()  # previously raised RuntimeError: ... instance was frozen
@@ -148,9 +146,9 @@ def test_study_export() -> None:
 
 
 def test_fake_fmri_study_load(tmp_path: Path) -> None:
-    # Processpool ``infra_timelines`` pickles the cycle-prone graph
-    # that drives ``__setstate__`` mid-cycle — not reached by simply
-    # submitting a fresh Step to a worker.
+    # The process-pool study infra pickles the cycle-prone graph that drives
+    # ``__setstate__`` mid-cycle — not reached by simply submitting a fresh
+    # Step to a worker.
     infra: tp.Any = {"folder": tmp_path}
     study = ns.Study(name="Fake2025Fmri", path=ns.CACHE_FOLDER, infra=infra)
     events = study.run()
@@ -219,7 +217,6 @@ def test_xp(tmp_path: Path) -> None:
         study={  # type: ignore[arg-type]
             "name": "Mne2013Sample",
             "path": ns.CACHE_FOLDER,
-            "infra_timelines": {"cluster": None},
             "infra": {"backend": "Cached", "folder": tmp_path / "study"},
         },
     )
@@ -241,11 +238,6 @@ class FakeData2025(base.Study):
     # study level
     myparam: int = 12
     # class level
-
-    def model_post_init(self, log__: tp.Any) -> None:
-        super().model_post_init(log__)
-        # sequential: no need to spawn processes for test data
-        self.infra_timelines.cluster = None
 
     # for testing special loader param
     _add_offset: float = 0
@@ -296,8 +288,7 @@ def test_dict_to_kv(d: dict[str, tp.Any], expected: str) -> None:
 
 def test_timeline_string_pandas_query(tmp_path: Path) -> None:
     """Timeline strings must be usable in pd.DataFrame.query() without escaping."""
-    infra: tp.Any = {"folder": tmp_path, "cluster": None}
-    study = FakeData2025(path=tmp_path / "data", infra_timelines=infra)
+    study = FakeData2025(path=tmp_path / "data")
     df = study.run()
     assert df.timeline.nunique() == 4
     tl = df.timeline.iloc[0]
@@ -334,33 +325,29 @@ def test_study_build(tmp_path: Path) -> None:
     assert not study.requirements
 
 
-def test_study_caching(tmp_path: Path) -> None:
-    """Per-timeline caching, query filtering, infra.folder propagation."""
-    # infra.folder propagates to infra_timelines.folder when unset
-    infra: tp.Any = {"backend": "Cached", "folder": tmp_path, "mode": "force"}
-    study = FakeData2025(path=tmp_path / "data", infra=infra)
-    assert study.infra_timelines.folder == tmp_path
-    assert study.infra_timelines.mode == "force"
-    # retry mode propagates as cached
-    assert study.infra is not None
-    infra_retry = study.infra.model_copy(update={"mode": "retry"}, deep=True)
-    study_retry = FakeData2025(path=tmp_path / "data", infra=infra_retry)
-    assert study_retry.infra_timelines.mode == "cached"
-    # explicit folder: build and check cache files
-    infra_timelines: tp.Any = {"folder": tmp_path, "cluster": None}
-    study = FakeData2025(path=tmp_path / "data", infra_timelines=infra_timelines)
+def test_study_caching(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    loaded: list[dict[str, tp.Any]] = []
+    original = FakeData2025._load_timeline_events
+
+    def _counting(self: FakeData2025, timeline: dict[str, tp.Any]) -> pd.DataFrame:
+        loaded.append(timeline)
+        return original(self, timeline)
+
+    monkeypatch.setattr(FakeData2025, "_load_timeline_events", _counting)
+    timelines: tp.Any = {"infra": {"backend": "Cached", "folder": tmp_path}}
+    study = FakeData2025(path=tmp_path / "data", timelines=timelines)
     study.run()
-    folder = study.infra_timelines.uid_folder()
-    assert folder is not None
-    fps = list((folder / "data").glob("*.parquet"))
-    assert len(fps) == 4
-    # query filters timelines but does not create new cache files
-    study = FakeData2025(
-        path=tmp_path / "data", infra_timelines=infra_timelines, query="run==1"
-    )
-    df = study.run()
-    assert len(df) == 4
-    assert len(list((folder / "data").glob("*.parquet"))) == 4
+    assert len(loaded) == 4  # one load per timeline
+    loaded.clear()
+    queried = FakeData2025(path=tmp_path / "data", timelines=timelines, query="run==1")
+    df = queried.run()
+    assert len(df) == 4  # 2 selected timelines x 2 events
+    assert not loaded  # query never re-loads
+    # clear_cache must wipe the per-timeline cache, not just the gathered result
+    loaded.clear()
+    study.lookup().clear_cache()
+    study.run()
+    assert len(loaded) == 4  # cleared -> every timeline reloads
 
 
 class _SimpleStudy(base.Study):
@@ -389,8 +376,7 @@ class _SimpleStudy(base.Study):
 
 
 def _build_simple(tmp_path: Path, **overrides: tp.Any) -> pd.DataFrame:
-    infra: tp.Any = {"folder": tmp_path, "cluster": None}
-    study = _SimpleStudy(path=tmp_path / "data", infra_timelines=infra)
+    study = _SimpleStudy(path=tmp_path / "data")
     for k, v in overrides.items():
         setattr(study, k, v)
     return study.run()
@@ -483,7 +469,6 @@ def test_bad_transform(tmp_path: Path):
         {
             "name": "FakeData2025",
             "path": tmp_path,
-            "infra_timelines": {"cluster": None},
         },
         {"name": "BadEnhancer"},
     ]
@@ -521,25 +506,16 @@ def test_study_discovery(tmp_path: Path) -> None:
     assert result.returncode == 0, result.stderr
 
 
-def test_concat_studies(tmp_path: Path) -> None:
-    step: tp.Any = {
-        "name": "FakeData2025",
-        "path": tmp_path / "data",
-        "infra_timelines": {"cluster": None},
-    }
-    chain = ns.Chain(steps=[step])
-    df = chain.run()
-    assert len(df) == 8
-    chain = ns.Chain(steps=[step, step])
-    df = chain.run()
-    assert len(df) == 16
-
-
 def test_intermediary_study_cache(tmp_path: Path) -> None:
     infra: tp.Any = {"backend": "Cached", "folder": tmp_path}
     steps: list[tp.Any] = [
         # cache after study as it can be slow
-        {"name": "Fake2025Meg", "path": ns.CACHE_FOLDER, "infra": infra},
+        {
+            "name": "Fake2025Meg",
+            "path": ns.CACHE_FOLDER,
+            "infra": infra,
+            "timelines": {"infra": {"backend": "Cached"}},
+        },
         #  Cache after chunking - useful if chunking is slow
         {
             "name": "ChunkEvents",
@@ -561,14 +537,11 @@ def test_intermediary_study_cache(tmp_path: Path) -> None:
     assert isinstance(df, pd.DataFrame)  # cached
     assert hasattr(df, "stop")  # validated
     chain_caches = set(extract_cache_folders(tmp_path))
-    expected = [
-        "name=Fake2025Meg,infra_timelines.version=v3-66b17a23",
-        "max_duration=5,name=ChunkEvents,event_type_to_chunk=Audio-7702b0cc",
-        "name=QueryEvents,query=type-in-Audio,-Word,-Meg-c3b10366",
-    ]
-    for k in range(len(expected) - 1):  # concatenate as each cache is a subfolder
-        expected[k + 1] = expected[k] + "/" + expected[k + 1]
-    assert chain_caches == set(expected)
+    study = "version=v3,name=Fake2025Meg-ff4b4eb4"
+    chunk = f"{study}/max_duration=5,name=ChunkEvents,event_type_to_chunk=Audio-7702b0cc"
+    query = f"{chunk}/name=QueryEvents,query=type-in-Audio,-Word,-Meg-c3b10366"
+    loader = f"{study}/name=TimelineLoader-99bb1625"  # per-timeline loader cache
+    assert chain_caches == {study, chunk, query, loader}
 
 
 def test_validate_events_in_steps(tmp_path: Path) -> None:
@@ -605,8 +578,7 @@ def test_sub_chain(tmp_path) -> None:
 
 def test_no_full_scan_on_unpickle(tmp_path: Path) -> None:
     """Unpickling a Study must not trigger a full package scan (name='')."""
-    infra: tp.Any = {"cluster": None}
-    study = FakeData2025(path=tmp_path / "data", infra_timelines=infra)
+    study = FakeData2025(path=tmp_path / "data")
     data = cloudpickle.dumps(study)
     scan_calls: list[str] = []
     real_scan = base._scan_package_for_studies

--- a/neuralset-repo/neuralset/events/testing/examplemultimodal.py
+++ b/neuralset-repo/neuralset/events/testing/examplemultimodal.py
@@ -243,13 +243,13 @@ class ExampleMultiModal(study.Study):
 
     def model_post_init(self, log__: tp.Any) -> None:
         super().model_post_init(log__)
-        self.infra_timelines.cluster = None  # purely sequential
+        # purely sequential and uncached (None => inline loader, no caching).
         # Events embed absolute filepaths under `self.path`. Study's cache
         # UID excludes `path` (it varies per machine), so a cache populated
         # under one path keeps returning stale filepaths after the user
         # moves the studies folder. The dataset is tiny (~2 MB) and cheap
         # to regenerate; skip the events cache so the demo stays robust.
-        self.infra_timelines.folder = None
+        self.timelines.infra = None
 
     def iter_timelines(self) -> tp.Iterator[dict[str, tp.Any]]:
         for s in (1, 2):

--- a/neuralset-repo/neuralset/events/testing/mne2013sample.py
+++ b/neuralset-repo/neuralset/events/testing/mne2013sample.py
@@ -46,9 +46,7 @@ class Mne2013Sample(study.Study):
 
     def model_post_init(self, log__: tp.Any) -> None:
         super().model_post_init(log__)
-        self.infra_timelines.version = (
-            "v3"  # other option requires overriding _load_events
-        )
+        self.version = "v3"  # other option requires overriding _load_events
 
     def _download_root(self) -> Path:
         # raw downloads live under <study path>/download (package convention);
@@ -148,11 +146,6 @@ class Fake2025Meg(Mne2013Sample):
     description: tp.ClassVar[str] = (
         """mne sample MEG dataset with additional fake events"""
     )
-
-    def model_post_init(self, log__: tp.Any) -> None:
-        super().model_post_init(log__)
-        # sequential: no need to spawn processes for test data
-        self.infra_timelines.cluster = None
 
     _info: tp.ClassVar[study.StudyInfo] = study.StudyInfo(
         num_timelines=2,

--- a/neuralset-repo/neuralset/events/testing/test2023meg.py
+++ b/neuralset-repo/neuralset/events/testing/test2023meg.py
@@ -14,11 +14,6 @@ from neuralset.events import study
 
 
 class Test2023Meg(study.Study):
-    def model_post_init(self, log__: tp.Any) -> None:
-        super().model_post_init(log__)
-        # sequential: no need to spawn processes for test data
-        self.infra_timelines.cluster = None
-
     _info: tp.ClassVar[study.StudyInfo] = study.StudyInfo(
         num_timelines=3,
         num_subjects=3,

--- a/neuralset-repo/neuralset/events/testing/test_mne2013sample.py
+++ b/neuralset-repo/neuralset/events/testing/test_mne2013sample.py
@@ -39,8 +39,8 @@ def data_path_calls(monkeypatch: pytest.MonkeyPatch) -> list:
 def test_download_and_read_share_single_root(
     tmp_path: Path, data_path_calls: list
 ) -> None:
-    infra: tp.Any = {"cluster": None}
-    study = Mne2013Sample(path=tmp_path, infra_timelines=infra)
+    timelines: tp.Any = {"infra": None}
+    study = Mne2013Sample(path=tmp_path, timelines=timelines)
     root = study._download_root()
 
     study._download()  # writer
@@ -59,8 +59,8 @@ def test_download_and_read_share_single_root(
 def test_fake2025meg_iter_timelines_uses_same_root(
     tmp_path: Path, data_path_calls: list
 ) -> None:
-    infra: tp.Any = {"cluster": None}
-    study = Fake2025Meg(path=tmp_path, infra_timelines=infra)
+    timelines: tp.Any = {"infra": None}
+    study = Fake2025Meg(path=tmp_path, timelines=timelines)
     list(study.iter_timelines())  # pre-download hook before concurrent loading
     assert {called_root for called_root, _ in data_path_calls} == {study._download_root()}
     assert all(verbose is True for _, verbose in data_path_calls)

--- a/neuralset-repo/neuralset/events/transforms/test_transforms.py
+++ b/neuralset-repo/neuralset/events/transforms/test_transforms.py
@@ -917,7 +917,6 @@ def test_configure_event_loader(test_data_path: Path) -> None:
     study_events = ns.Study(
         name="Test2023Fmri",
         path=test_data_path,
-        infra_timelines={"cluster": None},  # type: ignore[arg-type]
     ).run()
     sl_transform = _transf.ConfigureEventLoader(
         event_types="Fmri",

--- a/neuralset-repo/neuralset/extractors/test_neuro.py
+++ b/neuralset-repo/neuralset/extractors/test_neuro.py
@@ -28,9 +28,6 @@ from neuralset.events import etypes, test_etypes
 from neuralset.events.utils import extract_events
 from neuralset.extractors.neuro import FmriTimedArray, _overlap
 
-# avoid processpool which requires permissions unavailable in sandboxes
-_NO_CLUSTER: tp.Any = {"cluster": None}
-
 
 @pytest.mark.parametrize("cls", (ns.extractors.MegExtractor, ns.extractors.FmriExtractor))
 def test_neuro_pkl(cls: tp.Type[ns.extractors.BaseExtractor]) -> None:
@@ -56,13 +53,12 @@ def make_meg_event(filepath, start=0.0):
 
 def test_fmri(test_data_path: Path, tmp_path: Path) -> None:
     # load study to create nii.gz files
-    infra: tp.Any = {"folder": tmp_path / "cache", **_NO_CLUSTER}
+    infra: tp.Any = {"folder": tmp_path / "cache", "cluster": None}
     fmri_data = test_data_path / "Test2023Fmri"
     study = ns.Study(
         name="Test2023Fmri",
         path=test_data_path,
         query="timeline_index<1",
-        infra_timelines=infra,
     ).run()
 
     timeline = 'Test2023Fmri:{"subject":"0"}'
@@ -168,12 +164,11 @@ def test_fmri(test_data_path: Path, tmp_path: Path) -> None:
 
 @pytest.mark.parametrize("kind", ["Fmri", "Meg"])
 def test_extractor_cached_start(test_data_path: Path, tmp_path: Path, kind: str) -> None:
-    infra: tp.Any = {"folder": tmp_path / "cache", **_NO_CLUSTER}
+    infra: tp.Any = {"folder": tmp_path / "cache", "cluster": None}
     study = ns.Study(
         name=f"Test2023{kind}",
         path=test_data_path,
         query="timeline_index<1",
-        infra_timelines=_NO_CLUSTER,
     ).run()
     event = study.query(f'type=="{kind}"').iloc[:1]
     start, duration = event["start"].item(), event["duration"].item()
@@ -192,7 +187,6 @@ def test_fmri_resample(test_data_path: Path, frequency: float) -> None:
         name="Test2023Fmri",
         path=test_data_path,
         query="timeline_index<1",
-        infra_timelines=_NO_CLUSTER,
     ).run()
     event = study.query('type=="Fmri"').iloc[:1]
     orig_frequency = event.frequency.item()
@@ -231,7 +225,6 @@ def test_meg(test_data_path: Path, tmp_path: Path) -> None:
         name="Test2023Meg",
         path=test_data_path,
         query="timeline_index<1",
-        infra_timelines=_NO_CLUSTER,
     ).run()
 
     # check caching infra
@@ -301,7 +294,6 @@ def test_meg(test_data_path: Path, tmp_path: Path) -> None:
         name="Test2023Meg",
         path=test_data_path,
         query="timeline_index<2",
-        infra_timelines=_NO_CLUSTER,
     ).run()
     extractor.prepare(study)
     images = study.query('type=="Image"')
@@ -350,7 +342,6 @@ def test_meg_filter(
         name="Test2023Meg",
         path=test_data_path,
         query="timeline_index<1",
-        infra_timelines=_NO_CLUSTER,
     ).run()
     fif = test_data_path / "Test2023Meg" / "sub-0-raw.fif"
 
@@ -396,7 +387,6 @@ def test_meg_notch_filter(
         name="Test2023Meg",
         path=test_data_path,
         query="timeline_index<1",
-        infra_timelines=_NO_CLUSTER,
     ).run()
     fif = test_data_path / "Test2023Meg" / "sub-0-raw.fif"
 
@@ -427,7 +417,6 @@ def test_meg_baseline(
         name="Test2023Meg",
         path=test_data_path,
         query="timeline_index<1",
-        infra_timelines=_NO_CLUSTER,
     ).run()
     fif = test_data_path / "Test2023Meg" / "sub-0-raw.fif"
 
@@ -477,7 +466,6 @@ def test_meg_offset(
         name="Test2023Meg",
         path=test_data_path,
         query="timeline_index<1",
-        infra_timelines=_NO_CLUSTER,
     ).run()
     fif = test_data_path / "Test2023Meg" / "sub-0-raw.fif"
     event = make_meg_event(fif, start=0)
@@ -493,7 +481,6 @@ def test_fnirs(test_data_path: Path) -> None:
         name="Test2024Fnirs",
         path=test_data_path,
         query="timeline_index<1",
-        infra_timelines=_NO_CLUSTER,
     ).run()
 
     sfreq = 10.0
@@ -564,9 +551,7 @@ def test_cache(test_data_path: Path, tmp_path: Path) -> None:
 
     for cond in (meg, fmri):
         study = str(cond["study"])
-        events = ns.Study(
-            name=study, path=test_data_path, infra_timelines=_NO_CLUSTER
-        ).run()
+        events = ns.Study(name=study, path=test_data_path).run()
         sel = events.type == cond["stim"]
         dset = ns.segments.list_segments(
             events, triggers=sel, start=0.0, duration=cond["duration"]
@@ -630,9 +615,7 @@ def test_cache(test_data_path: Path, tmp_path: Path) -> None:
 
 
 def test_meg_feature_cache(test_data_path: Path, tmp_path: Path) -> None:
-    events = ns.Study(
-        name="Test2023Meg", path=test_data_path, infra_timelines=_NO_CLUSTER
-    ).run()
+    events = ns.Study(name="Test2023Meg", path=test_data_path).run()
     cache = tmp_path / "cache"
     extractor = ns.extractors.MegExtractor(
         frequency=100.0,
@@ -655,9 +638,7 @@ def test_meg_feature_cache(test_data_path: Path, tmp_path: Path) -> None:
 
 
 def test_eeg_feature_cache(test_data_path: Path, tmp_path: Path) -> None:
-    events = ns.Study(
-        name="Test2024Eeg", path=test_data_path, infra_timelines=_NO_CLUSTER
-    ).run()
+    events = ns.Study(name="Test2024Eeg", path=test_data_path).run()
     cache = tmp_path / "cache"
     extractor = ns.extractors.EegExtractor(
         frequency=100.0,
@@ -708,9 +689,7 @@ def test_base_meg(tmp_path: Path) -> None:
 @pytest.mark.parametrize("apply_proj", (True, False))
 def test_epoch_correct(apply_proj: bool) -> None:
     # download the first time
-    events = ns.Study(
-        name="Mne2013Sample", path=ns.CACHE_FOLDER, infra_timelines=_NO_CLUSTER
-    ).run()
+    events = ns.Study(name="Mne2013Sample", path=ns.CACHE_FOLDER).run()
     NUM = 12
 
     # Define segments
@@ -774,7 +753,6 @@ def test_channel_positions_meg(
         name="Test2023Meg",
         path=test_data_path,
         query="timeline_index<1",
-        infra_timelines=_NO_CLUSTER,
     ).run()
     meg.prepare(events)
 
@@ -806,7 +784,6 @@ def test_channel_positions_eeg(test_data_path: Path, n_spatial_dims, normalize) 
         name="Test2024Eeg",
         path=test_data_path,
         query="timeline_index<1",
-        infra_timelines=_NO_CLUSTER,
     ).run()
     eeg.prepare(events)
 
@@ -837,7 +814,6 @@ def test_channel_positions_wrong_event_type(test_data_path: Path) -> None:
         name="Test2024Eeg",
         path=test_data_path,
         query="timeline_index<1",
-        infra_timelines=_NO_CLUSTER,
     ).run()
     eeg.prepare(events)
 
@@ -868,7 +844,6 @@ def test_unique_channels_ieeg(
         name="Test2025Ieeg",
         path=test_data_path,
         query="subject_index<2",
-        infra_timelines=_NO_CLUSTER,
     ).run()
 
     if channel_order == "unique":
@@ -890,7 +865,6 @@ def test_batch_size_unique_channels_ieeg(
         name="Test2025Ieeg",
         path=test_data_path,
         query="subject_index<2",
-        infra_timelines=_NO_CLUSTER,
     ).run()
 
     ieeg = ns.extractors.IeegExtractor(channel_order=channel_order)
@@ -921,7 +895,6 @@ def test_channel_positions_ieeg(test_data_path: Path) -> None:
         name="Test2025Ieeg",
         path=test_data_path,
         query="timeline_index<1",
-        infra_timelines=_NO_CLUSTER,
     ).run()
     ieeg.prepare(events)
 
@@ -1184,7 +1157,6 @@ def test_meg_borders(test_data_path: Path, tmp_path: Path) -> None:
         name="Test2023Meg",
         path=test_data_path,
         query="timeline_index<1",
-        infra_timelines=_NO_CLUSTER,
     )
     events = loader.run()
     extractor = ns.extractors.MegExtractor(infra=dict(folder=cache_path))  # type: ignore
@@ -1216,7 +1188,6 @@ def test_scaled_meg(
         name="Test2023Meg",
         path=test_data_path,
         query="timeline_index<1",
-        infra_timelines=_NO_CLUSTER,
     )
     events = loader.run()
     event = etypes.Meg.from_dict(events.query('type=="Meg"').iloc[0])
@@ -1244,9 +1215,7 @@ def test_scaled_meg(
 
 
 def test_first_samp() -> None:
-    events = ns.Study(
-        name="Mne2013Sample", path=ns.CACHE_FOLDER, infra_timelines=_NO_CLUSTER
-    ).run()
+    events = ns.Study(name="Mne2013Sample", path=ns.CACHE_FOLDER).run()
     meg_event = ns.events.Event.from_dict(events.loc[events.type == "Meg"].iloc[0])
     assert meg_event.start > 0
     # first samp is ~6k at 150Hz, so start is at about 42s
@@ -1256,9 +1225,7 @@ def test_first_samp() -> None:
 
 
 def test_fast_event() -> None:
-    events = ns.Study(
-        name="Mne2013Sample", path=ns.CACHE_FOLDER, infra_timelines=_NO_CLUSTER
-    ).run()
+    events = ns.Study(name="Mne2013Sample", path=ns.CACHE_FOLDER).run()
     meg_event = ns.events.Event.from_dict(events.loc[events.type == "Meg"].iloc[0])
     assert meg_event.start > 0
     extractor = ns.extractors.MegExtractor(frequency=150)
@@ -1267,9 +1234,7 @@ def test_fast_event() -> None:
 
 
 def test_border_baseline(test_data_path: Path) -> None:
-    events = ns.Study(
-        name="Test2023Meg", path=test_data_path, infra_timelines=_NO_CLUSTER
-    ).run()
+    events = ns.Study(name="Test2023Meg", path=test_data_path).run()
     meg_event = ns.events.Event.from_dict(events.loc[events.type == "Meg"].iloc[0])
     extractor = ns.extractors.MegExtractor(frequency=150, baseline=(0, 0.6))
     _ = extractor(meg_event, meg_event.stop - 0.5, 1)  # baseline should not bug
@@ -1313,9 +1278,7 @@ all_meg_channels = {
     ],
 )
 def test_meg_picks(test_data_path: Path, picks, expected: set[str]) -> None:
-    events = ns.Study(
-        name="Test2023Meg", path=test_data_path, infra_timelines=_NO_CLUSTER
-    ).run()
+    events = ns.Study(name="Test2023Meg", path=test_data_path).run()
     meg_event = ns.events.Event.from_dict(events.loc[events.type == "Meg"].iloc[0])
     extractor = ns.extractors.MegExtractor(frequency=150, picks=picks)
     ta = next(iter(extractor._get_data([meg_event])))  # type: ignore
@@ -1328,7 +1291,6 @@ def test_meg_method_on_infra(test_data_path: Path, tmp_path: Path) -> None:
         name="Test2023Meg",
         path=test_data_path,
         query="timeline_index<1",
-        infra_timelines=_NO_CLUSTER,
     ).run()
     infra: tp.Any = {"cluster": "local", "folder": tmp_path}
     extractor = ns.extractors.MegExtractor(frequency=150, baseline=(0, 0.6), infra=infra)
@@ -1340,7 +1302,7 @@ def test_fmri_cluster_local(test_data_path: Path, tmp_path: Path) -> None:
         name="Test2023Fmri",
         path=test_data_path,
         query="timeline_index<1",
-        infra_timelines={"folder": tmp_path, **_NO_CLUSTER},  # type: ignore
+        timelines={"infra": {"backend": "Cached", "folder": tmp_path}},  # type: ignore
     ).run()
     fmri_event = extract_events(study, types=etypes.Fmri)[0]
     assert isinstance(fmri_event, etypes.Fmri)
@@ -1417,7 +1379,6 @@ def test_ieeg(test_data_path: Path) -> None:
         name="Test2025Ieeg",
         path=test_data_path,
         query="timeline_index<1",
-        infra_timelines=_NO_CLUSTER,
     ).run()
 
     sfreq = 2048.0
@@ -1525,9 +1486,7 @@ def test_overlap() -> None:
 
 
 def test_drop_bad_channels(test_data_path: Path, tmp_path: Path) -> None:
-    events = ns.Study(
-        name="Test2024Eeg", path=test_data_path, infra_timelines=_NO_CLUSTER
-    ).run()
+    events = ns.Study(name="Test2024Eeg", path=test_data_path).run()
     cache = tmp_path / "cache"
     # Check bad channels present
     extractor = ns.extractors.EegExtractor(
@@ -1556,9 +1515,7 @@ def test_drop_bad_channels(test_data_path: Path, tmp_path: Path) -> None:
 
 
 def test_pick_channel_names(test_data_path: Path, tmp_path: Path) -> None:
-    events = ns.Study(
-        name="Test2024Eeg", path=test_data_path, infra_timelines=_NO_CLUSTER
-    ).run()
+    events = ns.Study(name="Test2024Eeg", path=test_data_path).run()
     cache = tmp_path / "cache"
     # Check that picks allows list of channel names
     extractor = ns.extractors.EegExtractor(
@@ -1591,7 +1548,6 @@ def test_fake_meg_study() -> None:
         name="Fake2025Meg",
         path=ns.CACHE_FOLDER,
         query="subject_index < 1",
-        infra_timelines=_NO_CLUSTER,
     )
     events = loader.run()
     assert set(events.type) == {
@@ -1611,7 +1567,6 @@ def test_fake_fmri_study() -> None:
         name="Fake2025Fmri",
         path=ns.CACHE_FOLDER,
         query="timeline_index < 1",
-        infra_timelines=_NO_CLUSTER,
     )
     events = loader.run()
     try:
@@ -1759,7 +1714,6 @@ def test_fmri_smoothing(test_data_path: Path) -> None:
         name="Test2023Fmri",
         path=test_data_path,
         query="timeline_index<1",
-        infra_timelines=_NO_CLUSTER,
     ).run()
     event = study.query('type=="Fmri"').iloc[:1]
 

--- a/neuralset-repo/neuralset/test_base.py
+++ b/neuralset-repo/neuralset/test_base.py
@@ -104,7 +104,6 @@ def test_data(test_data_path: Path) -> None:
     events = ns.Study(
         name="Test2023Fmri",
         path=test_data_path,
-        infra_timelines={"cluster": None},
     ).run()
 
     # Build a list of segments time-locked to specific events

--- a/neuralset-repo/pyproject.toml
+++ b/neuralset-repo/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
   "torch>=2.5.1",
   "nibabel>=5.1.0",
   "tqdm>=4.65.0",
-  "exca>=0.5.20",
+  "exca>=0.5.27",
   "rapidfuzz",
   "packaging",
   "ujson",


### PR DESCRIPTION
- `version` is now a first-class `Study` field (was `infra_timelines.version`): set `version="..."` directly.
- `infra_timelines` → `timelines.infra` (with step backend syntax). Defaults to `ProcessPool`. To keep 
in-process, use `timelines={"infra": {"backend": "Cached"}}` (cached) or `timelines={"infra": None}` (uncached).
- Cache reset for versioned studies only — consequence of the `version` move: a study with a version gets a new cache folder and recomputes once; unversioned studies keep their global (non-per-timeline) cache.
- Requires exca ≥ 0.5.27.