### PR TITLE
Add "spoken" and "signed" to BaseText.modality

### DIFF
--- a/neuralset-repo/neuralset/events/etypes.py
+++ b/neuralset-repo/neuralset/events/etypes.py
@@ -639,7 +639,7 @@ class BaseText(Event):
         The text content (must be non-empty)
     context : str, optional
         Contextual information (e.g., preceding words). Default: ""
-    modality : Literal["heard", "read", "imagined", "typed", "written", "caption"], optional
+    modality : Literal["heard", "spoken", "signed", "read", "imagined", "typed", "written", "caption"], optional
         Modality of the text event. Default: None
 
     Raises
@@ -652,7 +652,10 @@ class BaseText(Event):
     language: str = ""
     context: str = ""
     modality: (
-        tp.Literal["heard", "read", "imagined", "typed", "written", "caption"] | None
+        tp.Literal[
+            "heard", "spoken", "signed", "read", "imagined", "typed", "written", "caption"
+        ]
+        | None
     ) = None
 
 


### PR DESCRIPTION
Hi! 

## What does this PR do?

BaseText.modality currently offers "heard" (perceived speech) but no value for *produced* speech, and no value for sign language. This makes it impossible to label, e.g., a Word the subject spoke vs. heard in a conversation dataset — a common need in ECoG/production studies.

Add two values to the Literal:
  - "spoken": produced speech (the counterpart to "heard")
  - "signed": produced sign language (just added for completeness :) )

modality is metadata only (it is never branched on anywhere in the codebase), so this is fully backward-compatible: existing values and callers are unaffected, and invalid values still raise ValidationError.


## Related Issues

NA

## Checklist

- [NA] Tests added or updated
- [O] Docstrings updated for any changed public APIs
- [NA] `pytest` and `mypy` pass locally
