### PR TITLE
neuralfetch: standardize `overwrite` for `_download`

### DIFF
--- a/neuralfetch-repo/neuralfetch/download.py
+++ b/neuralfetch-repo/neuralfetch/download.py
@@ -65,11 +65,18 @@ def ensure_study_symlink(studies_root: Path, link_name: str, target_name: str) -
 
 @contextlib.contextmanager
 def success_writer(
-    fname: str | Path, suffix: str = "_success.txt", success_msg: str = "done"
+    fname: str | Path,
+    suffix: str = "_success.txt",
+    success_msg: str = "done",
+    overwrite: bool = False,
 ):
     """Look for a file ending with ``suffix`` indicating ``fname`` has
     already been processed and create it after the encapsulated block
     succeeds.
+
+    When ``overwrite`` is True an existing marker is reported as absent (the
+    yielded value is False), so callers re-run the guarded work; the marker
+    itself is preserved on disk.
 
     Examples
     --------
@@ -82,9 +89,9 @@ def success_writer(
     ./test.txt
     """
     success_fname = Path(str(Path(fname).with_suffix("")) + suffix)
-    file_exists = success_fname.exists()
-    yield file_exists
-    if not file_exists:
+    marker_exists = success_fname.exists()
+    yield marker_exists and not overwrite
+    if not marker_exists:
         with open(success_fname, "w") as f:
             f.write(success_msg)
 
@@ -392,13 +399,20 @@ class BaseDownload(_Module):
         self._check_requirements()
         print(f"Downloading {Path(self.dset_dir).name} to {self._dl_dir}...")
 
-        self._download()
+        self._download(overwrite=overwrite)
         self.get_success_file().write_text("success")
         print("Done! Consider running giving read/write permissions to everyone:")
         print(f"chmod -R 777 {self._dl_dir}")  # we should do this on FAIR cluster
 
     @abstractmethod
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
+        """Perform the actual transfer.
+
+        ``overwrite`` requests a *forced* re-transfer: implementations must
+        re-fetch/re-verify files rather than trusting mere on-disk existence
+        (e.g. clear ``skip_existing`` guards, pass ``force_download``), so that
+        a corrupted or partial download is repaired.
+        """
         raise NotImplementedError
 
 
@@ -465,8 +479,12 @@ class S3(BaseDownload):
             return Path(self.output_dir)
         return self._dl_dir
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         import boto3
+
+        # ``overwrite`` forces re-transfer of every object, even those already
+        # present locally.
+        skip_existing = self.skip_existing and not overwrite
 
         session_kwargs: dict[str, tp.Any] = {}
         if self.profile:
@@ -491,13 +509,13 @@ class S3(BaseDownload):
         bucket = s3.Bucket(self.bucket)
 
         if self.files_with_destinations:
-            jobs = self._resolve_mapped()
+            jobs = self._resolve_mapped(skip_existing)
         else:
-            jobs = self._resolve_prefix(bucket)
+            jobs = self._resolve_prefix(bucket, skip_existing)
 
         self._download_parallel(bucket, jobs)
 
-    def _resolve_mapped(self) -> list[tuple[str, Path]]:
+    def _resolve_mapped(self, skip_existing: bool) -> list[tuple[str, Path]]:
         jobs: list[tuple[str, Path]] = []
         for s3_key, local_rel in self.files_with_destinations:
             local_path = (
@@ -505,12 +523,12 @@ class S3(BaseDownload):
                 if Path(local_rel).is_absolute()
                 else self._out / local_rel
             )
-            if self.skip_existing and local_path.exists():
+            if skip_existing and local_path.exists():
                 continue
             jobs.append((s3_key, local_path))
         return jobs
 
-    def _resolve_prefix(self, bucket: tp.Any) -> list[tuple[str, Path]]:
+    def _resolve_prefix(self, bucket: tp.Any, skip_existing: bool) -> list[tuple[str, Path]]:
         jobs: list[tuple[str, Path]] = []
         for obj in bucket.objects.filter(Prefix=self.prefix):
             rel = obj.key
@@ -519,7 +537,7 @@ class S3(BaseDownload):
             if not rel:
                 continue
             target = self._out / rel
-            if self.skip_existing and target.exists():
+            if skip_existing and target.exists():
                 continue
             jobs.append((obj.key, target))
         return jobs
@@ -550,11 +568,12 @@ class Dandi(BaseDownload):
     requirements: tp.ClassVar[tuple[str, ...]] = ("dandi",)
     version: str = "draft"
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         import dandi.download  # type: ignore[import-not-found,import-untyped]
 
         url = f"https://dandiarchive.org/dandiset/{self.study}/{self.version}"
-        dandi.download.download([url], output_dir=str(self._dl_dir), existing="skip")
+        existing = "overwrite" if overwrite else "skip"
+        dandi.download.download([url], output_dir=str(self._dl_dir), existing=existing)
 
 
 class Datalad(BaseDownload):
@@ -608,8 +627,11 @@ class Datalad(BaseDownload):
         cmd = f'datalad get "{cur_path}"{threads_}'
         self._datalad(cmd, self._dl_dir / self.repo_name)
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         """Downloads data from datalab
+
+        ``datalad get`` is idempotent and self-repairing, so ``overwrite`` needs
+        no special handling here: re-running fetches any missing/broken content.
 
         Since this requires a git connection to handle, make sure that
         git ssh-key is password free
@@ -688,7 +710,9 @@ class Donders(BaseDownload):
         self._user = user
         self._password = password
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
+        # ``overwrite`` is best-effort for the Donders WebDAV mirror: wget
+        # already refetches over the existing tree.
         command = "wget -r -nH -np --cut-dirs=1"
         command += " --no-check-certificate -U Mozilla"
         command += f" --user={self._user} --password={self._password}"
@@ -785,7 +809,7 @@ class Dryad(BaseDownload):
         files_resp = self._api_get(files_href)
         return files_resp.get("_embedded", {}).get("stash:files", [])
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         from urllib.parse import quote
 
         import requests as req
@@ -802,7 +826,7 @@ class Dryad(BaseDownload):
                 )
             except req.exceptions.HTTPError as e:
                 if e.response is not None and e.response.status_code == 405:
-                    self._download_individual_files()
+                    self._download_individual_files(overwrite=overwrite)
                     return
                 raise e
             try:
@@ -814,9 +838,9 @@ class Dryad(BaseDownload):
             if tmp.exists():
                 tmp.unlink()
 
-        self._download_individual_files()
+        self._download_individual_files(overwrite=overwrite)
 
-    def _download_individual_files(self) -> None:
+    def _download_individual_files(self, overwrite: bool = False) -> None:
         """Download each file in the dataset individually."""
         files = self._latest_version_files()
         print(f"Downloading {len(files)} files individually from Dryad...")
@@ -830,7 +854,10 @@ class Dryad(BaseDownload):
             dest = self._dl_dir / name
             is_zip = name.endswith(".zip")
             extracted_dir = self._dl_dir / Path(name).stem if is_zip else None
-            if dest.exists() or (extracted_dir is not None and extracted_dir.exists()):
+            already = dest.exists() or (
+                extracted_dir is not None and extracted_dir.exists()
+            )
+            if already and not overwrite:
                 print(f"  [{i}/{len(files)}] {name} already exists, skipping")
                 continue
             print(f"  [{i}/{len(files)}] Downloading {name}...")
@@ -871,7 +898,9 @@ class Eegdash(BaseDownload):
     requirements: tp.ClassVar[tuple[str, ...]] = ("eegdash>=0.8.2",)
     database: str = "eegdash"
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
+        # ``overwrite`` is best-effort: eegdash's client manages its own cache
+        # and refetches missing recordings on demand.
         from eegdash import EEGDashDataset  # type: ignore[import-not-found]
 
         EEGDashDataset(
@@ -896,7 +925,9 @@ class Figshare(BaseDownload):
         in the article URL on figshare.com.
     """
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
+        # Every file is (re)written unconditionally, so a forced re-run under
+        # ``overwrite`` naturally refreshes the whole article.
         import requests
 
         item_ids = [self.study]
@@ -1029,7 +1060,7 @@ class Globus(BaseDownload):
         )
         return app
 
-    def _resolve_walk(self, tc: tp.Any) -> list[tuple[str, Path]]:
+    def _resolve_walk(self, tc: tp.Any, skip_existing: bool) -> list[tuple[str, Path]]:
         jobs: list[tuple[str, Path]] = []
         root = self.study.rstrip("/") or "/"
         stack: list[str] = [root]
@@ -1047,13 +1078,16 @@ class Globus(BaseDownload):
                 elif etype == "file":
                     rel = full[len(root) :].lstrip("/")
                     local_path = self._dl_dir / rel
-                    if self.skip_existing and local_path.exists():
+                    if skip_existing and local_path.exists():
                         continue
                     jobs.append((full, local_path))
         return jobs
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         import globus_sdk
+
+        # ``overwrite`` forces re-transfer of files already on disk.
+        skip_existing = self.skip_existing and not overwrite
 
         app = self._build_app()
         tc = globus_sdk.TransferClient(app=app)
@@ -1072,7 +1106,7 @@ class Globus(BaseDownload):
             ).get_authorization_header()
         }
 
-        jobs = self._resolve_walk(tc)
+        jobs = self._resolve_walk(tc, skip_existing)
 
         if not jobs:
             print(f"Nothing to download for {self.study}")
@@ -1108,13 +1142,14 @@ class Huggingface(BaseDownload):
     requirements: tp.ClassVar[tuple[str, ...]] = ("huggingface_hub",)
     org: str
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         from huggingface_hub import snapshot_download
 
         snapshot_download(
             repo_id=f"{self.org}/{self.study}",
             repo_type="dataset",
             local_dir=self._dl_dir,
+            force_download=overwrite,
         )
         print("\nDownloaded Dataset")
 
@@ -1143,7 +1178,10 @@ class Openneuro(BaseDownload):
     include: list[str] | None = None
     nworkers: int = 5
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
+        # openneuro-py verifies size/hash of files already on disk on every
+        # run and repairs mismatches in place, so a forced ``overwrite`` re-run
+        # needs no extra flag -- re-invoking already re-verifies and repairs.
         import openneuro as on
 
         on.download(
@@ -1174,7 +1212,7 @@ class Osf(BaseDownload):
     storage_inds: list[int] = [0]  # In case of multiple storages, storages to download
     requirements: tp.ClassVar[tuple[str, ...]] = ("osfclient>=0.0.5",)
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         import osfclient  # noqa
 
         project = osfclient.OSF().project(self.study)
@@ -1189,7 +1227,7 @@ class Osf(BaseDownload):
 
                 file_ = self._dl_dir / path
 
-                if file_.exists():
+                if file_.exists() and not overwrite:
                     continue
 
                 pbar.set_description(file_.name)
@@ -1209,7 +1247,7 @@ class Physionet(S3):
     bucket: str = "physionet-open"
     version: str
 
-    def _download(self, overwrite=False) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         self.prefix = f"{self.study}/{self.version}"
         self.output_dir = self._dl_dir / self.study / self.version
 
@@ -1217,7 +1255,7 @@ class Physionet(S3):
         # - list only keys under <study>/<version> via `prefix`
         # - S3 strips that prefix from each key before writing
         # - write under download/<study>/<version>/
-        super()._download()
+        super()._download(overwrite=overwrite)
 
 
 synapse_msg = """Requires creating a Synapse account with 2FA.
@@ -1255,7 +1293,9 @@ class Synapse(BaseDownload):
             )
         self._auth_token = token
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
+        # ``overwrite`` is best-effort: syncFromSynapse manages its own local
+        # cache and refetches changed/missing entities on each sync.
         import synapseclient  # type: ignore[import-not-found]
         import synapseutils  # type: ignore[import-not-found]
 
@@ -1310,7 +1350,7 @@ class Zenodo(BaseDownload):
                 f"Please check the record ID or provide dataset_fname/dataset_hash manually."
             ) from e
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         # TODO: Consider making the download async for multiple file downloads to occur
         # cf. openneuro-py implementation
 
@@ -1332,7 +1372,7 @@ class Zenodo(BaseDownload):
 
         for filename, file_hash in zipped_files.items():
             dest = self._dl_dir / Path(filename).stem
-            if dest.exists():
+            if dest.exists() and not overwrite:
                 continue
             tmp = self._dl_dir / f"temp_{filename}"
             download_file(
@@ -1345,7 +1385,7 @@ class Zenodo(BaseDownload):
 
         for filename, file_hash in info_files.items():
             dest = self._dl_dir / filename
-            if dest.exists():
+            if dest.exists() and not overwrite:
                 continue
             download_file(
                 f"{base_url}/files/{filename}",

--- a/neuralfetch-repo/neuralfetch/download.py
+++ b/neuralfetch-repo/neuralfetch/download.py
@@ -528,7 +528,9 @@ class S3(BaseDownload):
             jobs.append((s3_key, local_path))
         return jobs
 
-    def _resolve_prefix(self, bucket: tp.Any, skip_existing: bool) -> list[tuple[str, Path]]:
+    def _resolve_prefix(
+        self, bucket: tp.Any, skip_existing: bool
+    ) -> list[tuple[str, Path]]:
         jobs: list[tuple[str, Path]] = []
         for obj in bucket.objects.filter(Prefix=self.prefix):
             rel = obj.key

--- a/neuralfetch-repo/neuralfetch/studies/albrecht2019increased.py
+++ b/neuralfetch-repo/neuralfetch/studies/albrecht2019increased.py
@@ -76,7 +76,7 @@ class Albrecht2019Increased(study.Study):
         frequency=1000,
     )
 
-    def _download(self, overwrite=False) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         # https://predict.cs.unm.edu/downloads.php d004
         # Unable to use original dataset on PRED+ct.
         # Files shared here rely on Sharepoint and cannot be programmatically downloaded there.

--- a/neuralfetch-repo/neuralfetch/studies/allen2022massive.py
+++ b/neuralfetch-repo/neuralfetch/studies/allen2022massive.py
@@ -444,10 +444,10 @@ IIS-1822929."
 
     # ---- download ----
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         self._check_nsd_data_access_agreement()
         with success_writer(self.path / "download_all") as already_done:
-            if already_done:
+            if already_done and not overwrite:
                 return
             self._download_nsd_timeseries_dataset()
             self._validate_downloaded_dataset()
@@ -676,10 +676,10 @@ class Allen2022MassiveRaw(Allen2022Massive):
         fmri_spaces={"MNI152NLin2009cAsym", "T1w", "fsaverage", "fsnative"},
     )
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         self._check_nsd_data_access_agreement()
         with success_writer(self.path / "download_all") as already_done:
-            if already_done:
+            if already_done and not overwrite:
                 return
             nsd_common_path = get_allen2022massive_common_path(self.path)
             self._download_nsd_raw_dataset()
@@ -913,7 +913,7 @@ class Allen2022MassiveSample(Allen2022Massive):
         fmri_spaces={"custom"},
     )
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         self._check_nsd_data_access_agreement()
 
         s3_files = [_S3_ROI_PATH]
@@ -927,7 +927,7 @@ class Allen2022MassiveSample(Allen2022Massive):
 
         for filepath in s3_files:
             local_path = self.path / filepath
-            if local_path.exists():
+            if local_path.exists() and not overwrite:
                 continue
             local_path.parent.mkdir(parents=True, exist_ok=True)
             command = [

--- a/neuralfetch-repo/neuralfetch/studies/alvarez2022haaglanden.py
+++ b/neuralfetch-repo/neuralfetch/studies/alvarez2022haaglanden.py
@@ -63,7 +63,7 @@ class Alvarez2022Haaglanden(study.Study):
         frequency=256,
     )
 
-    def _download(self, overwrite=False) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         self.path.mkdir(exist_ok=True, parents=True)
         physionet = download.Physionet(
             study="hmc-sleep-staging",

--- a/neuralfetch-repo/neuralfetch/studies/bel2026petit.py
+++ b/neuralfetch-repo/neuralfetch/studies/bel2026petit.py
@@ -85,7 +85,7 @@ class _Bel2026PetitBase(study.Study):
         super().model_post_init(log__)
         self.version = "v3"
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         raise NotImplementedError(
             "This function is meant to be called on each independent study, Bel2026PetitRead and Bel2026PetitListen,"
             "which have different dataset IDs. See their implementations for details."
@@ -243,10 +243,10 @@ class Bel2026PetitListen(_Bel2026PetitBase):
         frequency=1000.0,
     )
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         dataset_id = "ds007523"
         client = download.Openneuro(folder="", study=dataset_id, dset_dir=self.path)
-        client.download()
+        client.download(overwrite=overwrite)
 
     def _load_timeline_events(self, timeline: dict[str, tp.Any]) -> pd.DataFrame:
         """Load events from the events.tsv file for the listen task."""
@@ -416,10 +416,10 @@ class Bel2026PetitRead(_Bel2026PetitBase):
         frequency=1000.0,
     )
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         dataset_id = "ds007524"
         client = download.Openneuro(folder="", study=dataset_id, dset_dir=self.path)
-        client.download()
+        client.download(overwrite=overwrite)
 
     def _load_timeline_events(self, timeline: dict[str, tp.Any]) -> pd.DataFrame:
         """Load events from the events.tsv file for the read task."""
@@ -583,7 +583,7 @@ class Bel2026PetitListenSample(Bel2026PetitListen):
         frequency=1000.0,
     )
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         # ds007523 is the full dataset; here we download only subject 26
         dataset_id = "ds007523"
         client = download.Openneuro(
@@ -604,7 +604,7 @@ class Bel2026PetitListenSample(Bel2026PetitListen):
                 "dataset_description.json",
             ],
         )
-        client.download()
+        client.download(overwrite=overwrite)
 
     def iter_timelines(self) -> tp.Iterator[dict[str, tp.Any]]:
         """Yield only subject 26, run 01."""
@@ -654,7 +654,7 @@ class Bel2026PetitReadSample(Bel2026PetitRead):
         frequency=1000.0,
     )
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         # ds007524 is the full dataset; here we download only subject 26 run 01
         dataset_id = "ds007524"
         client = download.Openneuro(
@@ -672,7 +672,7 @@ class Bel2026PetitReadSample(Bel2026PetitRead):
                 "dataset_description.json",
             ],
         )
-        client.download()
+        client.download(overwrite=overwrite)
 
     def iter_timelines(self) -> tp.Iterator[dict[str, tp.Any]]:
         """Yield only subject 26, run 01."""

--- a/neuralfetch-repo/neuralfetch/studies/brennan2019hierarchical.py
+++ b/neuralfetch-repo/neuralfetch/studies/brennan2019hierarchical.py
@@ -96,7 +96,7 @@ class Brennan2019Hierarchical(study.Study):
             study="/bn/99/97/38/r/",
             dset_dir=self.path,
             collection_id="cc387c09-b0e5-422b-a384-0d96e7ffdc73",
-        ).download()
+        ).download(overwrite=overwrite)
 
         # Bumped from "success_extract": the v1 marker predates proc.zip
         # extraction, so existing caches must re-extract to get the .mat files.

--- a/neuralfetch-repo/neuralfetch/studies/chang2019bold5000.py
+++ b/neuralfetch-repo/neuralfetch/studies/chang2019bold5000.py
@@ -113,14 +113,16 @@ class Chang2019Bold5000(study.Study):
     SUBJ_PADDING: tp.ClassVar[str] = "01"
     SUBJ_SUFFIX: tp.ClassVar[str] = "CSI"
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         with download.success_writer(self.path / "download_all") as already_done:
-            if already_done:
+            if already_done and not overwrite:
                 return
             # Download fMRI data from OpenNeuro
             from neuralfetch.download import Openneuro
 
-            Openneuro(study="ds001499", dset_dir=self.path).download()
+            Openneuro(study="ds001499", dset_dir=self.path).download(
+                overwrite=overwrite
+            )
 
             # Download stimuli data
             stimuli_zip = self.path / "BOLD5000_Stimuli.zip"

--- a/neuralfetch-repo/neuralfetch/studies/chang2019bold5000.py
+++ b/neuralfetch-repo/neuralfetch/studies/chang2019bold5000.py
@@ -120,9 +120,7 @@ class Chang2019Bold5000(study.Study):
             # Download fMRI data from OpenNeuro
             from neuralfetch.download import Openneuro
 
-            Openneuro(study="ds001499", dset_dir=self.path).download(
-                overwrite=overwrite
-            )
+            Openneuro(study="ds001499", dset_dir=self.path).download(overwrite=overwrite)
 
             # Download stimuli data
             stimuli_zip = self.path / "BOLD5000_Stimuli.zip"

--- a/neuralfetch-repo/neuralfetch/studies/chen2023large.py
+++ b/neuralfetch-repo/neuralfetch/studies/chen2023large.py
@@ -94,7 +94,7 @@ class Chen2023Large(study.Study):
         frequency=1000,
     )
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         """Data can also be downloaded manually after login at:
         https://www.synapse.org/Synapse:syn50614194
         """
@@ -102,7 +102,7 @@ class Chen2023Large(study.Study):
             study="Chen2023Large",
             study_id="syn50614194",
             dset_dir=self.path,
-        ).download()
+        ).download(overwrite=overwrite)
 
     def iter_timelines(self) -> tp.Iterator[dict[str, tp.Any]]:
         for subj_ind in range(123):

--- a/neuralfetch-repo/neuralfetch/studies/dan2023bids.py
+++ b/neuralfetch-repo/neuralfetch/studies/dan2023bids.py
@@ -108,11 +108,11 @@ class Dan2023Bids(study.Study):
         "24": [list(range(0, 22))],
     }
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         zenodo = download.Zenodo(
             study="CHB-MIT-EEG-Corpus", dset_dir=self.path, record_id="10259996"
         )
-        zenodo.download()
+        zenodo.download(overwrite=overwrite)
 
     def _get_bids_path(self, timeline: dict[str, tp.Any]) -> BIDSPath:
         """Returns the BIDS path for a study"""

--- a/neuralfetch-repo/neuralfetch/studies/ghassemi2018you.py
+++ b/neuralfetch-repo/neuralfetch/studies/ghassemi2018you.py
@@ -164,13 +164,13 @@ class Ghassemi2018You(study.Study):
     _PHYSIONET_STUDY: tp.ClassVar[str] = "challenge-2018"
     _PHYSIONET_VERSION: tp.ClassVar[str] = "1.0.0"
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         physionet = download.Physionet(
             study=self._PHYSIONET_STUDY,
             dset_dir=self.path,
             version=self._PHYSIONET_VERSION,
         )
-        physionet.download()
+        physionet.download(overwrite=overwrite)
 
     def _download_root(self) -> Path:
         return self.path / "download" / self._PHYSIONET_STUDY / self._PHYSIONET_VERSION

--- a/neuralfetch-repo/neuralfetch/studies/gifford2022large.py
+++ b/neuralfetch-repo/neuralfetch/studies/gifford2022large.py
@@ -124,10 +124,10 @@ class Gifford2022Large(study.Study):
         raw = mne.io.RawArray(out["raw_eeg_data"], info)
         return raw
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         dataset_id = "18470912"
         figshare = download.Figshare(study=dataset_id, dset_dir=self.path)
-        figshare.download()
+        figshare.download(overwrite=overwrite)
 
         # Unzip EEG data
         from pyunpack import Archive
@@ -135,18 +135,20 @@ class Gifford2022Large(study.Study):
         dl_dir = self.path / "download"
         for zip_file in dl_dir.glob("sub-*.zip"):
             with download.success_writer(zip_file) as already_done:
-                if not already_done:
+                if overwrite or not already_done:
                     Archive(str(zip_file)).extractall(str(dl_dir))
 
         # Load .npy and save as mne.io.Raw to enable memmaping
         for eeg_fname in tqdm(dl_dir.glob("**/**/raw_eeg_*.npy")):
             with download.success_writer(eeg_fname) as already_done:
-                if not already_done:
+                if overwrite or not already_done:
                     raw = self._create_raw_from_npy(eeg_fname)
                     raw.save(str(eeg_fname).replace(".npy", "_raw.fif"), overwrite=True)
 
         # Download images from OSF
-        download.Osf(study="y63gw", dset_dir=self.path, folder="download").download()
+        download.Osf(study="y63gw", dset_dir=self.path, folder="download").download(
+            overwrite=overwrite
+        )
 
         # Check for / Download THINGS-images database (used across multiple THINGS studies)
         download_things_images(self.path)
@@ -155,7 +157,7 @@ class Gifford2022Large(study.Study):
         for image_fname in ["training_images.zip", "test_images.zip"]:
             zip_file = dl_dir / image_fname
             with download.success_writer(zip_file) as already_done:
-                if not already_done:
+                if overwrite or not already_done:
                     Archive(str(zip_file)).extractall(str(dl_dir))
 
         # Clean up zip files

--- a/neuralfetch-repo/neuralfetch/studies/grootswagers2022human.py
+++ b/neuralfetch-repo/neuralfetch/studies/grootswagers2022human.py
@@ -96,9 +96,11 @@ class Grootswagers2022Human(study.Study):
 
     _test_image_names: list[str] | None = None
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         # Download EEG data from OpenNeuro
-        download.Openneuro(study="ds003825", dset_dir=self.path).download()
+        download.Openneuro(study="ds003825", dset_dir=self.path).download(
+            overwrite=overwrite
+        )
         # Check for / Download THINGS-images database (used across multiple THINGS studies)
         # Note: Images must be preprocessed and placed in prepare/ folder separately
         utils.download_things_images(self.path)
@@ -216,7 +218,7 @@ class Grootswagers2022HumanSample(Grootswagers2022Human):
         frequency=1000,
     )
 
-    def _download(self, overwrite=False) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         sub = self._SAMPLE_SUBJECT
         include_patterns = [
             "dataset_description.json",

--- a/neuralfetch-repo/neuralfetch/studies/hebart2023things.py
+++ b/neuralfetch-repo/neuralfetch/studies/hebart2023things.py
@@ -119,7 +119,7 @@ class _Hebart2023Things(study.Study):
             )
         return df
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         """Download the shared THINGS-images database."""
         utils.download_things_images(self.path)
 
@@ -180,9 +180,9 @@ class Hebart2023ThingsMeg(_Hebart2023Things):
         frequency=1200.0,
     )
 
-    def _download(self) -> None:
-        super()._download()  # Download shared THINGS-images database
-        download.Openneuro("ds004212", self.path).download()  # type: ignore
+    def _download(self, overwrite: bool = False) -> None:
+        super()._download(overwrite=overwrite)  # Download shared THINGS-images database
+        download.Openneuro("ds004212", self.path).download(overwrite=overwrite)  # type: ignore
 
     def iter_timelines(self) -> tp.Iterator[dict[str, tp.Any]]:
         """Returns a generator of all recordings"""
@@ -378,18 +378,18 @@ class Hebart2023ThingsBold(_Hebart2023Things):
     SESSION_SUFFIX: tp.ClassVar[str] = "things"
     TR_FMRI_S: tp.ClassVar[float] = 1.5
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         with download.success_writer(self.path / "download_all") as already_done:
-            if already_done:
+            if already_done and not overwrite:
                 return
-            super()._download()  # Download shared THINGS-images database
+            super()._download(overwrite=overwrite)  # Download shared THINGS-images database
             download.Datalad(
                 study="hebart2023bold",
                 dset_dir=self.path,
                 repo_url="https://github.com/OpenNeuroDatasets/ds004192.git",
                 threads=4,
                 folders=[download.Wildcard(folder="sub-*")],
-            ).download()
+            ).download(overwrite=overwrite)
             self._write_test_categories()
 
     def _write_test_categories(self) -> None:

--- a/neuralfetch-repo/neuralfetch/studies/hebart2023things.py
+++ b/neuralfetch-repo/neuralfetch/studies/hebart2023things.py
@@ -382,7 +382,9 @@ class Hebart2023ThingsBold(_Hebart2023Things):
         with download.success_writer(self.path / "download_all") as already_done:
             if already_done and not overwrite:
                 return
-            super()._download(overwrite=overwrite)  # Download shared THINGS-images database
+            super()._download(
+                overwrite=overwrite
+            )  # Download shared THINGS-images database
             download.Datalad(
                 study="hebart2023bold",
                 dset_dir=self.path,

--- a/neuralfetch-repo/neuralfetch/studies/hinss2023open.py
+++ b/neuralfetch-repo/neuralfetch/studies/hinss2023open.py
@@ -83,9 +83,9 @@ class Hinss2023Open(study.Study):
         "MATBdiff",
     ]
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         zenodo = download.Zenodo(study="COG-BCI", dset_dir=self.path, record_id="7413650")
-        zenodo.download()
+        zenodo.download(overwrite=overwrite)
 
     def _get_filepath(self, timeline: dict[str, tp.Any]):
         tl = timeline

--- a/neuralfetch-repo/neuralfetch/studies/hollenstein2018zuco.py
+++ b/neuralfetch-repo/neuralfetch/studies/hollenstein2018zuco.py
@@ -99,11 +99,13 @@ class Hollenstein2018Zuco(study.Study):
     # 13: control sentence offset
     url: tp.ClassVar[str] = "https://osf.io/q3zws/"
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         with download.success_writer(self.path / "download_all") as already_done:
-            if already_done:
+            if already_done and not overwrite:
                 return
-            download.Osf(study="q3zws", dset_dir=self.path, folder="download").download()
+            download.Osf(study="q3zws", dset_dir=self.path, folder="download").download(
+                overwrite=overwrite
+            )
 
             # Cleanup directory names
             dl_dir = self.path / "download"

--- a/neuralfetch-repo/neuralfetch/studies/kemp2000analysis.py
+++ b/neuralfetch-repo/neuralfetch/studies/kemp2000analysis.py
@@ -81,7 +81,7 @@ class Kemp2000Analysis(study.Study):
         x for x in SUBJECTS if x not in [13, 39, 68, 69, 78, 79]
     ]
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         """
         Leverages mne.datasets.fetch_dataset method to download.
         - The reported download link: https://physionet.org/physiobank/database/sleep-edfx/sleep-cassette/
@@ -95,10 +95,16 @@ class Kemp2000Analysis(study.Study):
         subprocess.run((f"wget -r -N -c -np -P {folder} {download_url}"), shell=True)
         """
         sleep_physionet.age.fetch_data(
-            subjects=self.SUBJECTS_REC_1, recording=[1], path=self.path
+            subjects=self.SUBJECTS_REC_1,
+            recording=[1],
+            path=self.path,
+            force_update=overwrite,
         )
         sleep_physionet.age.fetch_data(
-            subjects=self.SUBJECTS_REC_2, recording=[2], path=self.path
+            subjects=self.SUBJECTS_REC_2,
+            recording=[2],
+            path=self.path,
+            force_update=overwrite,
         )
 
     def iter_timelines(self) -> tp.Iterator[dict[str, tp.Any]]:

--- a/neuralfetch-repo/neuralfetch/studies/kueper2024eeg.py
+++ b/neuralfetch-repo/neuralfetch/studies/kueper2024eeg.py
@@ -109,9 +109,9 @@ class Kueper2024Eeg(study.Study):
         "BY74D": {"date": ["20230424"], "runs": list(range(1, 11))},
     }
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         zenodo = download.Zenodo(study="EEG", dset_dir=self.path, record_id="8345429")
-        zenodo.download()
+        zenodo.download(overwrite=overwrite)
 
     def _get_basename(self, timeline: dict[str, tp.Any]):
         tl = timeline

--- a/neuralfetch-repo/neuralfetch/studies/levy2026noninvasive.py
+++ b/neuralfetch-repo/neuralfetch/studies/levy2026noninvasive.py
@@ -139,13 +139,13 @@ class _Levy2026Noninvasive(study.Study):
       to the data spreadsheet to correct the event dataframe when doing per subject analysis.
     """
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         """Download the public SpanishBCBL (DECOMEG) release from Hugging Face."""
         download.Huggingface(
             study="SpanishBCBL",
             org="bcbl190626",
             dset_dir=self.path,
-        ).download()
+        ).download(overwrite=overwrite)
 
     def iter_timelines(self) -> tp.Iterator[dict[str, tp.Any]]:
         # List all recordings: depends on study structure

--- a/neuralfetch-repo/neuralfetch/studies/li2022petit.py
+++ b/neuralfetch-repo/neuralfetch/studies/li2022petit.py
@@ -106,7 +106,7 @@ class Li2022Petit(study.Study):
         super().model_post_init(log__)
         self.version = "v3"
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         """
         Data is available here:
         https://openneuro.org/datasets/ds003643/versions/2.0.5/
@@ -117,7 +117,7 @@ class Li2022Petit(study.Study):
         if path.name.lower() != self.__class__.__name__.lower():
             path = path / self.__class__.__name__
         client = download.Openneuro(study=dataset_id, dset_dir=path)
-        client.download()
+        client.download(overwrite=overwrite)
         # TODO when available, automate download of transcripts files
 
     def iter_timelines(self) -> tp.Iterator[dict[str, tp.Any]]:
@@ -314,7 +314,7 @@ class Li2022PetitSample(Li2022Petit):
         "https://belcorentin.github.io/pi-aiche-dee/lpp_en_text.zip"
     )
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         """Download ultra-minimal dataset: EN057 section 1 only."""
         dataset_id = "ds003643"
         path = self.path
@@ -334,12 +334,12 @@ class Li2022PetitSample(Li2022Petit):
         client = download.Openneuro(
             study=dataset_id, dset_dir=path, include=include_patterns
         )
-        client.download()
+        client.download(overwrite=overwrite)
 
         # Download English transcripts from hosted location
-        self._download_transcripts(path)
+        self._download_transcripts(path, overwrite=overwrite)
 
-    def _download_transcripts(self, path: tp.Any) -> None:
+    def _download_transcripts(self, path: tp.Any, overwrite: bool = False) -> None:
         """Download English transcript files."""
         import requests
 
@@ -347,7 +347,7 @@ class Li2022PetitSample(Li2022Petit):
         transcripts_dir.mkdir(parents=True, exist_ok=True)
         zip_path = transcripts_dir / "lpp_en_text.zip"
 
-        if zip_path.exists():
+        if zip_path.exists() and not overwrite:
             return  # Already downloaded
 
         try:

--- a/neuralfetch-repo/neuralfetch/studies/liu2024eeg2video.py
+++ b/neuralfetch-repo/neuralfetch/studies/liu2024eeg2video.py
@@ -168,7 +168,7 @@ class Liu2024Eeg2video(study.Study):
         frequency=200.0,
     )
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         raise NotImplementedError(
             "SEED-DV requires manual download. Steps:\n"
             "1. Download and sign the license agreement:\n"

--- a/neuralfetch-repo/neuralfetch/studies/miltiadous2023dice.py
+++ b/neuralfetch-repo/neuralfetch/studies/miltiadous2023dice.py
@@ -85,8 +85,10 @@ class Miltiadous2023Dice(study.Study):
         frequency=500,
     )
 
-    def _download(self, overwrite=False) -> None:
-        download.Openneuro(study="ds004504", dset_dir=self.path).download()
+    def _download(self, overwrite: bool = False) -> None:
+        download.Openneuro(study="ds004504", dset_dir=self.path).download(
+            overwrite=overwrite
+        )
 
     def iter_timelines(self):
         """Returns a generator of all recordings"""
@@ -170,7 +172,7 @@ class Miltiadous2023DiceSample(Miltiadous2023Dice):
         frequency=500,
     )
 
-    def _download(self, overwrite=False) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         """Download only 3 subjects from the dataset."""
         include_patterns = [
             "dataset_description.json",

--- a/neuralfetch-repo/neuralfetch/studies/moabb2025.py
+++ b/neuralfetch-repo/neuralfetch/studies/moabb2025.py
@@ -231,18 +231,21 @@ class _BaseMoabb(studies.Study):
         return df
 
     # Populate subclass-level metadata
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         """
         Download MoABB dataset and write timelines as a csv.
 
         (Timelines needed to avoid 'moabb.datasets.studies.get_data()' in self.iter_timelines, which loads ALL raw data.)
 
+        With ``overwrite`` the manifest is rebuilt even if it already exists;
+        forcing moabb to re-fetch the raw cache is best-effort and delegated to
+        the upstream client.
         """
         from moabb.datasets.base import CacheConfig
 
         timeline_path = Path(self.path) / "timelines.csv"
 
-        if not timeline_path.exists():
+        if overwrite or not timeline_path.exists():
             dl_path = Path(self.path) / "download"
             try:
                 dl_path.mkdir(exist_ok=True, parents=True)
@@ -3199,10 +3202,10 @@ class Romani2025Brainform(_BaseMoabb):
         labels = [s for s in labels if s not in self._EXCLUDE_SUBJECTS]
         return {i: s for i, s in enumerate(labels)}
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         """Build timelines.csv by scanning BIDS directory (no mne_bids needed)."""
         timeline_path = Path(self.path) / "timelines.csv"
-        if timeline_path.exists():
+        if timeline_path.exists() and not overwrite:
             return
 
         bids = self._bids_root()

--- a/neuralfetch-repo/neuralfetch/studies/mumtaz2018machine.py
+++ b/neuralfetch-repo/neuralfetch/studies/mumtaz2018machine.py
@@ -105,10 +105,10 @@ class Mumtaz2018Machine(study.Study):
         "MDD": "major_depressive_disorder",
     }
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         dataset_id = "4244171"
         figshare = download.Figshare(study=dataset_id, dset_dir=self.path)
-        figshare.download()
+        figshare.download(overwrite=overwrite)
 
     @staticmethod
     def _get_fname(path: Path, basename: str) -> Path:

--- a/neuralfetch-repo/neuralfetch/studies/nieuwland2018large.py
+++ b/neuralfetch-repo/neuralfetch/studies/nieuwland2018large.py
@@ -99,11 +99,13 @@ class Nieuwland2018Large(study.Study):
         frequency=500,
     )
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         with download.success_writer(self.path / "download_all") as already_done:
-            if already_done:
+            if already_done and not overwrite:
                 return
-            download.Osf(study="eyzaq", dset_dir=self.path, folder="download").download()
+            download.Osf(study="eyzaq", dset_dir=self.path, folder="download").download(
+                overwrite=overwrite
+            )
             _preproc_stimuli(self.path)
 
     def iter_timelines(self) -> tp.Iterator[dict[str, tp.Any]]:

--- a/neuralfetch-repo/neuralfetch/studies/schalk2004bci2000.py
+++ b/neuralfetch-repo/neuralfetch/studies/schalk2004bci2000.py
@@ -90,17 +90,18 @@ class Schalk2004Bci2000(study.Study):
         temp_folder = self.path / "temp"
         download_url = "https://physionet.org/files/eegmmidb/1.0.0/"
         with download.success_writer(folder) as already_done:
-            if overwrite or not already_done:
-                temp_folder.mkdir(exist_ok=True, parents=True)
-                subprocess.run(
-                    (f"wget -r -N -c -np -P {temp_folder} {download_url}"),
-                    shell=True,
-                    check=False,
-                )
-                download_path = temp_folder / "physionet.org/files/eegmmidb/1.0.0/"
-                download_path.rename(folder)
-                shutil.rmtree(temp_folder)  # cleanup empty folder
-                logger.info(f"Downloaded files to {folder}.")
+            if already_done and not overwrite:
+                return
+            temp_folder.mkdir(exist_ok=True, parents=True)
+            subprocess.run(
+                (f"wget -r -N -c -np -P {temp_folder} {download_url}"),
+                shell=True,
+                check=False,
+            )
+            download_path = temp_folder / "physionet.org/files/eegmmidb/1.0.0/"
+            download_path.rename(folder)
+            shutil.rmtree(temp_folder)  # cleanup empty folder
+            logger.info(f"Downloaded files to {folder}.")
 
     _RUN_CONDITION: tp.ClassVar[dict[str, str]] = {
         "R01": "Rest",

--- a/neuralfetch-repo/neuralfetch/studies/schalk2004bci2000.py
+++ b/neuralfetch-repo/neuralfetch/studies/schalk2004bci2000.py
@@ -83,14 +83,14 @@ class Schalk2004Bci2000(study.Study):
         frequency=160,
     )
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         #  Option to download through S3
         #  aws s3 sync s3://physionet-open/eegmmidb/1.0.0/ DESTINATION
         folder = self.path / "download"
         temp_folder = self.path / "temp"
         download_url = "https://physionet.org/files/eegmmidb/1.0.0/"
         with download.success_writer(folder) as already_done:
-            if not already_done:
+            if overwrite or not already_done:
                 temp_folder.mkdir(exist_ok=True, parents=True)
                 subprocess.run(
                     (f"wget -r -N -c -np -P {temp_folder} {download_url}"),

--- a/neuralfetch-repo/neuralfetch/studies/shirazi2024hbn.py
+++ b/neuralfetch-repo/neuralfetch/studies/shirazi2024hbn.py
@@ -129,13 +129,15 @@ class Shirazi2024Hbn(study.Study):
     DUR_CONTRAST_CHANGE_TARGET: tp.ClassVar[float] = 2.4
     DUR_CONTRAST_CHANGE_FEEDBACK: tp.ClassVar[float] = 0.4
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         for release, study_id in self.RELEASE_TO_STUDYID.items():
             n = release.split("-")[-1]
             logger.info(
                 f"Downloading Dataset: Healthy Brain Network (HBN) EEG - Release {n}"
             )
-            download.Openneuro(study=study_id, dset_dir=self.path / release).download()
+            download.Openneuro(study=study_id, dset_dir=self.path / release).download(
+                overwrite=overwrite
+            )
 
     def iter_timelines(self):
         for release in self.RELEASE_TO_STUDYID.keys():

--- a/neuralfetch-repo/neuralfetch/studies/singh2021timing.py
+++ b/neuralfetch-repo/neuralfetch/studies/singh2021timing.py
@@ -113,7 +113,7 @@ class Singh2021Timing(study.Study):
         frequency=500,
     )
 
-    def _download(self, overwrite=False) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         # https://predict.cs.unm.edu/downloads.php d014
         # Unable to use original dataset on PRED+ct.
         # Files shared here rely on Sharepoint

--- a/neuralfetch-repo/neuralfetch/studies/sivakumar2024emg2qwerty.py
+++ b/neuralfetch-repo/neuralfetch/studies/sivakumar2024emg2qwerty.py
@@ -83,8 +83,10 @@ class Sivakumar2024Emg2qwerty(study.Study):
 
     _bids_root_cache: Path | None = pydantic.PrivateAttr(default=None)
 
-    def _download(self) -> None:
-        download.Eegdash(study=self.NEMAR_DATASET_ID, dset_dir=self.path).download()
+    def _download(self, overwrite: bool = False) -> None:
+        download.Eegdash(study=self.NEMAR_DATASET_ID, dset_dir=self.path).download(
+            overwrite=overwrite
+        )
 
     @property
     def bids_root(self) -> Path:

--- a/neuralfetch-repo/neuralfetch/studies/tuh_eeg.py
+++ b/neuralfetch-repo/neuralfetch/studies/tuh_eeg.py
@@ -127,7 +127,7 @@ class _BaseTuhEeg(study.Study):
     )
 
     # TODO: Add download method, requires authentication
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         raise NotImplementedError("Dataset not available to download yet.")
         # self._create_symbolic_links()
 

--- a/neuralfetch-repo/neuralfetch/studies/xu2024alljoined.py
+++ b/neuralfetch-repo/neuralfetch/studies/xu2024alljoined.py
@@ -83,8 +83,10 @@ class Xu2024Alljoined(study.Study):
         frequency=512.0,
     )
 
-    def _download(self) -> None:
-        download.Osf(study="kqgs8", dset_dir=self.path, folder="xu2024").download()
+    def _download(self, overwrite: bool = False) -> None:
+        download.Osf(study="kqgs8", dset_dir=self.path, folder="xu2024").download(
+            overwrite=overwrite
+        )
 
     @staticmethod
     def _get_fname(

--- a/neuralfetch-repo/neuralfetch/studies/xu2025alljoined.py
+++ b/neuralfetch-repo/neuralfetch/studies/xu2025alljoined.py
@@ -76,7 +76,7 @@ class Xu2025Alljoined(study.Study):
         frequency=256.0,
     )
 
-    def _download(self, overwrite=False) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         accept = os.environ.get("ALLJOINED_ACCEPT_LICENCE", "").lower() in (
             "1",
             "true",

--- a/neuralfetch-repo/neuralfetch/studies/zyma2019electroencephalograms.py
+++ b/neuralfetch-repo/neuralfetch/studies/zyma2019electroencephalograms.py
@@ -81,7 +81,7 @@ class Zyma2019Electroencephalograms(study.Study):
     _PHYSIONET_STUDY: tp.ClassVar[str] = "eegmat"
     _PHYSIONET_VERSION: tp.ClassVar[str] = "1.0.0"
 
-    def _download(self, overwrite=False) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         physionet = download.Physionet(
             study=self._PHYSIONET_STUDY,
             version=self._PHYSIONET_VERSION,

--- a/neuralfetch-repo/neuralfetch/test_download.py
+++ b/neuralfetch-repo/neuralfetch/test_download.py
@@ -195,7 +195,7 @@ def test_physionet_preserves_study_version_structure(tmp_path: Path) -> None:
         dset_dir=tmp_path / "study",
     )
 
-    def mock_s3_download(self: download.S3) -> None:
+    def mock_s3_download(self: download.S3, overwrite: bool = False) -> None:
         assert self.prefix == "eegmat/1.0.0"
         assert self.output_dir == self._dl_dir / "eegmat" / "1.0.0"
         out_dir = tp.cast(Path, self.output_dir)

--- a/neuralfetch-repo/neuralfetch/test_studies.py
+++ b/neuralfetch-repo/neuralfetch/test_studies.py
@@ -79,8 +79,9 @@ def test_all_download_backends_accept_overwrite() -> None:
     for cls in sorted(
         _all_subclasses(_download_mod.BaseDownload), key=lambda c: c.__name__
     ):
-        if not _accepts_overwrite(cls._download):
-            sig = inspect.signature(cls._download)
+        download_fn = cls._download  # type: ignore[attr-defined]
+        if not _accepts_overwrite(download_fn):
+            sig = inspect.signature(download_fn)
             failures.append(f"{cls.__name__}: _download{sig}")
 
     assert not failures, (

--- a/neuralfetch-repo/neuralfetch/test_studies.py
+++ b/neuralfetch-repo/neuralfetch/test_studies.py
@@ -7,6 +7,7 @@
 """Tests for neuralfetch: study discovery and study info validation."""
 
 import importlib.util
+import inspect
 import sys
 from pathlib import Path
 
@@ -16,11 +17,76 @@ import requests
 from scipy.io import loadmat
 
 import neuralset as ns
+from neuralfetch import download as _download_mod
 from neuralfetch import utils
 from neuralfetch.studies.moabb2025 import Reichert2020Impact
 from neuralset.events import study as _study_mod
 
 INFO_STUDIES = [n for n, c in ns.Study.catalog().items() if c._info is not None]
+
+
+def _accepts_overwrite(func: object) -> bool:
+    """True if *func* can be called with an ``overwrite=`` keyword."""
+    params = inspect.signature(func).parameters  # type: ignore[arg-type]
+    if "overwrite" in params:
+        return True
+    return any(p.kind is p.VAR_KEYWORD for p in params.values())
+
+
+def test_all_neuralfetch_studies_accept_overwrite() -> None:
+    """Every neuralfetch study's ``_download`` must accept ``overwrite=``.
+
+    ``Study.download(**kwargs)`` forwards ``overwrite`` verbatim to
+    ``_download``; a study missing the parameter makes ``neuralfetch download
+    <Study>`` raise ``TypeError`` on every invocation (even without the flag,
+    since the CLI always passes ``overwrite=``). This is the anti-regression
+    guard for that contract.
+    """
+    checked = 0
+    failures: list[str] = []
+    for name, cls in sorted(ns.Study.catalog().items()):
+        module = getattr(cls, "__module__", "")
+        if not module.startswith("neuralfetch."):
+            continue
+        checked += 1
+        if not _accepts_overwrite(cls._download):
+            sig = inspect.signature(cls._download)
+            failures.append(f"{name} ({module}): _download{sig}")
+
+    assert checked, "no neuralfetch studies were discovered"
+    assert not failures, (
+        "these neuralfetch studies' _download() cannot accept overwrite=, so "
+        "`neuralfetch download <Study>` would raise TypeError:\n  "
+        + "\n  ".join(failures)
+    )
+
+
+def test_all_download_backends_accept_overwrite() -> None:
+    """Every ``BaseDownload`` backend's ``_download`` must accept ``overwrite=``.
+
+    ``BaseDownload.download(overwrite)`` forwards the flag into ``_download``;
+    a backend missing the parameter would raise ``TypeError`` as soon as it is
+    used with the two-tier overwrite semantics.
+    """
+
+    def _all_subclasses(cls: type) -> set[type]:
+        subs = set(cls.__subclasses__())
+        for sub in list(subs):
+            subs |= _all_subclasses(sub)
+        return subs
+
+    failures: list[str] = []
+    for cls in sorted(
+        _all_subclasses(_download_mod.BaseDownload), key=lambda c: c.__name__
+    ):
+        if not _accepts_overwrite(cls._download):
+            sig = inspect.signature(cls._download)
+            failures.append(f"{cls.__name__}: _download{sig}")
+
+    assert not failures, (
+        "these download backends' _download() cannot accept overwrite=:\n  "
+        + "\n  ".join(failures)
+    )
 
 
 def test_neuralfetch_discovery() -> None:

--- a/neuralset-repo/neuralset/events/study.py
+++ b/neuralset-repo/neuralset/events/study.py
@@ -432,14 +432,22 @@ class Study(patterns.Scatter, base.Step):  # type: ignore[misc]
         # )
         # return pd.DataFrame([event])
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         """Download dataset.
-        Needs to be overridden by user.
+
+        Needs to be overridden by user. Overrides MUST accept ``overwrite``
+        (see :meth:`download`): when True the study should redo the work --
+        ignore success markers/exists-gates and force per-file re-transfer or
+        re-verification rather than trusting mere existence on disk.
         """
         raise NotImplementedError("Dataset not available to download yet.")
 
     @tp.final
     def download(self, **kwargs: tp.Any) -> None:
+        # ``**kwargs`` (notably ``overwrite``) is forwarded verbatim to
+        # ``_download``; every ``_download`` override must therefore accept it,
+        # or ``neuralfetch download <Study>`` raises TypeError before doing any
+        # work (the CLI always passes ``overwrite=``).
         self._check_requirements()
         # The study subfolder is settled in ``model_post_init`` (see there), so
         # ``download()`` never reassigns ``self.path`` and is safe to call on a

--- a/neuralset-repo/neuralset/events/testing/examplemultimodal.py
+++ b/neuralset-repo/neuralset/events/testing/examplemultimodal.py
@@ -256,7 +256,7 @@ class ExampleMultiModal(study.Study):
             for r in (1, 2):
                 yield {"subject": f"sub-{s:02d}", "run": r}
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         for tl in self.iter_timelines():
             self._materialize(tl)
 

--- a/neuralset-repo/neuralset/events/testing/mne2013sample.py
+++ b/neuralset-repo/neuralset/events/testing/mne2013sample.py
@@ -65,7 +65,7 @@ class Mne2013Sample(study.Study):
         root.mkdir(parents=True, exist_ok=True)
         return mne.datasets.sample.data_path(root, verbose=True)
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         """Download the MNE sample dataset.
 
         The dataset will be automatically downloaded by MNE-Python

--- a/neuralset-repo/neuralset/events/testing/test2023fmri.py
+++ b/neuralset-repo/neuralset/events/testing/test2023fmri.py
@@ -110,7 +110,7 @@ class Fake2025Fmri(study.Study):
         fmri_spaces=("custom",),
     )
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         raise NotImplementedError
 
     def iter_timelines(self) -> tp.Iterator[dict[str, tp.Any]]:

--- a/neuralset-repo/neuralset/events/testing/test2023meg.py
+++ b/neuralset-repo/neuralset/events/testing/test2023meg.py
@@ -23,7 +23,7 @@ class Test2023Meg(study.Study):
         frequency=100,
     )
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         raise NotImplementedError
 
     def iter_timelines(self) -> tp.Iterator[dict[str, tp.Any]]:

--- a/neuralset-repo/neuralset/events/testing/test2024eeg.py
+++ b/neuralset-repo/neuralset/events/testing/test2024eeg.py
@@ -19,7 +19,7 @@ class _BaseTest2024Eeg(study.Study):
     ch_types: tp.ClassVar[list[str]]
     sfreq: tp.ClassVar[float]
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         raise NotImplementedError
 
     def iter_timelines(self) -> tp.Iterator[dict[str, tp.Any]]:

--- a/neuralset-repo/neuralset/events/testing/test2024fnirs.py
+++ b/neuralset-repo/neuralset/events/testing/test2024fnirs.py
@@ -26,7 +26,7 @@ class Test2024Fnirs(study.Study):
         frequency=10.0,
     )
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         raise NotImplementedError
 
     def iter_timelines(self) -> tp.Iterator[dict[str, tp.Any]]:

--- a/neuralset-repo/neuralset/events/testing/test2025ieeg.py
+++ b/neuralset-repo/neuralset/events/testing/test2025ieeg.py
@@ -19,7 +19,7 @@ class _BaseTest2025Ieeg(study.Study):
     ch_types: tp.ClassVar[list[str]]
     sfreq: tp.ClassVar[float]
 
-    def _download(self) -> None:
+    def _download(self, overwrite: bool = False) -> None:
         raise NotImplementedError
 
     def iter_timelines(self) -> tp.Iterator[dict[str, tp.Any]]:


### PR DESCRIPTION
## Why

In preparation for some cli commands for neuralfetch, we need to standardize our approach to overwriting. `neuralfetch download <Study>` always forwards `overwrite=` to `Study._download`,
so any study whose `_download` didn't declare the parameter raised
`TypeError: _download() got an unexpected keyword argument 'overwrite'` **before
doing any work** — even without the flag, since the CLI always passes it. This PR
makes the contract uniform and gives `overwrite` real, well-defined semantics.

This does not introduce new functionality, it just standardizes our private download method to accept the overwrite parameter. Since it's a private method, we don't need to worry about a deprecation cycle since this is all internal.

## What

**Two-tier overwrite semantics**
- `overwrite=False` (default) — resume/repair. Success marker present ⇒ no-op;
  absent ⇒ run and let backends skip files already on disk.
- `overwrite=True` — redo the work: ignore success markers / exists-gates and
  force per-file re-transfer or re-verification in the backend.

**Core (`neuralfetch/download.py`)**
- `BaseDownload.download(overwrite)` threads the flag into `_download`.
- `success_writer(..., overwrite=...)` reports an existing marker as absent when
  forcing.
- Per-backend "force" mapping (e.g. `skip_existing=False`, `force_download=True`,
  `existing="overwrite"`, exists-gate bypass) for tier-2 re-transfer; documented
  as best-effort where the upstream client owns the decision.
- Drop the stray unused `overwrite` param on `Physionet._download`.

**Base contract (`neuralset/events/study.py`)**
- Abstract `Study._download` gains `overwrite: bool = False`; `download()` documents
  that `**kwargs` is forwarded verbatim, so every override must accept `overwrite`.

**Studies**
- `_BaseMoabb` (fans out to the concrete dataset classes) and the remaining
  neuralfetch studies now accept + thread `overwrite`.
- Fix two no-ops: `miltiadous2023dice` and `brennan2019hierarchical` accepted
  `overwrite` but never forwarded it.

**Guardrails (`neuralfetch/test_studies.py`)**
- Registry-introspection tests assert every neuralfetch study and every
  `BaseDownload` backend's `_download` accepts `overwrite=` — the anti-regression
  guard for the CLI contract.
- `test_download.py`: update the `Physionet` mock to the new signature.

## Test plan
- [x] `pytest neuralfetch/test_studies.py -k "overwrite or discovery or backends"`
- [x] `pytest neuralfetch/test_download.py`
- [x] `ruff check` clean on changed files