### PR TITLE
Follow up on get_default_dataloaders: dataset variants, input validation, one config-merge home

### DIFF
--- a/docs/neuralbench/api.rst
+++ b/docs/neuralbench/api.rst
@@ -14,6 +14,14 @@ Core
    Experiment
    BenchmarkAggregator
 
+.. currentmodule:: neuralbench.data
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   get_default_dataloaders
+
 .. currentmodule:: neuralbench.pl_module
 
 .. autosummary::

--- a/neuralbench-repo/neuralbench/data.py
+++ b/neuralbench-repo/neuralbench/data.py
@@ -9,7 +9,6 @@ import typing as tp
 
 import numpy as np
 import torch
-from exca import ConfDict
 from pydantic import field_validator
 from torch.utils.data import DataLoader
 from tqdm import tqdm
@@ -17,8 +16,9 @@ from tqdm import tqdm
 import neuralset as ns
 
 from .config_manager import _ensure_initialized
+from .experiment_config import merge_task_config
 from .extractors import SleepOnsetTargetExtractor  # noqa: F401
-from .registry import DEFAULTS_DIR, _resolve_task_dir, load_yaml_config
+from .registry import _validate_inputs
 from .transforms import (  # noqa: F401
     AddDefaultEvents,
     AddSleepOnsetTargets,
@@ -293,14 +293,44 @@ class Data(ns.BaseModel):
 
 
 def get_default_dataloaders(
-    device: str, task: str, **overrides: tp.Any
+    device: str, task: str, *, dataset: str | None = None, **overrides: tp.Any
 ) -> dict[str, DataLoader]:
-    """Return the train/val/test DataLoaders a ``device``/``task`` benchmark run uses."""
+    """Return the train/val/test DataLoaders for a task's default data config.
 
+    The dataloaders match those of a benchmark run for the same task, except
+    for model-specific preprocessing: model configs override ``data.neuro``
+    fields (sampling frequency, filters, clamping) to suit each architecture,
+    and those overrides are not applied here.
+
+    Parameters
+    ----------
+    device
+        Brain recording device (``"eeg"``, ``"meg"``, ``"fmri"``, ...).
+    task
+        Single task name, e.g. ``"motor_imagery"``.
+    dataset
+        Dataset variant from the task's ``datasets/`` directory. ``None`` uses
+        the study of the task config.
+    **overrides
+        Overrides for the ``data`` config, as dotted paths, e.g.
+        ``batch_size=8`` or ``**{"neuro.frequency": 60.0}``.
+
+    Returns
+    -------
+    dict with keys ``"train"``, ``"val"``, ``"test"`` mapping to
+    :class:`~torch.utils.data.DataLoader` instances.
+
+    Examples
+    --------
+    Extraction inherits the benchmark infra, which submits SLURM jobs where a
+    cluster is available. To extract in-process instead:
+
+    >>> loaders = get_default_dataloaders(
+    ...     "eeg", "audiovisual_stimulus", **{"neuro.infra.cluster": None}
+    ... )
+    """
     _ensure_initialized()
-
-    config = ConfDict(load_yaml_config(DEFAULTS_DIR / "config.yaml"))
-    config.update(load_yaml_config(_resolve_task_dir(device, task) / "config.yaml"))
-    data_config = ConfDict(config)["data"]
+    _validate_inputs(device, task, None, None)
+    data_config = merge_task_config(device, task, dataset)["data"]
     data_config.update(overrides)
     return Data(**data_config).prepare()

--- a/neuralbench-repo/neuralbench/data.py
+++ b/neuralbench-repo/neuralbench/data.py
@@ -297,10 +297,11 @@ def get_default_dataloaders(
 ) -> dict[str, DataLoader]:
     """Return the train/val/test DataLoaders for a task's default data config.
 
-    The dataloaders match those of a benchmark run for the same task, except
-    for model-specific preprocessing: model configs override ``data.neuro``
-    fields (sampling frequency, filters, clamping) to suit each architecture,
-    and those overrides are not applied here.
+    The dataloaders match those of a non-debug benchmark run for the same
+    task, except for model-specific preprocessing: model configs override
+    ``data.neuro`` (sampling frequency, filters, clamping) and, for some
+    models, ``data.channel_positions``, and those overrides are not applied
+    here.
 
     Parameters
     ----------
@@ -329,8 +330,8 @@ def get_default_dataloaders(
     ...     "eeg", "audiovisual_stimulus", **{"neuro.infra.cluster": None}
     ... )
     """
+    _validate_inputs(device, task, model=None, downstream_wrapper=None, allow_all=False)
     _ensure_initialized()
-    _validate_inputs(device, task, None, None)
     data_config = merge_task_config(device, task, dataset)["data"]
     data_config.update(overrides)
     return Data(**data_config).prepare()

--- a/neuralbench-repo/neuralbench/experiment_config.py
+++ b/neuralbench-repo/neuralbench/experiment_config.py
@@ -130,9 +130,15 @@ def _merge_dataset_config(
     config: ConfDict, device: str, task_name: str, dataset: str
 ) -> None:
     """Layer a task's ``datasets/<dataset>.yaml`` over *config*, in place."""
-    task_dir = _resolve_task_dir(device, task_name)
+    datasets_dir = _resolve_task_dir(device, task_name) / "datasets"
+    dataset_fname = datasets_dir / f"{dataset}.yaml"
+    if not dataset_fname.is_file():
+        raise ValueError(
+            f"Unknown dataset {dataset!r} for {device}/{task_name}. "
+            f"Choose from: {sorted(p.stem for p in datasets_dir.glob('*.yaml'))}"
+        )
     source_defaults = dict(config["data.study.source"])
-    config.update(load_yaml_config(task_dir / "datasets" / f"{dataset}.yaml"))
+    config.update(load_yaml_config(dataset_fname))
     # =replace= may wipe source; restore default path/infra
     for k, v in source_defaults.items():
         config["data.study.source"].setdefault(k, v)

--- a/neuralbench-repo/neuralbench/experiment_config.py
+++ b/neuralbench-repo/neuralbench/experiment_config.py
@@ -23,6 +23,7 @@ from exca import ConfDict
 from neuralbench.config_manager import get_config
 from neuralbench.registry import (
     DEBUG_STUDY_QUERIES,
+    DEFAULTS_DIR,
     _resolve_model_config_path,
     _resolve_task_dir,
     load_yaml_config,
@@ -95,6 +96,46 @@ def _download_dataset(config: ConfDict) -> None:
     study_dict = dict(config["data"]["study"]["source"])
     study_dict["path"] = Path(study_dict["path"]) / study_dict["name"]
     ns.Study(**study_dict).download()
+
+
+# ---------------------------------------------------------------------------
+# Config merging
+# ---------------------------------------------------------------------------
+
+
+def merge_task_config(
+    device: str,
+    task_name: str,
+    dataset: str | None = None,
+    base: ConfDict | None = None,
+) -> ConfDict:
+    """Layer a task config, and an optional dataset variant, over the base defaults.
+
+    *base* defaults to ``defaults/config.yaml``; callers pass their own copy of
+    it when it already carries run-level overrides (checkpoint, W&B).
+    """
+    config = (
+        ConfDict(load_yaml_config(DEFAULTS_DIR / "config.yaml"))
+        if base is None
+        else base.copy()
+    )
+    task_config_fname = _resolve_task_dir(device, task_name) / "config.yaml"
+    config.update(load_yaml_config(task_config_fname))
+    if dataset is not None:
+        _merge_dataset_config(config, device, task_name, dataset)
+    return config
+
+
+def _merge_dataset_config(
+    config: ConfDict, device: str, task_name: str, dataset: str
+) -> None:
+    """Layer a task's ``datasets/<dataset>.yaml`` over *config*, in place."""
+    task_dir = _resolve_task_dir(device, task_name)
+    source_defaults = dict(config["data.study.source"])
+    config.update(load_yaml_config(task_dir / "datasets" / f"{dataset}.yaml"))
+    # =replace= may wipe source; restore default path/infra
+    for k, v in source_defaults.items():
+        config["data.study.source"].setdefault(k, v)
 
 
 # ---------------------------------------------------------------------------
@@ -205,10 +246,7 @@ def prepare_task_configs(
     if datasets is None:
         datasets = [None]
 
-    task_dir = _resolve_task_dir(device, task_name)
-    task_config_fname = task_dir / "config.yaml"
-    task_config = load_yaml_config(task_config_fname)
-    config.update(task_config)
+    config = merge_task_config(device, task_name, base=config)
 
     configs = []
     for model_name in models:
@@ -225,12 +263,7 @@ def prepare_task_configs(
             if dataset_name is not None:
                 if not quiet:
                     LOGGER.info("~~~ USING DATASET: %s ~~~", dataset_name)
-                dataset_config_fname = task_dir / "datasets" / f"{dataset_name}.yaml"
-                dataset_config = load_yaml_config(dataset_config_fname)
-                dataset_exp_config.update(dataset_config)
-                # =replace= may wipe source; restore default path/infra
-                for k, v in config["data.study.source"].items():
-                    dataset_exp_config["data.study.source"].setdefault(k, v)
+                _merge_dataset_config(dataset_exp_config, device, task_name, dataset_name)
 
             exp_configs = _prepare_single_task_config(
                 dataset_exp_config,

--- a/neuralbench-repo/neuralbench/registry.py
+++ b/neuralbench-repo/neuralbench/registry.py
@@ -537,8 +537,14 @@ def _validate_inputs(
     task: str | list[str],
     model: str | list[str] | None,
     downstream_wrapper: str | list[str] | None,
+    *,
+    allow_all: bool = True,
 ) -> None:
-    """Raise ``ValueError`` on invalid device / task / model names."""
+    """Raise ``ValueError`` on invalid device / task / model names.
+
+    *allow_all* accepts the ``"all"`` / ``"all_multi_dataset"`` task
+    aggregates, which only callers that expand them can handle.
+    """
     if device not in ALL_DEVICES:
         raise ValueError(f"Unknown device {device!r}. Choose from: {ALL_DEVICES}")
     tasks = [task] if isinstance(task, str) else task
@@ -548,7 +554,7 @@ def _validate_inputs(
             f"No tasks ship for device {device!r} yet. "
             f"Devices with tasks: {[d for d in ALL_DEVICES if TASKS.get(d) or UNVALIDATED_TASKS.get(d)]}"
         )
-    valid_tasks = {"all", "all_multi_dataset"} | device_tasks
+    valid_tasks = device_tasks | ({"all", "all_multi_dataset"} if allow_all else set())
     for t in tasks:
         if t not in valid_tasks:
             raise ValueError(

--- a/neuralbench-repo/neuralbench/test_data.py
+++ b/neuralbench-repo/neuralbench/test_data.py
@@ -202,6 +202,16 @@ def test_get_default_dataloaders_selects_dataset_variant(
     assert type(study.steps["source"]).__name__ == "Schalk2004Bci2000"
 
 
-def test_get_default_dataloaders_rejects_unknown_task() -> None:
-    with pytest.raises(ValueError, match="Unknown task"):
-        get_default_dataloaders("eeg", "motor_imgery")
+@pytest.mark.parametrize(
+    "task,dataset",
+    [
+        ("motor_imgery", None),
+        ("all", None),  # aggregate: only the CLI expands it
+        ("motor_imagery", "schalk2004"),
+    ],
+)
+def test_get_default_dataloaders_rejects_unknown_inputs(
+    task: str, dataset: str | None
+) -> None:
+    with pytest.raises(ValueError, match="Unknown"):
+        get_default_dataloaders("eeg", task, dataset=dataset)

--- a/neuralbench-repo/neuralbench/test_data.py
+++ b/neuralbench-repo/neuralbench/test_data.py
@@ -4,23 +4,29 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""Tests for ``neuralbench.data.Data`` RNG plumbing.
+"""Tests for ``neuralbench.data``: ``Data`` RNG plumbing and the config merge
+behind ``get_default_dataloaders``.
 
-Uses the synthetic ``Test2024Eeg`` study from neuralset (3 timelines, ~12 train
-Word events) so we exercise the real ``SegmentDataset`` + ``DataLoader``
-pipeline instead of mocking it.  Each test compares the first-epoch index
-sequence from ``train_loader.sampler``, which is the ground-truth signal that
-``Data.seed`` actually controls shuffling.
+The RNG tests use the synthetic ``Test2024Eeg`` study from neuralset (3
+timelines, ~12 train Word events) so we exercise the real ``SegmentDataset`` +
+``DataLoader`` pipeline instead of mocking it.  Each test compares the
+first-epoch index sequence from ``train_loader.sampler``, which is the
+ground-truth signal that ``Data.seed`` actually controls shuffling.
 
 The ``build_data`` factory fixture (see ``conftest.py``) owns the Data
     construction config, so tests here only have to vary ``seed`` /
     ``sampler``.
+
+The ``get_default_dataloaders`` tests stub out ``Data.prepare`` only, so the
+real task YAMLs still go through ``Data`` validation without reading any data.
 """
 
 import random
+import typing as tp
 from collections.abc import Callable
 
 import numpy as np
+import pytest
 import torch
 from torch.utils.data import DataLoader
 
@@ -158,24 +164,44 @@ def test_per_split_loader_generators_have_distinct_seeds(
     )
 
 
-def test_get_default_dataloaders_merges_and_overrides(monkeypatch):
-    cfg = None
-    expected_loaders = {"train": object(), "val": object(), "test": object()}
+def test_get_default_dataloaders_merges_and_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cfg: Data | None = None
+    expected_loaders: dict[str, DataLoader] = {}
 
-    def fake_prepare(self):
+    def fake_prepare(self: Data) -> dict[str, DataLoader]:
         nonlocal cfg
         cfg = self
         return expected_loaders
 
     monkeypatch.setattr(Data, "prepare", fake_prepare)
+    overrides: dict[str, tp.Any] = {"neuro.frequency": 60.0}
     loaders = get_default_dataloaders(
         "eeg",
         "audiovisual_stimulus",
         batch_size=8,
-        **{"neuro.frequency": 60.0},
+        **overrides,
     )
     assert loaders is expected_loaders
+    assert cfg is not None
+    target: tp.Any = cfg.target
     assert cfg.trigger_event_type == "Stimulus"  # task config wins over base
-    assert cfg.target.event_field == "description"  # task =replace= target
+    assert target.event_field == "description"  # task =replace= target
     assert cfg.batch_size == 8  # base default -> kwarg override
     assert cfg.neuro.frequency == 60.0  # dotted override (base default 120.0)
+
+
+def test_get_default_dataloaders_selects_dataset_variant(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: list[Data] = []
+    monkeypatch.setattr(Data, "prepare", lambda self: captured.append(self))
+    get_default_dataloaders("eeg", "motor_imagery", dataset="schalk2004bci2000")
+    study: tp.Any = captured[0].study
+    assert type(study.steps["source"]).__name__ == "Schalk2004Bci2000"
+
+
+def test_get_default_dataloaders_rejects_unknown_task() -> None:
+    with pytest.raises(ValueError, match="Unknown task"):
+        get_default_dataloaders("eeg", "motor_imgery")


### PR DESCRIPTION
## What does this PR do?

Follow-up to #209, which added `get_default_dataloaders`.

- **Narrows the docstring.** The loaders were advertised as the ones a benchmark
  run uses, but 10 of the 24 model YAMLs override `data.neuro` — every EEG
  foundation model and all four sklearn baselines. On `eeg/motor_imagery`,
  `--model labram` moves `neuro.frequency` 120.0 -> 200.0, `notch_filter`
  [50, 60] -> [50] and `clamp` 20.0 -> None. Model configs stay out of scope
  here; the docstring now says so, and documents `**overrides` and the infra
  gotcha (extraction inherits `neuro.infra.cluster="auto"`, so the first call
  submits SLURM jobs where a cluster is available).
- **Adds `dataset`**, so multi-dataset tasks are reachable (`motor_imagery`
  ships 17 variants; only the default study was).
- **Validates `device` / `task`** via `_validate_inputs`, as `run_benchmark`
  does. A typo gave a bare `FileNotFoundError` with no list of valid tasks.
- **One home for the config merge.** `merge_task_config` and
  `_merge_dataset_config` in `experiment_config.py` own the
  base -> task -> dataset layering, including the `=replace=` source restore;
  `prepare_task_configs` and `get_default_dataloaders` both call them.

`dataset` is keyword-only: as a positional-or-keyword parameter it collides with
`**overrides`, and mypy rejects the existing `**{"neuro.frequency": 60.0}` call
style because a `dict[str, float]` could fill it. Worth deciding separately
whether `overrides` should become an explicit `dict[str, Any] | None` argument.

## Tests

- The config-merge test is annotated (which is what surfaced the mypy issue
  above) and asserts the merged study.
- New: `dataset="schalk2004bci2000"` resolves to the variant's study, and an
  unknown task raises `ValueError`.
- `prepare_task_configs` behaviour is already covered by `test_cli.py` and
  `test_registry.py`, which exercise the refactored merge path.

## Checklist

- [x] Tests added or updated
- [x] Docstrings updated for any changed public APIs (plus an `api.rst` entry,
      since the function is in `__all__`)
- [x] `pytest`, `mypy` and `ruff` pass locally

Made with [Cursor](https://cursor.com)