### PR TITLE
fix hardcoded cluster config

### DIFF
--- a/neuralbench-repo/neuralbench/conftest.py
+++ b/neuralbench-repo/neuralbench/conftest.py
@@ -29,9 +29,9 @@ def patch_config(monkeypatch: pytest.MonkeyPatch) -> Callable[..., None]:
         base = config_manager._default_config()
         base.update(overrides)
         monkeypatch.setattr(config_manager, "_config", base)
-        monkeypatch.setattr(config_manager, "_initialized", False)
         for key in config_manager._LAZY_CONFIG_KEYS:
             monkeypatch.delattr(config_manager, key, raising=False)
+        monkeypatch.setattr(config_manager, "_initialized", False)
 
     return _apply
 

--- a/neuralbench-repo/neuralbench/tasks/eeg/image/config.yaml
+++ b/neuralbench-repo/neuralbench/tasks/eeg/image/config.yaml
@@ -24,7 +24,7 @@ data:
     imsize: 518
     aggregation: trigger
     infra:
-      cluster: auto
+      cluster: !!python/name:neuralbench.config_manager.CLUSTER
       keep_in_ram: false
       timeout_min: 180
       gpus_per_node: 1

--- a/neuralbench-repo/neuralbench/tasks/eeg/speech/config.yaml
+++ b/neuralbench-repo/neuralbench/tasks/eeg/speech/config.yaml
@@ -44,7 +44,7 @@ data:
       token_aggregation: mean
       aggregation: first
       infra:
-        cluster: auto
+        cluster: !!python/name:neuralbench.config_manager.CLUSTER
         keep_in_ram: false
         slurm_partition: !!python/name:neuralbench.config_manager.SLURM_PARTITION
         folder: !!python/name:neuralbench.config_manager.CACHE_DIR

--- a/neuralbench-repo/neuralbench/tasks/eeg/video/config.yaml
+++ b/neuralbench-repo/neuralbench/tasks/eeg/video/config.yaml
@@ -26,7 +26,7 @@ data:
       use_audio: False
       aggregation: trigger
       infra:
-        cluster: auto
+        cluster: !!python/name:neuralbench.config_manager.CLUSTER
         keep_in_ram: false
         slurm_partition: !!python/name:neuralbench.config_manager.SLURM_PARTITION
         folder: !!python/name:neuralbench.config_manager.CACHE_DIR

--- a/neuralbench-repo/neuralbench/tasks/eeg/word/config.yaml
+++ b/neuralbench-repo/neuralbench/tasks/eeg/word/config.yaml
@@ -23,7 +23,7 @@ data:
     name: SpacyEmbedding
     aggregation: trigger
     infra:
-      cluster: auto
+      cluster: !!python/name:neuralbench.config_manager.CLUSTER
       keep_in_ram: true
       timeout_min: 180
       gpus_per_node: 1

--- a/neuralbench-repo/neuralbench/tasks/emg/typing/config.yaml
+++ b/neuralbench-repo/neuralbench/tasks/emg/typing/config.yaml
@@ -68,7 +68,7 @@ data:
     scaler: null
     clamp: null
     infra:
-      cluster: auto
+      cluster: !!python/name:neuralbench.config_manager.CLUSTER
       folder: !!python/name:neuralbench.config_manager.CACHE_DIR
       keep_in_ram: true
       slurm_partition: !!python/name:neuralbench.config_manager.SLURM_PARTITION

--- a/neuralbench-repo/neuralbench/tasks/fmri/image/config.yaml
+++ b/neuralbench-repo/neuralbench/tasks/fmri/image/config.yaml
@@ -26,7 +26,7 @@ data:
     frequency: native
     infra:
       mode: cached
-      cluster: auto
+      cluster: !!python/name:neuralbench.config_manager.CLUSTER
       folder: !!python/name:neuralbench.config_manager.CACHE_DIR
       keep_in_ram: true
       slurm_partition: !!python/name:neuralbench.config_manager.SLURM_PARTITION

--- a/neuralbench-repo/neuralbench/tasks/fmri/image/config.yaml
+++ b/neuralbench-repo/neuralbench/tasks/fmri/image/config.yaml
@@ -42,7 +42,7 @@ data:
     imsize: 518
     aggregation: trigger
     infra:
-      cluster: auto
+      cluster: !!python/name:neuralbench.config_manager.CLUSTER
       keep_in_ram: false
       timeout_min: 180
       gpus_per_node: 1

--- a/neuralbench-repo/neuralbench/tasks/meg/image/config.yaml
+++ b/neuralbench-repo/neuralbench/tasks/meg/image/config.yaml
@@ -32,7 +32,7 @@ data:
     imsize: 518
     aggregation: trigger
     infra:
-      cluster: auto
+      cluster: !!python/name:neuralbench.config_manager.CLUSTER
       keep_in_ram: false
       timeout_min: 180
       gpus_per_node: 1

--- a/neuralbench-repo/neuralbench/test_cli.py
+++ b/neuralbench-repo/neuralbench/test_cli.py
@@ -22,7 +22,7 @@ from .experiment_config import (
     prepare_task_configs,
 )
 from .main import Data
-from .registry import ALL_DATASETS, ALL_TASKS, DEFAULTS_DIR, load_yaml_config
+from .registry import ALL_DATASETS, ALL_TASKS, DEFAULTS_DIR, load_yaml_config, _resolve_task_dir
 
 
 def test_build_all_datasets() -> None:
@@ -78,6 +78,30 @@ def test_cluster_config_wires_all_infra_clusters(
     assert raw["data"]["neuro"]["infra"]["cluster"] == cluster
     assert raw["data"]["target"]["infra"]["cluster"] == cluster
 
+@pytest.mark.parametrize("cluster", [None, "slurm"])
+def test_task_configs_do_not_override_infra_cluster(
+    patch_config: Callable[..., None], cluster: str | None
+) -> None:
+    """No task config may hardcode *.infra.cluster, overriding the user config."""
+    patch_config(CLUSTER=cluster)
+    defaults = load_yaml_config(DEFAULTS_DIR / "config.yaml")
+    assert defaults is not None
+    base = ConfDict(defaults)
+    for device, tasks in ALL_DATASETS.items():
+        for task_name in tasks:
+            merged = base.copy()
+            task_dir = _resolve_task_dir(device, task_name)
+            task_cfg = load_yaml_config(task_dir / "config.yaml")
+            if task_cfg is None:
+                continue
+            merged.update(task_cfg)
+            flat = merged.flat()
+            for key, value in flat.items():
+                if key.endswith("infra.cluster"):
+                    assert value == cluster, (
+                        f"{device}/{task_name}: {key} is {value!r}, "
+                        f"expected {cluster!r}"
+                    )
 
 @pytest.mark.parametrize("cluster", [None, "auto", "slurm"])
 def test_prepare_overlay_respects_cluster(

--- a/neuralbench-repo/neuralbench/test_cli.py
+++ b/neuralbench-repo/neuralbench/test_cli.py
@@ -22,7 +22,13 @@ from .experiment_config import (
     prepare_task_configs,
 )
 from .main import Data
-from .registry import ALL_DATASETS, ALL_TASKS, DEFAULTS_DIR, load_yaml_config, _resolve_task_dir
+from .registry import (
+    ALL_DATASETS,
+    ALL_TASKS,
+    DEFAULTS_DIR,
+    _resolve_task_dir,
+    load_yaml_config,
+)
 
 
 def test_build_all_datasets() -> None:
@@ -78,6 +84,7 @@ def test_cluster_config_wires_all_infra_clusters(
     assert raw["data"]["neuro"]["infra"]["cluster"] == cluster
     assert raw["data"]["target"]["infra"]["cluster"] == cluster
 
+
 @pytest.mark.parametrize("cluster", [None, "slurm"])
 def test_task_configs_do_not_override_infra_cluster(
     patch_config: Callable[..., None], cluster: str | None
@@ -99,9 +106,9 @@ def test_task_configs_do_not_override_infra_cluster(
             for key, value in flat.items():
                 if key.endswith("infra.cluster"):
                     assert value == cluster, (
-                        f"{device}/{task_name}: {key} is {value!r}, "
-                        f"expected {cluster!r}"
+                        f"{device}/{task_name}: {key} is {value!r}, expected {cluster!r}"
                     )
+
 
 @pytest.mark.parametrize("cluster", [None, "auto", "slurm"])
 def test_prepare_overlay_respects_cluster(


### PR DESCRIPTION
## What does this PR do?
Issue:
Even I set `"CLUSTER": null` in config.json but neuralbench still call to slurm when run extractor task.

This pull request updates the configuration for several task files to improve how the compute cluster is specified. Instead of hardcoding the cluster as `auto`, the configs now reference a central Python variable.

