### PR TITLE
Preserve a non-default StudyInfo.query when rewriting _info

### DIFF
--- a/neuralfetch-repo/neuralfetch/test_utils.py
+++ b/neuralfetch-repo/neuralfetch/test_utils.py
@@ -5,7 +5,10 @@
 # LICENSE file in the root directory of this source tree.
 
 
+import importlib.util
 import os
+import re
+import sys
 from pathlib import Path
 
 import pandas as pd
@@ -54,3 +57,68 @@ def test_download_things_images_missing_password_raises(tmp_path: Path) -> None:
     finally:
         if old_val is not None:
             os.environ["NEURALFETCH_THINGS_PASSWORD"] = old_val
+
+
+_QUERY_STUDY_SOURCE = """\
+import typing as tp
+import pandas as pd
+from neuralset.events import study
+
+class DummyQueryTest2099(study.Study):
+    _info: tp.ClassVar[study.StudyInfo] = study.StudyInfo(query="timeline_index < 2")
+    def iter_timelines(self):
+        yield from ({"subject": f"s{i}"} for i in range(3))
+    def _load_timeline_events(self, timeline):
+        return pd.DataFrame([{"type": "Stimulus", "start": 0, "duration": 1, "code": 1}])
+"""
+
+
+def test_format_study_info_keeps_non_default_query() -> None:
+    """A non-default query must survive serialization back to source."""
+    from neuralfetch.utils import format_study_info
+
+    actual = dict(
+        num_timelines=3,
+        num_subjects=3,
+        query="timeline_index < 2",
+        num_events_in_query=2,
+        event_types_in_query={"Stimulus"},
+    )
+    assert 'query="timeline_index < 2"' in format_study_info(actual)
+
+
+def test_format_study_info_omits_default_query() -> None:
+    """Studies on the default query emit no ``query=``, so their files don't churn."""
+    from neuralfetch.utils import format_study_info
+
+    actual = dict(
+        num_timelines=1,
+        num_subjects=1,
+        num_events_in_query=5,
+        event_types_in_query={"Stimulus"},
+    )
+    # ``\\b`` does not match inside ``num_events_in_query=``: ``_`` is a word char.
+    assert re.search(r"\bquery=", format_study_info(actual)) is None
+
+
+def test_update_source_info_preserves_non_default_query(tmp_path: Path) -> None:
+    """Rewriting ``_info`` must not reset a custom query while keeping its counts."""
+    from neuralfetch.utils import update_source_info
+    from neuralset.events import study as study_mod
+
+    study_file = tmp_path / "dummy_query_study.py"
+    study_file.write_text(_QUERY_STUDY_SOURCE)
+    spec = importlib.util.spec_from_file_location("dummy_query_study", study_file)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore
+    sys.modules["dummy_query_study"] = mod
+    try:
+        actual = update_source_info("DummyQueryTest2099", folder=tmp_path)
+        # The query keeps 2 of the 3 timelines, one event each.
+        assert actual["query"] == "timeline_index < 2"
+        assert actual["num_events_in_query"] == 2
+        assert 'query="timeline_index < 2"' in study_file.read_text("utf8")
+    finally:
+        study_mod.STUDIES.pop("DummyQueryTest2099", None)
+        sys.modules.pop("dummy_query_study", None)

--- a/neuralfetch-repo/neuralfetch/utils.py
+++ b/neuralfetch-repo/neuralfetch/utils.py
@@ -57,8 +57,10 @@ def compute_study_info(name: str, folder: str | Path) -> dict[str, tp.Any]:
     """Load study *name* from *folder* and return a dict of actual ``StudyInfo`` values.
 
     Always computes num_timelines, num_subjects, num_events_in_query, and
-    event_types_in_query.  Attempts to read one Fmri/MneRaw event for
-    data_shape, frequency, and fmri_spaces (skipped on failure).
+    event_types_in_query.  Includes query when the study declares a non-default
+    one, so that the counts computed from it stay paired with it.  Attempts to
+    read one Fmri/MneRaw event for data_shape, frequency, and fmri_spaces
+    (skipped on failure).
     """
     folder = Path(folder)
     default_query = "timeline_index < 1"
@@ -80,6 +82,10 @@ def compute_study_info(name: str, folder: str | Path) -> dict[str, tp.Any]:
         num_events_in_query=len(events),
         event_types_in_query=set(events["type"].unique()),
     )
+    if query != default_query:
+        # Only report a diverging query: emitting the default everywhere would
+        # churn every study file without adding information.
+        actual["query"] = query
     # Read first Fmri/MneRaw event for data_shape / frequency.
     types = ev.etypes.EventTypesHelper(["Fmri", "MneRaw"]).names
     matching = events.loc[events.type.isin(types)]
@@ -158,9 +164,7 @@ def _repr_val(val: tp.Any) -> str:
 def format_study_info(actual: dict[str, tp.Any]) -> str:
     """Return a formatted ``StudyInfo(...)`` string from computed values."""
     parts = [
-        f"{f}={_repr_val(actual[f])}"
-        for f in base.StudyInfo.model_fields
-        if f != "query" and f in actual
+        f"{f}={_repr_val(actual[f])}" for f in base.StudyInfo.model_fields if f in actual
     ]
     code = f"StudyInfo({', '.join(parts)})"
     result = subprocess.run(


### PR DESCRIPTION
compute_study_info honors a study's custom query when counting events but never puts that query into the dict it returns, so update_source_info wrote back a StudyInfo whose counts came from the custom query while the query itself silently reverted to the "timeline_index < 1" default.

The `f != "query"` guard in format_study_info was dead code -- `query` was never a key in `actual` -- so the fix is to have compute_study_info report the resolved query, and only when it diverges from the default so that default-query study files stay byte-identical.

Reported-by: Luiz Tauffer <luiztauffer>

## What does this PR do?

<!-- Brief description of the change. -->

## Related Issues

<!-- e.g. Fixes #123, Closes #456 -->

## Checklist

- [ ] Tests added or updated
- [ ] Docstrings updated for any changed public APIs
- [ ] `pytest` and `mypy` pass locally
