### PR TITLE
Add NeuralFetch to the NeuralBench datasets extra

### DIFF
--- a/docs/neuralbench/install.md
+++ b/docs/neuralbench/install.md
@@ -41,12 +41,23 @@ pre-commit install
 
 ## Optional dependencies
 
-Extra dependency groups are available for dataset downloading and
-model loading:
+Extra dependency groups are available for dataset downloads and model loading.
+
+For a released package, run:
 
 ```bash
-pip install 'neuralbench-repo/.[datasets,models]'
+pip install 'neuralbench[datasets,models]'
 ```
+
+For an editable monorepo checkout, run:
+
+```bash
+pip install -e 'neuralbench-repo/.[datasets,models]'
+```
+
+The `datasets` extra installs NeuralFetch. NeuralFetch registers the Study
+classes that benchmark configurations use. Some studies need additional
+backend-specific dependencies.
 
 ## First-run configuration
 

--- a/neuralbench-repo/neuralbench/test_registry.py
+++ b/neuralbench-repo/neuralbench/test_registry.py
@@ -21,7 +21,10 @@ these tests guard the end-to-end wiring:
 
 from __future__ import annotations
 
+from importlib import metadata
+
 import pandas as pd
+from packaging.requirements import Requirement
 
 from neuralbench.plots.tables import _collapse_feature_based_baselines
 from neuralbench.registry import (
@@ -31,6 +34,17 @@ from neuralbench.registry import (
     _expand_models,
     _task_aware_baseline,
 )
+
+
+def test_datasets_extra_metadata_includes_neuralfetch() -> None:
+    """The built datasets extra must install the NeuralFetch Study catalog."""
+    requirements = [Requirement(item) for item in metadata.requires("neuralbench") or []]
+    neuralfetch = [item for item in requirements if item.name == "neuralfetch"]
+    assert len(neuralfetch) == 1
+    marker = neuralfetch[0].marker
+    assert marker is not None
+    assert marker.evaluate({"extra": "datasets"})
+    assert not marker.evaluate({"extra": ""})
 
 
 def test_device_baseline_models_meg_has_riemannian_pipelines() -> None:

--- a/neuralbench-repo/pyproject.toml
+++ b/neuralbench-repo/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
 
 [project.optional-dependencies]
     datasets = [
+        "neuralfetch",
         # Download
         "boto3",
         "botocore",


### PR DESCRIPTION
## Summary

Add `neuralfetch` to `neuralbench[datasets]`.

NeuralFetch registers the Study classes that NeuralBench benchmark configurations use.

## Problem

NeuralBench configurations reference 104 Study names. The current
`neuralbench[datasets]` installation does not install NeuralFetch. Without
NeuralFetch, 103 of those Study names are unavailable.

Issue #63 discusses the names and contents of package extras. It does not add
the missing Study provider to NeuralBench.

## Changes

- Add `neuralfetch` to the `datasets` extra.
- Show installation commands for released packages and editable monorepo checkouts.
- Explain that some studies need additional backend-specific dependencies.
- Add a regression test that checks generated distribution metadata with
  `importlib.metadata` and `packaging.Requirement`.

## Validation

- Full NeuralBench suite: 193 passed; 1 external-resource test deselected.
- Registry module: 9 passed; 1 external-resource test deselected.
- Metadata regression test: passed.
- Mypy: passed for 60 source files.
- Ruff, formatting, codespell, and `git diff --check`: passed.
- Built and installed the wheel successfully.
- Confirmed wheel metadata contains `neuralfetch; extra == "datasets"`.
- Confirmed the base installation does not add NeuralFetch.

## Compatibility

The base installation does not change. Only users who select the `datasets`
extra install NeuralFetch.

Related: #63
