### PR TITLE
Fix ambiguous truth value in Event.from_dict for array-valued columns

### DIFF
--- a/neuralset-repo/neuralset/events/etypes.py
+++ b/neuralset-repo/neuralset/events/etypes.py
@@ -121,7 +121,7 @@ class Event(_Module):
         kwargs: dict[str, tp.Any] = {}
         extra = {}
         for k, v in row.items():
-            if pd.isna(v):
+            if pd.api.types.is_scalar(v) and pd.isna(v):
                 continue
             if k in fs:
                 kwargs[k] = v

--- a/neuralset-repo/neuralset/events/test_etypes.py
+++ b/neuralset-repo/neuralset/events/test_etypes.py
@@ -52,6 +52,26 @@ def test_event_from_dict_with_nan() -> None:
     assert out["category"] == "verb"
 
 
+def test_event_from_dict_with_array_column() -> None:
+    # Mirrors a parquet cache round-trip, where an array-valued cell
+    # (e.g. a series event's `dims`) comes back as an np.ndarray rather
+    # than the original tuple. `pd.isna` on an array is element-wise, so
+    # the NaN-skip check in `from_dict` shouldnt choke on it.
+    data = {
+        "type": "Word",
+        "start": 0,
+        "duration": 1.0,
+        "timeline": "t",
+        "text": "hello",
+        "dims": np.array(["x", "y", "z"]),
+    }
+    word = ns.events.Event.from_dict(data)
+    assert np.array_equal(word.extra["dims"], np.array(["x", "y", "z"]))
+    out = word.to_dict()
+    assert np.array_equal(out["dims"], np.array(["x", "y", "z"]))
+    assert out["text"] == "hello"
+
+
 def test_sound(tmp_path: Path) -> None:
     fp = tmp_path / "Sub1" / "Sub2" / "Sub3" / "noise.wav"
     fp.parent.mkdir(parents=True)


### PR DESCRIPTION
## What does this PR do?

`Event.from_dict` skips NaN cells with `pd.isna(v)`. When a cell holds an
array (e.g. the `dims` of a series event coming back from a parquet cache
round-trip as an `np.ndarray`), `pd.isna` returns an element-wise boolean
array, so using it in an `if` raises:

    ValueError: The truth value of an array with more than one element is ambiguous.

This is why `Study.run()` only crashes when a disk cache folder is set
(`infra={"folder": ...}`): the in-RAM value is a `tuple` (`pd.isna` → scalar
`False`), but the parquet round-trip yields an `ndarray`.

The fix guards the NaN check with `pd.api.types.is_scalar(v)` so array-valued
cells pass through as "present" instead of being tested for NaN. A regression
test adds an array-valued column to mimic the parquet round-trip.

## Related Issues

Fixes #178

## Checklist

- [x] Tests added or updated
- [x] Docstrings updated for any changed public APIs (no public API changed)
- [x] `pytest` and `mypy` pass locally