### PR TITLE
neuralbench: adaptation strategies for foundation models (linear/attentive probe, LoRA, fine-tuning)

### DIFF
--- a/.github/actions/setup-python-env/action.yml
+++ b/.github/actions/setup-python-env/action.yml
@@ -60,8 +60,8 @@ runs:
 
     - name: Install / sync packages
       shell: bash
-      # All editables in a single resolution pass. transformers pinned
-      # because neuralset's tests target 4.41.0 (pyproject leaves it open).
+      # All editables in a single resolution pass. transformers pinned for
+      # reproducibility (pyproject leaves it open); 4.43+ is required by peft.
       run: |
         source .venv/bin/activate
         uv pip install \
@@ -70,7 +70,7 @@ runs:
           -e neuralfetch-repo/. \
           -e neuraltrain-repo/.[lightning,dev,models,metrics] \
           -e neuralbench-repo/.[dev,wandb,models] \
-          'transformers==4.41.0'
+          'transformers==4.57.6'
 
     - name: Download spacy models (on cache miss)
       if: steps.cache-venv.outputs.cache-hit != 'true'

--- a/docs/neuralbench/full_benchmark.rst
+++ b/docs/neuralbench/full_benchmark.rst
@@ -162,6 +162,33 @@ Use ``-m`` to specify alternative models or model groups:
 **Foundation models** (6): ``bendr``, ``biot``, ``cbramod``, ``labram``,
 ``luna``, ``reve``
 
+Running with adaptation strategies
+-----------------------------------
+
+Foundation models are fine-tuned end-to-end by default. Use ``-w`` to sweep
+over other adaptation strategies instead:
+
+.. code-block:: bash
+
+   neuralbench eeg all -m all_fm -w linear_probe_flatten   # Frozen backbone, linear probe
+   neuralbench eeg all -m all_fm -w lora_r4_flatten        # Frozen backbone, LoRA adapters
+   neuralbench eeg all -m all_fm -w all                    # All 7 presets
+
+**Frozen backbone** (3): ``linear_probe_flatten``, ``linear_probe_mean``,
+``attentive_probe`` -- only the head trains. The suffix is how encoder outputs
+are pooled before the head.
+
+**LoRA** (2): ``lora_r4_flatten``, ``lora_r32_flatten`` -- frozen backbone plus
+low-rank adapters at the attention projections, at rank 4 and 32.
+
+**Full fine-tune** (2): ``finetune_mean``, ``finetune_flatten`` -- all weights
+train.
+
+Presets apply to foundation models only; task-specific models ignore ``-w``.
+Each preset is reported as a separate entry, suffixed in plots and tables (for
+example ``REVE (LP flatten)``), so a single run can compare strategies
+side by side.
+
 Running with dataset variants
 ------------------------------
 

--- a/docs/neuralbench/tutorials/04_adding_model/create_new_model.py
+++ b/docs/neuralbench/tutorials/04_adding_model/create_new_model.py
@@ -161,11 +161,12 @@ NeuralTrain, and (2) creating the NeuralBench YAML config.
 #      name: NtReve
 #      from_pretrained_name: "brain-bzh/reve-base"
 #
-#    # Downstream wrapper: freeze the backbone, flatten, linear probe
+#    # Downstream wrapper: flatten the backbone output into a linear head
 #    downstream_model_wrapper:
 #      model_output_key: null
 #      aggregation: flatten
 #      probe_config: linear
+#      lora_target_modules: [to_qkv, to_out]
 #
 # Key foundation-model fields
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -180,7 +181,8 @@ NeuralTrain, and (2) creating the NeuralBench YAML config.
 #
 # ``downstream_model_wrapper``
 #   Controls how the pretrained backbone is adapted for each task.
-#   Main options:
+#   These are the defaults; the ``-w`` adaptation presets override
+#   them per run, and are what freeze the backbone.  Main options:
 #
 #   - ``aggregation``: how to reduce the temporal/spatial dimensions
 #     of the backbone output (``flatten``, ``mean``, ``first``).
@@ -190,6 +192,11 @@ NeuralTrain, and (2) creating the NeuralBench YAML config.
 #     applied before the model.
 #   - ``channel_merger_config``: optional learned projection from
 #     variable input channels to the model's expected channels.
+#   - ``lora_target_modules``: the ``nn.Linear`` leaf modules LoRA
+#     adapters attach to, typically the attention projections (e.g.
+#     ``["to_q", "to_k", "to_v", "to_out"]``).  Required to run the
+#     model under the ``lora_*`` presets; see
+#     :doc:`/neuralbench/full_benchmark`.
 
 # %%
 # Advanced: custom optimizer and scheduler

--- a/neuralbench-repo/neuralbench/aggregator.py
+++ b/neuralbench-repo/neuralbench/aggregator.py
@@ -20,6 +20,7 @@ from tqdm import tqdm
 
 import neuralset as ns
 
+from .plots._constants import AdaptationMode
 from .plots.benchmark import plot_all_results
 from .plots.tables import print_skip_table
 
@@ -27,6 +28,23 @@ if tp.TYPE_CHECKING:
     from .main import Experiment
 
 LOGGER = logging.getLogger(__name__)
+
+
+def _infer_eval_mode(experiment: "Experiment") -> str:
+    """Classify *experiment* by adaptation strategy, as an :class:`AdaptationMode` tag."""
+    # derived rather than an Experiment field, which would change the config hash
+    wrapper = experiment.downstream_model_wrapper
+    if wrapper is None:
+        return AdaptationMode("finetune").tag
+    aggregation = "" if wrapper.aggregation is None else str(wrapper.aggregation)
+    if wrapper.lora_config is not None:
+        return AdaptationMode("lora", aggregation, wrapper.lora_config.r).tag
+    if wrapper.layers_to_unfreeze == [""]:
+        strategy = (
+            "attentive_probe" if wrapper.probe_config == "attention" else "linear_probe"
+        )
+        return AdaptationMode(strategy, aggregation).tag
+    return AdaptationMode("finetune", aggregation).tag
 
 
 def _default_output_dir() -> str:
@@ -169,6 +187,7 @@ class BenchmarkAggregator(ns.BaseModel):
         out["model_variant"] = _experiment_variant(experiment)
         out["loss"] = {"name": type(experiment.loss).__name__}
         out["seed"] = experiment.seed
+        out["eval_mode"] = _infer_eval_mode(experiment)
         return out, task, model
 
     def _collect_results(self, cached_only: bool = False) -> list[dict[str, tp.Any]]:

--- a/neuralbench-repo/neuralbench/cli.py
+++ b/neuralbench-repo/neuralbench/cli.py
@@ -32,6 +32,8 @@ from neuralbench.registry import (
     ALL_TASKS,
     ALL_UNVALIDATED_TASKS,
     DEFAULTS_DIR,
+    DEVICE_FM_MODELS,
+    FM_MODELS,
     _expand_models,
     _format_datasets_epilog,
     _resolve_datasets,
@@ -80,7 +82,9 @@ def run_benchmark(
     checkpoint : str or None
         Path to a model checkpoint to reload.
     downstream_wrapper : str or list of str or None
-        Downstream wrapper name(s) or ``"all"``.
+        Adaptation-strategy preset name(s) from
+        ``defaults/downstream_wrappers.yaml``, or ``"all"``.  Swept over
+        foundation models only.
     grid : bool
         Expand the task-specific hyperparameter grid.
     debug : bool
@@ -148,6 +152,7 @@ def run_benchmark(
         config["pretrained_weights_fname"] = checkpoint
 
     # --- downstream wrappers ---
+    overlays: list[dict[str, tp.Any]] | None = None
     if downstream_wrapper is not None:
         wrappers = (
             [downstream_wrapper]
@@ -156,8 +161,7 @@ def run_benchmark(
         )
         if wrappers == ["all"]:
             wrappers = list(ALL_DOWNSTREAM_WRAPPERS.keys())
-        wrapper_configs = [ALL_DOWNSTREAM_WRAPPERS[name] for name in wrappers]
-        grid_conf["downstream_model_wrapper"] = wrapper_configs
+        overlays = [ALL_DOWNSTREAM_WRAPPERS[name] for name in wrappers]
 
     # --- tasks ---
     tasks = _resolve_tasks(device, task)
@@ -176,22 +180,44 @@ def run_benchmark(
         # instead of launching every pipeline on every task.
         models = _expand_models(model, device=device, task_name=task_name)
         datasets = _resolve_datasets(device, task_name, dataset)
-        task_configs = prepare_task_configs(
-            config.copy(),
-            grid_conf,
-            device,
-            task_name,
-            grid,
-            debug,
-            force,
-            prepare,
-            download,
-            models,
-            datasets,
-            quiet=plot_cached,
-            retry=retry,
-        )
-        configs.extend(task_configs)
+        # adaptation needs a pretrained backbone: non-FMs get an overlay-free grid
+        model_groups: list[tuple[ConfDict, list[str | None]]]
+        if overlays is not None:
+            fm_names = set(DEVICE_FM_MODELS.get(device, FM_MODELS))
+            fm_models: list[str | None] = [m for m in models if m in fm_names]
+            other_models: list[str | None] = [m for m in models if m not in fm_names]
+            if not fm_models:
+                logger.warning(
+                    "Adaptation wrappers requested (-w) but no foundation model "
+                    "selected for task %r; running without adaptation.",
+                    task_name,
+                )
+            model_groups = []
+            if fm_models:
+                fm_grid = grid_conf.copy()
+                fm_grid["_adaptation_overlay"] = overlays
+                model_groups.append((fm_grid, fm_models))
+            if other_models:
+                model_groups.append((grid_conf, other_models))
+        else:
+            model_groups = [(grid_conf, models)]
+        for group_grid, group_models in model_groups:
+            task_configs = prepare_task_configs(
+                config.copy(),
+                group_grid,
+                device,
+                task_name,
+                grid,
+                debug,
+                force,
+                prepare,
+                download,
+                group_models,
+                datasets,
+                quiet=plot_cached,
+                retry=retry,
+            )
+            configs.extend(task_configs)
 
     if download:
         return []
@@ -291,7 +317,10 @@ def run_benchmark_cli() -> None:
         "--downstream-wrapper",
         nargs="*",
         choices=["all"] + list(ALL_DOWNSTREAM_WRAPPERS.keys()),
-        help="Override/add a model wrapper for the downstream tasks.",
+        help=(
+            "Adaptation strategy preset(s) to sweep over; applied to foundation "
+            "models only."
+        ),
     )
     parser.add_argument(
         "--download",

--- a/neuralbench-repo/neuralbench/defaults/downstream_wrappers.yaml
+++ b/neuralbench-repo/neuralbench/defaults/downstream_wrappers.yaml
@@ -3,90 +3,70 @@
 #
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
-
-# Downstream wrapper configs for evaluation of a pretrained model.
 #
-# Other strategies to implement:
-# - Attentive probe
-# - Frozen + linear probe, then finetune
-# - PEFT, LoRA, etc.
+# Downstream adaptation-strategy presets, selected via ``-w`` (e.g.
+# ``-w linear_probe_flatten lora_r4_flatten finetune_mean``).
+#
+# Each preset is a multi-key overlay merged into the assembled config;
+# ``downstream_model_wrapper`` is partial-merged, so model-specific fields such
+# as ``lora_target_modules`` are inherited from the model YAML.
 
-identity_freeze:
-  aggregation: null
-  probe_config: null
-  layers_to_unfreeze: "last"
-identity_finetune:
-  aggregation: null
-  probe_config: null
-cls_linear_finetune:
-  model_output_key: c_out
-  aggregation: first
-avg_linear_finetune:
-  model_output_key: c_out
-  aggregation: mean
-conv_linear_finetune:
-  model_output_key: z
-  aggregation: 4
-flatten_linear_freeze:
-  model_output_key: null
-  aggregation: flatten
-  layers_to_unfreeze: [""]
-cls_linear_freeze:
-  model_output_key: c_out
-  aggregation: first
-  layers_to_unfreeze: [""]
-avg_linear_freeze:
-  model_output_key: c_out
-  aggregation: mean
-  layers_to_unfreeze: [""]
-conv_linear_freeze:
-  model_output_key: z
-  aggregation: 4
-  layers_to_unfreeze: [""]
-cls_mlp_freeze:
-  model_output_key: c_out
-  aggregation: first
-  layers_to_unfreeze: [""]
-  probe_config:
-    name: Mlp
-    hidden_sizes:
-      - 512
-      - -1  # Last value will be overwritten
-avg_mlp_freeze:
-  model_output_key: c_out
-  aggregation: mean
-  layers_to_unfreeze: [""]
-  probe_config:
-    name: Mlp
-    hidden_sizes:
-      - 512
-      - -1  # Last value will be overwritten
-conv_mlp_freeze:
-  model_output_key: z
-  aggregation: 4
-  layers_to_unfreeze: [""]
-  probe_config:
-    name: Mlp
-    hidden_sizes:
-      - 512
-      - -1  # Last value will be overwritten
-avg_linear_finetune_attention:
-  model_output_key: c_out
-  aggregation: mean
-  layers_to_unfreeze:
-    - to_q
-    - to_k
-    - to_v
-    - to_out
-  strict_matching: false
-flatten_mlp_finetune:  # For CBraMod
-  model_output_key: null
-  aggregation: flatten
-  probe_config:
-    name: Mlp
-    activation_layer: elu
-    dropout: 0.1
-    hidden_sizes:
-      - 800  # 4 * 200
-      - 200
-      - -1  # Last value will be overwritten
+# --- Frozen-backbone probing (linear or attentive head) ----------------------
+# High LR / no weight decay, since few params train.  The optimizer anchor below
+# is reused by every frozen-backbone preset, LoRA included.
+linear_probe_flatten:
+  downstream_model_wrapper:
+    layers_to_unfreeze: [""]
+    aggregation: flatten
+    probe_config: linear
+  lightning_optimizer_config: &head_only_optimizer
+    optimizer:
+      lr: 5.0e-4
+      kwargs:
+        weight_decay: 0.0
+    scheduler:
+      kwargs:
+        max_lr: 5.0e-4
+linear_probe_mean:
+  downstream_model_wrapper:
+    layers_to_unfreeze: [""]
+    aggregation: mean
+    probe_config: linear
+  lightning_optimizer_config: *head_only_optimizer
+attentive_probe:
+  downstream_model_wrapper:
+    layers_to_unfreeze: [""]
+    aggregation: null
+    probe_config: attention
+  lightning_optimizer_config: *head_only_optimizer
+
+# --- LoRA: frozen backbone + low-rank adapters on attention projections -------
+# ``lora_alpha = 2 * r``; ``target_modules`` comes from each model's YAML.
+lora_r4_flatten:
+  downstream_model_wrapper:
+    layers_to_unfreeze: [""]
+    aggregation: flatten
+    probe_config: linear
+    lora_config: {r: 4, lora_alpha: 8, lora_dropout: 0.1, bias: none}
+  lightning_optimizer_config: *head_only_optimizer
+lora_r32_flatten:
+  downstream_model_wrapper:
+    layers_to_unfreeze: [""]
+    aggregation: flatten
+    probe_config: linear
+    lora_config: {r: 32, lora_alpha: 64, lora_dropout: 0.1, bias: none}
+  lightning_optimizer_config: *head_only_optimizer
+
+# --- Full fine-tune: train all weights + probe head, default optimizer -------
+finetune_mean:
+  downstream_model_wrapper:
+    layers_to_unfreeze: null
+    layers_to_freeze: null
+    aggregation: mean
+    probe_config: linear
+finetune_flatten:
+  downstream_model_wrapper:
+    layers_to_unfreeze: null
+    layers_to_freeze: null
+    aggregation: flatten
+    probe_config: linear

--- a/neuralbench-repo/neuralbench/experiment_config.py
+++ b/neuralbench-repo/neuralbench/experiment_config.py
@@ -132,7 +132,14 @@ def _expand_grid(
     configs = []
     for params in grid_product:
         updated_config = config.copy()
+        # a multi-key preset, not a config key: merge whole, not per-axis
+        overlay = params.pop("_adaptation_overlay", None)
         updated_config.update(params)
+        if overlay is not None:
+            updated_config.update(overlay)
+            # re-null: debug's short run is under OneCycleLR warmup (pct_start div-by-zero)
+            if debug:
+                updated_config["lightning_optimizer_config.scheduler"] = None
         configs.append(updated_config)
 
     return configs

--- a/neuralbench-repo/neuralbench/main.py
+++ b/neuralbench-repo/neuralbench/main.py
@@ -391,13 +391,23 @@ class Experiment(BaseExperiment):
 
             wandb.finish()
 
-    @infra.apply(
-        exclude_from_cache_uid=(
-            "wandb_config",
-            "csv_config",
-            "brain_model_name",
-        )
-    )
+    def _exclude_from_cache_uid(self) -> list[str]:
+        """Config paths that must not affect the cache key.
+
+        The LoRA fields are inert while ``lora_config`` is unset, so dropping
+        them then keeps finetune / probe runs on the cache keys they had before
+        LoRA support landed.
+        """
+        excluded = ["wandb_config", "csv_config", "brain_model_name"]
+        wrapper = self.downstream_model_wrapper
+        if wrapper is not None and wrapper.lora_config is None:
+            excluded += [
+                "downstream_model_wrapper.lora_config",
+                "downstream_model_wrapper.lora_target_modules",
+            ]
+        return excluded
+
+    @infra.apply(exclude_from_cache_uid="method:_exclude_from_cache_uid")
     def run(self) -> dict[str, tp.Any]:
         """Execute the full experiment lifecycle: setup, train, test, cleanup.
 

--- a/neuralbench-repo/neuralbench/model_factory.py
+++ b/neuralbench-repo/neuralbench/model_factory.py
@@ -296,6 +296,7 @@ def build_brain_model(
     model_summary = summary(
         brain_model,
         input_data=dummy_batch,
+        col_names=("output_size", "num_params", "trainable"),
         row_settings=("hide_recursive_layers",),
         verbose=0,
     )

--- a/neuralbench-repo/neuralbench/models/bendr.yaml
+++ b/neuralbench-repo/neuralbench/models/bendr.yaml
@@ -75,5 +75,8 @@ downstream_model_wrapper:
   # LUNA, REVE).
   aggregation: mean
   probe_config: linear
+  # nn.MultiheadAttention packs Q/K/V into in_proj_weight: only out_proj is patchable
+  lora_target_modules:
+    - out_proj
 
 # Paper config (Kostas et al. 2021): Adam lr 1e-5-5e-5 wd 0.01, cosine+10% warmup, full FT, linear head on CLS.

--- a/neuralbench-repo/neuralbench/models/biot.yaml
+++ b/neuralbench-repo/neuralbench/models/biot.yaml
@@ -66,5 +66,11 @@ downstream_model_wrapper:
   # BIOT's encoder already averages all patches internally (.mean(dim=1) in
   # _BIOTEncoder), so its output is (B, emb_dim). No further aggregation needed.
   aggregation: null
+  # encoder.transformer.layers.layers.*.0.fn.{to_q,to_k,to_v,to_out}
+  lora_target_modules:
+    - to_q
+    - to_k
+    - to_v
+    - to_out
 
 # Paper config (Yang et al. NeurIPS 2023): Adam lr 1e-3 wd 1e-5, 100ep, batch 512, mean pool + ELU+Linear head, full FT.

--- a/neuralbench-repo/neuralbench/models/cbramod.yaml
+++ b/neuralbench-repo/neuralbench/models/cbramod.yaml
@@ -25,5 +25,8 @@ downstream_model_wrapper:
   model_output_key: null
   aggregation: mean
   probe_config: linear
+  # self_attn_{s,t} are nn.MultiheadAttention: only their out_proj is patchable
+  lora_target_modules:
+    - out_proj
 
 # Paper config (Wang et al. 2025): AdamW lr 1e-4 wd 5e-2, CosineAnnealingLR, 50ep, flatten + MLP head (dropout 0.1), full FT, label smoothing 0.1.

--- a/neuralbench-repo/neuralbench/models/labram.yaml
+++ b/neuralbench-repo/neuralbench/models/labram.yaml
@@ -29,5 +29,9 @@ downstream_model_wrapper:
   model_output_key: null
   aggregation: mean
   probe_config: linear
+  # blocks.*.attn.{qkv,proj}
+  lora_target_modules:
+    - qkv
+    - proj
 
 # Paper config (Jiang et al. ICLR 2024): AdamW lr 5e-4 wd 0.05, cosine+5ep warmup, 50ep, batch 512, LLRD 0.65, mean pool, full FT, drop_path 0.1, label smoothing 0.1.

--- a/neuralbench-repo/neuralbench/models/luna.yaml
+++ b/neuralbench-repo/neuralbench/models/luna.yaml
@@ -42,5 +42,9 @@ downstream_model_wrapper:
   model_output_key: null
   aggregation: mean
   probe_config: linear
+  # blocks.*.attn.{qkv_proj,proj}; the cross-attention prediction head is excluded
+  lora_target_modules:
+    - qkv_proj
+    - proj
 
 # Paper config (Doner et al. NeurIPS 2025): AdamW lr 1e-4 wd 0.05, cosine+5ep warmup, 50ep, batch 512, LLRD 0.5, cross-attn aggregation + MLP head, full FT, drop_path 0.1, label smoothing 0.1.

--- a/neuralbench-repo/neuralbench/models/reve.yaml
+++ b/neuralbench-repo/neuralbench/models/reve.yaml
@@ -24,5 +24,9 @@ downstream_model_wrapper:
   model_output_key: null
   aggregation: mean
   probe_config: linear
+  # transformer.layers.*.0.{to_qkv,to_out}, as in the REVE paper
+  lora_target_modules:
+    - to_qkv
+    - to_out
 
 # Paper config (El Ouahidi et al. NeurIPS 2025): StableAdamW, warmup + ReduceOnPlateau, attn-pool or flatten + Linear head, 2-step (linear probe then LoRA on QKVO); most downstream hyperparams unspecified.

--- a/neuralbench-repo/neuralbench/modules.py
+++ b/neuralbench-repo/neuralbench/modules.py
@@ -7,7 +7,8 @@
 """``nn.Module`` classes and pydantic config wrappers used by neuralbench.
 
 This module groups the small custom ``nn.Module`` building blocks
-(``IndexSelect``, ``Mean``, ``ConcatGroupedMean``) together with the
+(``IndexSelect``, ``Mean``, ``ConcatGroupedMean``, ``AttentivePool``) together
+with the
 pydantic configs that build trainable adapters / probes on top of a
 pretrained model (``ChannelProjection``, ``DownstreamWrapper``) and the
 runtime wrapper they produce (``DownstreamWrapperModel``).
@@ -27,7 +28,36 @@ from neuraltrain.models.preprocessor import OnTheFlyPreprocessor
 
 from .utils import detect_batch_dim, run_probe_hook
 
+if tp.TYPE_CHECKING:
+    import peft
+
 LOGGER = logging.getLogger(__name__)
+
+
+class LoraConfig(pydantic.BaseModel):
+    """Pydantic mirror of :class:`peft.LoraConfig`, exposing only the fields we sweep.
+
+    ``target_modules`` defaults to :attr:`DownstreamWrapper.lora_target_modules`.
+    """
+
+    model_config = pydantic.ConfigDict(extra="forbid")
+    r: int = 8
+    lora_alpha: int = 16
+    lora_dropout: float = 0.0
+    bias: tp.Literal["none", "all", "lora_only"] = "none"
+    target_modules: list[str] | None = None
+
+    def build(self, target_modules: list[str]) -> "peft.LoraConfig":
+        from peft import LoraConfig as _PeftLoraConfig
+
+        return _PeftLoraConfig(
+            r=self.r,
+            lora_alpha=self.lora_alpha,
+            lora_dropout=self.lora_dropout,
+            bias=self.bias,
+            target_modules=target_modules,
+            inference_mode=False,
+        )
 
 
 class IndexSelect(nn.Module):
@@ -72,6 +102,47 @@ class ConcatGroupedMean(nn.Module):
             ],
             dim=self.dim,
         )
+
+
+def _flatten_tokens(x: torch.Tensor) -> torch.Tensor:
+    """Collapse the axes between batch and embedding into a single token axis.
+
+    ``(B, emb)`` -> ``(B, 1, emb)``; ``(B, d1, ..., dk, emb)`` -> ``(B, d1 * ... * dk, emb)``.
+    """
+    if x.ndim <= 2:
+        return x.unsqueeze(1)
+    return x.reshape(x.shape[0], -1, x.shape[-1])
+
+
+class AttentivePool(nn.Module):
+    """Pool tokens with a single learnable query via multi-head cross-attention.
+
+    The attentive-probe read-out for frozen SSL features (cf. the MAE / V-JEPA
+    attentive pooler), without the surrounding transformer MLP/LayerNorm/residual.
+    """
+
+    def __init__(self, emb_dim: int, num_heads: int = 8) -> None:
+        super().__init__()
+        # nn.MultiheadAttention requires emb_dim % num_heads == 0
+        requested_heads = num_heads
+        while emb_dim % num_heads != 0:
+            num_heads //= 2
+        if num_heads != requested_heads:
+            LOGGER.warning(
+                "AttentivePool: emb_dim=%d is not divisible by num_heads=%d, "
+                "falling back to num_heads=%d.",
+                emb_dim,
+                requested_heads,
+                num_heads,
+            )
+        self.query = nn.Parameter(torch.randn(1, 1, emb_dim) * emb_dim**-0.5)
+        self.attn = nn.MultiheadAttention(emb_dim, num_heads=num_heads, batch_first=True)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = _flatten_tokens(x)  # (B, n_tokens, emb)
+        query = self.query.expand(x.shape[0], -1, -1)
+        pooled, _ = self.attn(query, x, x, need_weights=False)  # (B, 1, emb)
+        return pooled.squeeze(1)
 
 
 class ChannelProjection(pydantic.BaseModel):
@@ -379,20 +450,22 @@ class DownstreamWrapper(pydantic.BaseModel):
         (before the first dot) must match exactly. If False, any part of the layer name
         can match the patterns. Default is True.
     aggregation : {"flatten", "mean", "first"} or int, optional
-        Method to aggregate the model output.
+        Parameter-free reduction of the model output before the probe.
         ``"flatten"`` flattens all dimensions except batch;
         ``"mean"`` averages over the temporal/sequence dimension (dim=1);
         ``"first"`` selects only the first timestep/token;
         an ``int`` splits into n groups, averages each group, then concatenates;
-        ``None`` performs no aggregation.
+        ``None`` performs no aggregation (required by ``probe_config="attention"``).
         When ``probe_layer`` is set, the captured activation is canonicalised to
         batch-first before aggregation (see ``probe_batch_dim``), so these
         semantics are identical for intermediate and final outputs.
-    probe_config : Mlp | "linear" | None, optional
-        Configuration for the probe layer added on top.
+    probe_config : Mlp | "linear" | "attention" | None, optional
+        Configuration for the probe head added on top.
         ``None`` uses identity (no additional layer), e.g. if the model already
         has a linear layer of the right output size.
         ``"linear"`` adds a single linear layer.
+        ``"attention"`` adds an ``AttentivePool`` read-out plus a linear layer;
+        it pools the raw tokens itself, so requires ``aggregation=None``.
         An ``Mlp`` instance adds a multi-layer perceptron with specified configuration.
     probe_layer : str | None, optional
         Dotted submodule name (from ``model.named_modules()``) where a forward
@@ -405,6 +478,15 @@ class DownstreamWrapper(pydantic.BaseModel):
         finding the axis that scales with the batch.  Set explicitly (e.g. ``1``
         for sequence-first ``(T, B, D)`` transformer outputs) to skip detection
         or resolve an ambiguous layout.  Only used when ``probe_layer`` is set.
+    lora_config : LoraConfig | None, optional
+        If set, PEFT LoRA adapters are injected into the wrapped model, leaving
+        only the adapters and the probe head trainable.  Requires the ``peft``
+        package.  Default is None.
+    lora_target_modules : list[str] | None, optional
+        ``nn.Linear`` leaf-module names the adapters target (e.g.
+        ``["to_q", "to_k", "to_v", "to_out"]``), usually set per foundation
+        model in its YAML.  Overridden by :attr:`lora_config.target_modules`,
+        ignored when :attr:`lora_config` is None.  Default is None.
     """
 
     model_config = pydantic.ConfigDict(extra="forbid")
@@ -415,9 +497,11 @@ class DownstreamWrapper(pydantic.BaseModel):
     layers_to_unfreeze: list[str] | tp.Literal["last"] | None = None
     strict_matching: bool = True
     aggregation: tp.Literal["flatten", "mean", "first"] | int | None = "flatten"
-    probe_config: Mlp | tp.Literal["linear"] | None = "linear"
+    probe_config: Mlp | tp.Literal["linear", "attention"] | None = "linear"
     probe_layer: str | None = None
     probe_batch_dim: int | tp.Literal["auto"] = "auto"
+    lora_config: LoraConfig | None = None
+    lora_target_modules: list[str] | None = None
 
     @property
     def n_adapter_target_channels(self) -> int | None:
@@ -447,6 +531,12 @@ class DownstreamWrapper(pydantic.BaseModel):
             raise ValueError(
                 "probe_batch_dim only applies when probe_layer is set; "
                 f"got probe_batch_dim={self.probe_batch_dim} with probe_layer=None."
+            )
+
+        if self.probe_config == "attention" and self.aggregation is not None:
+            raise ValueError(
+                "probe_config='attention' pools the raw model tokens and "
+                f"requires aggregation=None; got aggregation={self.aggregation!r}."
             )
 
     def build(
@@ -520,6 +610,25 @@ class DownstreamWrapper(pydantic.BaseModel):
             probe_batch_dim=probe_batch_dim,
         )
 
+        # must follow the freeze pattern and load_checkpoint (build_brain_model step 3)
+        if self.lora_config is not None:
+            from peft import get_peft_model
+
+            targets = self.lora_config.target_modules or self.lora_target_modules
+            if not targets:
+                raise ValueError(
+                    "LoRA requires target_modules: either set "
+                    "downstream_model_wrapper.lora_config.target_modules in the "
+                    "overlay or downstream_model_wrapper.lora_target_modules in "
+                    "the model YAML."
+                )
+            peft_cfg = self.lora_config.build(target_modules=targets)
+            # typed for HF PreTrainedModel, but only needs named_modules
+            wrapper_model.wrapped_model = get_peft_model(
+                wrapper_model.wrapped_model,  # type: ignore[arg-type]
+                peft_cfg,
+            )
+
         # Sanity check (wrapper handles preprocessing internally)
         wrapper_output = wrapper_model(**dummy_batch)
         assert wrapper_output.shape[-1] == n_outputs
@@ -582,7 +691,7 @@ class DownstreamWrapperModel(nn.Module):
         layers_to_unfreeze: list[str] | tp.Literal["last"] | None = None,
         strict_matching: bool = True,
         aggregation: tp.Literal["flatten", "mean", "first"] | int | None = "flatten",
-        probe_config: Mlp | tp.Literal["linear"] | None = None,
+        probe_config: Mlp | tp.Literal["linear", "attention"] | None = None,
         probe_layer: str | None = None,
         probe_batch_dim: int = 0,
     ):
@@ -602,7 +711,9 @@ class DownstreamWrapperModel(nn.Module):
 
         self._apply_freeze(layers_to_freeze, layers_to_unfreeze, strict_matching)
         n_inputs = self._build_aggregation(aggregation, brain_model_output_size)
-        self._build_probe(probe_config, n_inputs, wrapper_n_outputs)
+        self._build_probe(
+            probe_config, n_inputs, wrapper_n_outputs, brain_model_output_size
+        )
 
         # The hook lives on ``self.wrapped_model`` (a submodule of ``self``), so
         # a strong closure over ``self`` would form a self -> wrapped_model ->
@@ -707,9 +818,10 @@ class DownstreamWrapperModel(nn.Module):
 
     def _build_probe(
         self,
-        probe_config: Mlp | tp.Literal["linear"] | None,
+        probe_config: Mlp | tp.Literal["linear", "attention"] | None,
         n_inputs: int,
         n_outputs: int,
+        brain_model_output_size: torch.Size,
     ) -> None:
         """Build the probe (classification/regression head) on top of the aggregated representations."""
         self.probe: nn.Module
@@ -717,6 +829,12 @@ class DownstreamWrapperModel(nn.Module):
             self.probe = nn.Identity()
         elif probe_config == "linear":
             self.probe = nn.Linear(n_inputs, n_outputs)
+        elif probe_config == "attention":
+            emb_dim = brain_model_output_size[-1]
+            self.probe = nn.Sequential(
+                AttentivePool(emb_dim=emb_dim),
+                nn.Linear(emb_dim, n_outputs),
+            )
         else:
             assert not isinstance(probe_config, str)
             self.probe = probe_config.build(

--- a/neuralbench-repo/neuralbench/pl_module.py
+++ b/neuralbench-repo/neuralbench/pl_module.py
@@ -90,7 +90,9 @@ class BrainModule(pl.LightningModule):
                 model.channel_adapter is not None and model._adapter_needs_positions
             )
             inner_model = model.wrapped_model
-        forward_sig = inspect.signature(inner_model.forward)
+        # PeftModel.forward is a (*args, **kwargs) delegator: unwrap for the real signature
+        sig_model = getattr(inner_model, "get_base_model", lambda: inner_model)()
+        forward_sig = inspect.signature(sig_model.forward)
         self._input_name = list(forward_sig.parameters.keys())[0]
         self._requires_subject = (
             "subject_ids" in forward_sig.parameters or adapter_needs_positions

--- a/neuralbench-repo/neuralbench/plots/_constants.py
+++ b/neuralbench-repo/neuralbench/plots/_constants.py
@@ -21,6 +21,8 @@ counts in :data:`MODEL_PARAMS` are loaded from
 
 from __future__ import annotations
 
+import typing as tp
+
 from neuralbench.plots._models import MODELS, load_param_counts
 
 # ---------------------------------------------------------------------------
@@ -182,6 +184,71 @@ DUMMY_DISPLAY = [
 FEATURE_BASED_COLOR = "#4ea64e"
 
 MODEL_YEAR: dict[str, int] = {m.name: m.year for m in MODELS if m.year is not None}
+
+# ---------------------------------------------------------------------------
+# Adaptation ``eval_mode`` tags
+#
+# :class:`AdaptationMode` is the single home for the grammar: ``aggregator``
+# renders tags through it and the plotting modules parse them back.
+# ---------------------------------------------------------------------------
+
+_LORA_STRATEGY = "lora"
+_LORA_PREFIX = f"{_LORA_STRATEGY}_r"
+
+# by trainable-parameter budget; unknown strategies sort last
+_STRATEGY_ORDER: dict[str, int] = {
+    "linear_probe": 0,
+    "attentive_probe": 1,
+    _LORA_STRATEGY: 2,
+    "finetune": 3,
+}
+_UNKNOWN_ORDER = 4
+_PLAIN_STRATEGIES = tuple(s for s in _STRATEGY_ORDER if s != _LORA_STRATEGY)
+
+
+class AdaptationMode(tp.NamedTuple):
+    """An adaptation strategy, as tagged on a result row.
+
+    Renders as ``{strategy}[_{aggregation}]``, with LoRA using ``lora_r{rank}``
+    as its stem. The aggregation is part of the tag because presets differing
+    only by it would otherwise merge everywhere downstream.
+    """
+
+    strategy: str
+    aggregation: str = ""
+    lora_rank: int | None = None
+
+    @classmethod
+    def parse(cls, tag: str) -> AdaptationMode:
+        """Read a tag back. Unrecognised tags become a strategy of their own."""
+        if tag.startswith(_LORA_PREFIX):
+            rank, _, aggregation = tag[len(_LORA_PREFIX) :].partition("_")
+            if rank.isdigit():
+                return cls(_LORA_STRATEGY, aggregation, int(rank))
+        for strategy in _PLAIN_STRATEGIES:
+            if tag == strategy:
+                return cls(strategy)
+            if tag.startswith(f"{strategy}_"):
+                return cls(strategy, tag[len(strategy) + 1 :])
+        return cls(tag)
+
+    @property
+    def is_lora(self) -> bool:
+        return self.lora_rank is not None
+
+    @property
+    def tag(self) -> str:
+        stem = (
+            self.strategy if self.lora_rank is None else f"{_LORA_PREFIX}{self.lora_rank}"
+        )
+        return f"{stem}_{self.aggregation}" if self.aggregation else stem
+
+    @property
+    def sort_key(self) -> tuple[int, int, str]:
+        """Canonical order, by trainable-parameter budget: probes -> LoRA -> finetune."""
+        order = _STRATEGY_ORDER.get(self.strategy, _UNKNOWN_ORDER)
+        return (order, self.lora_rank or 0, self.aggregation)
+
 
 # ---------------------------------------------------------------------------
 # Task categories and ordering (used for category-grouped layouts)

--- a/neuralbench-repo/neuralbench/plots/adaptation.py
+++ b/neuralbench-repo/neuralbench/plots/adaptation.py
@@ -1,0 +1,216 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Adaptation-strategy comparison plot for the ``adaptation/`` output group.
+
+:func:`plot_adaptation_comparison` answers "for each foundation model and task,
+which adaptation strategy wins, and by how much?".  It is a no-op unless the
+frame holds at least two distinct ``eval_mode`` values.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import matplotlib.colors as mcolors
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import seaborn as sns
+
+from neuralbench.plots._constants import (
+    FEATURE_BASED_COLOR,
+    MEEG_FM_DISPLAY,
+    TASK_DISPLAY_NAMES,
+    AdaptationMode,
+)
+from neuralbench.plots._style import save_figure
+
+LOGGER = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Labels and colours for eval-mode tags (tag parsing lives in ``_constants``)
+# ---------------------------------------------------------------------------
+
+_STRATEGY_LABEL: dict[str, str] = {
+    "linear_probe": "Linear Probe",
+    "attentive_probe": "Attentive Probe",
+    "finetune": "Full FT",
+}
+
+
+def eval_mode_label(tag: str) -> str:
+    """Human-readable label for an ``eval_mode`` tag (``"lora_r8"`` -> ``"LoRA r8"``)."""
+    mode = AdaptationMode.parse(tag)
+    if mode.is_lora:
+        label = f"LoRA r{mode.lora_rank}"
+    elif mode.strategy in _STRATEGY_LABEL:
+        label = _STRATEGY_LABEL[mode.strategy]
+    else:
+        return tag
+    return f"{label} ({mode.aggregation})" if mode.aggregation else label
+
+
+def order_modes(modes: list[str]) -> list[str]:
+    """Order eval-mode tags LP -> LoRA(ascending rank) -> FT."""
+    return sorted(set(modes), key=lambda m: AdaptationMode.parse(m).sort_key)
+
+
+def mode_palette(modes: list[str]) -> dict[str, str]:
+    """Sequential hex colour per mode following the ordered (param-budget) progression."""
+    ordered = order_modes(modes)
+    n = max(len(ordered), 1)
+    cmap = plt.get_cmap("viridis")
+    positions = np.linspace(0.12, 0.88, n)
+    return {m: mcolors.to_hex(cmap(pos)) for m, pos in zip(ordered, positions)}
+
+
+_BASELINE_COLORS: dict[str, str] = {
+    "Chance": "#888888",
+    "Handcrafted": FEATURE_BASED_COLOR,
+}
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def plot_adaptation_comparison(
+    df: pd.DataFrame,
+    output_dir: Path,
+) -> Path | None:
+    """Write ``adaptation_per_task_bars.{png,pdf}`` to ``output_dir``.
+
+    Parameters
+    ----------
+    df
+        Output of :func:`neuralbench.plots.tables.build_results_df`.  Must
+        contain ``eval_mode``, ``model_name``, ``task_name``,
+        ``metric_name`` and ``metric_value`` columns.
+    output_dir
+        Destination directory (created if needed).
+
+    Returns
+    -------
+    Path or None
+        Path to the saved PNG, or ``None`` when there is nothing to plot (no
+        foundation-model rows, or fewer than two of their ``eval_mode`` values).
+    """
+    if "eval_mode" not in df.columns:
+        LOGGER.info("plot_adaptation_comparison: no 'eval_mode' column -- skipping.")
+        return None
+
+    # strip any " (LoRA r8)" suffix build_results_df added, to group by model
+    work = df.copy()
+    work["display_name"] = (
+        work["model_name"].astype(str).str.split(" (", n=1, regex=False).str[0]
+    )
+
+    fm_names = set(MEEG_FM_DISPLAY)
+    fm_work = work[work["display_name"].isin(fm_names)].copy()
+    if fm_work.empty:
+        LOGGER.info("plot_adaptation_comparison: no foundation-model rows -- skipping.")
+        return None
+
+    modes_present = order_modes(fm_work["eval_mode"].dropna().unique().tolist())
+    if len(modes_present) < 2:
+        LOGGER.info(
+            "plot_adaptation_comparison: only %d FM eval_mode(s) present -- skipping.",
+            len(modes_present),
+        )
+        return None
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    palette = mode_palette(modes_present)
+    out_path = _plot_per_task_bars(fm_work, work, modes_present, palette, output_dir)
+    LOGGER.info("Wrote adaptation comparison to %s", out_path)
+    return out_path
+
+
+# ---------------------------------------------------------------------------
+# Per-task grouped bars (mean +/- SEM, house style)
+# ---------------------------------------------------------------------------
+
+
+def _plot_per_task_bars(
+    fm_df: pd.DataFrame,
+    all_df: pd.DataFrame,
+    modes_present: list[str],
+    palette: dict[str, str],
+    output_dir: Path,
+) -> Path | None:
+    """One subplot per task; per-FM clusters with one bar per strategy.
+
+    Bars are mean +/- SEM across seeds; available baselines are dashed h-lines.
+    """
+    tasks = sorted(fm_df["task_name"].unique())
+    if not tasks:
+        return None
+
+    n_tasks = len(tasks)
+    n_cols = min(3, n_tasks)
+    n_rows = int(np.ceil(n_tasks / n_cols))
+    fig, axes = plt.subplots(
+        n_rows,
+        n_cols,
+        figsize=(6.0 * n_cols, 4.2 * n_rows),
+        squeeze=False,
+    )
+
+    fm_order = [
+        name for name in MEEG_FM_DISPLAY if name in fm_df["display_name"].unique()
+    ]
+    mode_colors = [palette[m] for m in modes_present]
+    mode_labels = [eval_mode_label(m) for m in modes_present]
+
+    for ax, task in zip(axes.flat, tasks):
+        task_fm = fm_df[fm_df["task_name"] == task]
+        sns.barplot(
+            data=task_fm,
+            x="display_name",
+            y="metric_value",
+            hue="eval_mode",
+            order=fm_order,
+            hue_order=modes_present,
+            palette=mode_colors,
+            errorbar="se",
+            err_kws={"linewidth": 1.0},
+            ax=ax,
+        )
+        if ax.get_legend() is not None:
+            for txt, label in zip(ax.get_legend().get_texts(), mode_labels):
+                txt.set_text(label)
+            ax.get_legend().set_title("Strategy")
+            ax.get_legend().set_visible(ax is axes.flat[0])
+
+        task_metric = str(task_fm["metric_name"].iloc[0])
+        ax.set_xlabel("")
+        ax.set_ylabel(task_metric)
+        ax.set_title(TASK_DISPLAY_NAMES.get(task, task))
+        ax.tick_params(axis="x", rotation=30)
+
+        task_all = all_df[all_df["task_name"] == task]
+        for baseline, color in _BASELINE_COLORS.items():
+            base_rows = task_all[task_all["display_name"] == baseline]
+            if base_rows.empty:
+                continue
+            value = float(base_rows["metric_value"].mean())
+            ax.axhline(
+                value,
+                color=color,
+                linestyle="--",
+                linewidth=1.0,
+                label=f"{baseline} ({value:.1f})",
+            )
+
+    for ax in axes.flat[n_tasks:]:
+        ax.set_visible(False)
+
+    fig.suptitle("Per-task adaptation comparison (mean +/- SEM)", fontsize=14, y=1.02)
+    fig.tight_layout()
+    return save_figure(fig, output_dir, "adaptation_per_task_bars")

--- a/neuralbench-repo/neuralbench/plots/adaptation.py
+++ b/neuralbench-repo/neuralbench/plots/adaptation.py
@@ -29,6 +29,7 @@ from neuralbench.plots._constants import (
     AdaptationMode,
 )
 from neuralbench.plots._style import save_figure
+from neuralbench.plots.tables import eval_mode_suffix
 
 LOGGER = logging.getLogger(__name__)
 
@@ -90,8 +91,8 @@ def plot_adaptation_comparison(
     ----------
     df
         Output of :func:`neuralbench.plots.tables.build_results_df`.  Must
-        contain ``eval_mode``, ``model_name``, ``task_name``,
-        ``metric_name`` and ``metric_value`` columns.
+        contain ``eval_mode``, ``model_name``, ``base_model_name``,
+        ``task_name``, ``metric_name`` and ``metric_value`` columns.
     output_dir
         Destination directory (created if needed).
 
@@ -105,14 +106,16 @@ def plot_adaptation_comparison(
         LOGGER.info("plot_adaptation_comparison: no 'eval_mode' column -- skipping.")
         return None
 
-    # strip any " (LoRA r8)" suffix build_results_df added, to group by model
+    # drop the exact strategy suffix build_results_df added, keeping any
+    # ``[variant]`` bracket so distinct configs stay distinct clusters
     work = df.copy()
-    work["display_name"] = (
-        work["model_name"].astype(str).str.split(" (", n=1, regex=False).str[0]
-    )
+    work["display_name"] = [
+        name.replace(eval_mode_suffix(mode), "", 1)
+        for name, mode in zip(work["model_name"].astype(str), work["eval_mode"])
+    ]
 
     fm_names = set(MEEG_FM_DISPLAY)
-    fm_work = work[work["display_name"].isin(fm_names)].copy()
+    fm_work = work[work["base_model_name"].isin(fm_names)].copy()
     if fm_work.empty:
         LOGGER.info("plot_adaptation_comparison: no foundation-model rows -- skipping.")
         return None
@@ -162,11 +165,12 @@ def _plot_per_task_bars(
         squeeze=False,
     )
 
-    fm_order = [
-        name for name in MEEG_FM_DISPLAY if name in fm_df["display_name"].unique()
-    ]
+    # cluster order follows MEEG_FM_DISPLAY, with a model's variants adjacent
+    base_of = dict(zip(fm_df["display_name"], fm_df["base_model_name"]))
+    fm_rank = {name: i for i, name in enumerate(MEEG_FM_DISPLAY)}
+    fm_order = sorted(base_of, key=lambda name: (fm_rank[base_of[name]], name))
     mode_colors = [palette[m] for m in modes_present]
-    mode_labels = [eval_mode_label(m) for m in modes_present]
+    mode_set = set(modes_present)
 
     for ax, task in zip(axes.flat, tasks):
         task_fm = fm_df[fm_df["task_name"] == task]
@@ -182,12 +186,6 @@ def _plot_per_task_bars(
             err_kws={"linewidth": 1.0},
             ax=ax,
         )
-        if ax.get_legend() is not None:
-            for txt, label in zip(ax.get_legend().get_texts(), mode_labels):
-                txt.set_text(label)
-            ax.get_legend().set_title("Strategy")
-            ax.get_legend().set_visible(ax is axes.flat[0])
-
         task_metric = str(task_fm["metric_name"].iloc[0])
         ax.set_xlabel("")
         ax.set_ylabel(task_metric)
@@ -206,6 +204,17 @@ def _plot_per_task_bars(
                 linestyle="--",
                 linewidth=1.0,
                 label=f"{baseline} ({value:.1f})",
+            )
+
+        # rebuilt after the baselines so their lines get an entry too
+        if ax.get_legend() is not None:
+            ax.get_legend().remove()
+        if ax is axes.flat[0]:
+            handles, labels = ax.get_legend_handles_labels()
+            ax.legend(
+                handles,
+                [eval_mode_label(x) if x in mode_set else x for x in labels],
+                title="Strategy",
             )
 
     for ax in axes.flat[n_tasks:]:

--- a/neuralbench-repo/neuralbench/plots/benchmark.py
+++ b/neuralbench-repo/neuralbench/plots/benchmark.py
@@ -151,7 +151,7 @@ def _load_optional_scaling() -> tuple[
 
 
 def _run_steps(steps: list[_Step]) -> None:
-    """Execute *steps* in order, short-circuiting gracefully on ``None``."""
+    """Execute *steps* in order, under a shared progress bar."""
     for step in tqdm(steps, desc="Generating plots"):
         step.fn()
 

--- a/neuralbench-repo/neuralbench/plots/benchmark.py
+++ b/neuralbench-repo/neuralbench/plots/benchmark.py
@@ -24,6 +24,7 @@ import seaborn as sns
 from tqdm import tqdm
 
 from neuralbench.plots._filters import filter_core_dataset
+from neuralbench.plots.adaptation import plot_adaptation_comparison
 from neuralbench.plots.bar_charts import (  # noqa: F401  (re-exports)
     LETTER_STYLE,
     _FullGridStyle,
@@ -39,21 +40,28 @@ from neuralbench.plots.ranking import (  # noqa: F401  (re-exports)
 )
 from neuralbench.plots.tables import (
     build_results_df,
+    filter_results_for_eval_mode,
+    foundation_eval_modes,
     make_full_table,
     make_rank_table,
     make_results_table,
 )
 from neuralbench.plots.variability import plot_full_variability_panel
 
-OUTPUT_SUBFOLDERS: tuple[str, str, str] = ("core", "full", "other")
-"""Three output groups written by :func:`plot_all_results`.
+OUTPUT_SUBFOLDERS: tuple[str, str, str, str] = ("core", "full", "other", "adaptation")
+"""Four output groups written by :func:`plot_all_results`.
 
-* ``core``  -- single-dataset (core-study) plots and tables for the
+* ``core``       -- single-dataset (core-study) plots and tables for the
   NeuralBench-Core variant (one dataset per task).
-* ``full``  -- per-dataset breakdowns and variability analyses for the
+* ``full``       -- per-dataset breakdowns and variability analyses for the
   NeuralBench-Full variant (all datasets per task).
-* ``other`` -- everything else (data scaling, computational stats,
+* ``other``      -- everything else (data scaling, computational stats,
   LaTeX tables produced by external scripts).
+* ``adaptation`` -- cross-strategy foundation-model views (per-task comparison
+  + global rank boxplot), populated only with multiple FM ``eval_mode`` values.
+
+With several strategies present, ``core`` and ``full`` are emitted once per
+strategy into ``core/<eval_mode>/`` and ``full/<eval_mode>/``.
 """
 
 
@@ -67,25 +75,22 @@ class _Step:
     """
 
     label: str
-    group: tp.Literal["core", "full", "other"]
+    group: tp.Literal["core", "full", "other", "adaptation"]
     fn: tp.Callable[[], tp.Any]
 
 
-def _build_steps(
-    df,
+def _core_full_steps(
     core_df,
     full_df,
     core_dir: Path,
     full_dir: Path,
-    other_dir: Path,
-    optional_scaling: tuple[
-        tp.Callable[..., tp.Any] | None, tp.Callable[..., tp.Any] | None
-    ],
 ) -> list[_Step]:
-    """Assemble the full ordered registry of plotting / table steps."""
-    plot_data_scaling, make_data_scaling_table = optional_scaling
+    """Core + full artefacts for one result frame (a single adaptation strategy).
 
-    steps: list[_Step] = [
+    Cross-strategy artefacts and data-scaling extras are emitted once by
+    :func:`plot_all_results` instead.
+    """
+    return [
         # ---------------- NeuralBench-Core outputs ----------------
         _Step("core_bar_chart", "core", lambda: plot_bar_chart(core_df, core_dir)),
         _Step(
@@ -130,21 +135,6 @@ def _build_steps(
         ),
     ]
 
-    if plot_data_scaling is not None:
-        steps.append(
-            _Step("data_scaling", "other", lambda: plot_data_scaling(df, other_dir))
-        )
-    if make_data_scaling_table is not None:
-        steps.append(
-            _Step(
-                "data_scaling_table",
-                "other",
-                lambda: make_data_scaling_table(df, other_dir),
-            )
-        )
-
-    return steps
-
 
 def _load_optional_scaling() -> tuple[
     tp.Callable[..., tp.Any] | None, tp.Callable[..., tp.Any] | None
@@ -160,6 +150,12 @@ def _load_optional_scaling() -> tuple[
     return plot_data_scaling, make_data_scaling_table
 
 
+def _run_steps(steps: list[_Step]) -> None:
+    """Execute *steps* in order, short-circuiting gracefully on ``None``."""
+    for step in tqdm(steps, desc="Generating plots"):
+        step.fn()
+
+
 def plot_all_results(
     results: list[dict[str, tp.Any]],
     loss_to_metric_mapping: dict[str, str],
@@ -167,9 +163,8 @@ def plot_all_results(
 ) -> None:
     """Build a results DataFrame and produce all plots and tables.
 
-    Artefacts are written into three subfolders of *output_dir*:
-    ``core/``, ``full/``, and ``other/``.  See
-    :data:`OUTPUT_SUBFOLDERS`.
+    Artefacts are written into subfolders of *output_dir*; see
+    :data:`OUTPUT_SUBFOLDERS` for the layout.
     """
     # Use matplotlib's default font (``font.family = ["sans-serif"]`` ->
     # DejaVu Sans on most systems) so every text element -- including
@@ -184,28 +179,46 @@ def plot_all_results(
         }
     )
 
-    df = build_results_df(results, loss_to_metric_mapping)
+    full_df = build_results_df(results, loss_to_metric_mapping)
     out_dir = Path(output_dir)
     core_dir = out_dir / "core"
     full_dir = out_dir / "full"
     other_dir = out_dir / "other"
-    for d in (core_dir, full_dir, other_dir):
+    adaptation_dir = out_dir / "adaptation"
+    for d in (core_dir, full_dir, other_dir, adaptation_dir):
         d.mkdir(parents=True, exist_ok=True)
 
-    full_df = df
     core_df = filter_core_dataset(full_df)
+    fm_modes = foundation_eval_modes(results)
 
-    steps = _build_steps(
-        df,
-        core_df,
-        full_df,
-        core_dir,
-        full_dir,
-        other_dir,
-        optional_scaling=_load_optional_scaling(),
-    )
+    if len(fm_modes) < 2:
+        _run_steps(_core_full_steps(core_df, full_df, core_dir, full_dir))
+    else:
+        # one unsuffixed set per strategy, each keeping every baseline / classic
+        steps: list[_Step] = []
+        for mode in fm_modes:
+            sub_full = build_results_df(
+                filter_results_for_eval_mode(results, mode),
+                loss_to_metric_mapping,
+                suffix_eval_mode=False,
+            )
+            sub_core = filter_core_dataset(sub_full)
+            core_m = core_dir / mode
+            full_m = full_dir / mode
+            core_m.mkdir(parents=True, exist_ok=True)
+            full_m.mkdir(parents=True, exist_ok=True)
+            steps += _core_full_steps(sub_core, sub_full, core_m, full_m)
+        _run_steps(steps)
+        # every model x strategy together, on the suffixed names
+        plot_core_rank_boxplot(core_df, adaptation_dir, stem="adaptation_rank_boxplot")
 
-    for step in tqdm(steps, desc="Generating plots"):
-        step.fn()
+    plot_adaptation_comparison(core_df, adaptation_dir)
+
+    # brainai-only extras, emitted once
+    plot_data_scaling, make_data_scaling_table = _load_optional_scaling()
+    if plot_data_scaling is not None:
+        plot_data_scaling(full_df, other_dir)
+    if make_data_scaling_table is not None:
+        make_data_scaling_table(full_df, other_dir)
 
     print(f"\nOutputs saved under {out_dir.resolve()} in subfolders {OUTPUT_SUBFOLDERS}")

--- a/neuralbench-repo/neuralbench/plots/rank_chart.py
+++ b/neuralbench-repo/neuralbench/plots/rank_chart.py
@@ -17,6 +17,7 @@ import seaborn as sns
 from neuralbench.plots._style import (
     add_watermark,
     apply_two_tone_labels,
+    base_name,
     bold_legend_titles,
     build_color_dict,
     build_grouped_legend_stacked,
@@ -120,6 +121,7 @@ def plot_core_rank_boxplot(
     output_dir: Path,
     *,
     watermark: str | None = None,
+    stem: str = "core_rank_boxplot",
 ) -> Path:
     """Box chart of per-task normalized ranks, sorted by mean, colored by group.
 
@@ -141,14 +143,19 @@ def plot_core_rank_boxplot(
 
     display_models = long_df["model_name"].unique().tolist()
     color_dict = build_color_dict(display_models)
-    palette = {m: color_dict.get(m, "#888888") for m in model_order}
+    # fallback so suffixed variants ("REVE (LoRA r32)") keep their group colour
+    base_color = build_color_dict(sorted({base_name(m) for m in display_models}))
+    palette = {
+        m: color_dict.get(m) or base_color.get(base_name(m), "#888888")
+        for m in model_order
+    }
 
-    # Sized for a portrait US-letter document with ~1" side margins:
-    # full usable width (~6.5") and at most ~33% of the 11" page height.
+    # Sized for a portrait US-letter document with ~1" side margins: full usable
+    # width (~6.5") and ~33% of the 11" page height at the usual 10-15 models.
     # The legend sits to the right of the axes and stacks the three
     # model groups in a single column.
     fig_width = 6.5
-    fig_height = 3.5
+    fig_height = max(3.5, 0.22 * n_models)
     with sns.axes_style("white"):
         fig, ax = plt.subplots(figsize=(fig_width, fig_height))
 
@@ -180,4 +187,4 @@ def plot_core_rank_boxplot(
     if watermark:
         add_watermark(fig, watermark)
 
-    return save_figure(fig, output_dir, "core_rank_boxplot")
+    return save_figure(fig, output_dir, stem)

--- a/neuralbench-repo/neuralbench/plots/tables.py
+++ b/neuralbench-repo/neuralbench/plots/tables.py
@@ -13,7 +13,11 @@ from pathlib import Path
 
 import pandas as pd
 
-from neuralbench.plots._constants import MODEL_DISPLAY_NAMES
+from neuralbench.plots._constants import (
+    FM_DISPLAY,
+    MODEL_DISPLAY_NAMES,
+    AdaptationMode,
+)
 from neuralbench.plots._filters import multi_dataset_tasks
 from neuralbench.plots.ranking import compute_task_ranks
 from neuralbench.registry import FEATURE_BASED_BY_TASK, SKLEARN_BASELINE_MODELS
@@ -21,6 +25,9 @@ from neuralbench.registry import FEATURE_BASED_BY_TASK, SKLEARN_BASELINE_MODELS
 # Synthetic ``brain_model_name`` assigned to the task-appropriate sklearn row
 # after collapsing; resolves to ``"Handcrafted"`` via ``MODEL_DISPLAY_NAMES``.
 _FEATURE_BASED_LABEL = "feature_based"
+
+# the only models run with more than one adaptation strategy
+_FM_DISPLAY_SET: frozenset[str] = frozenset(FM_DISPLAY)
 
 # ---------------------------------------------------------------------------
 # Result aggregation
@@ -122,16 +129,85 @@ def _check_no_collisions(df: pd.DataFrame) -> None:
     )
 
 
+_STRATEGY_ABBREV: dict[str, str] = {
+    "finetune": "FT",
+    "linear_probe": "LP",
+    "attentive_probe": "AP",
+}
+
+
+def eval_mode_suffix(eval_mode: str) -> str:
+    """Display-name suffix for an ``eval_mode`` tag (``"lora_r4"`` -> ``" (LoRA r4)"``).
+
+    Unknown tags get no suffix.
+    """
+    mode = AdaptationMode.parse(eval_mode)
+    if mode.is_lora:
+        abbrev = f"LoRA r{mode.lora_rank}"
+    elif mode.strategy in _STRATEGY_ABBREV:
+        abbrev = _STRATEGY_ABBREV[mode.strategy]
+    else:
+        return ""
+    return f" ({abbrev} {mode.aggregation})" if mode.aggregation else f" ({abbrev})"
+
+
+def _result_is_foundation(row: dict[str, tp.Any]) -> bool:
+    """True when *row* belongs to a foundation model (by display name)."""
+    name = row.get("brain_model_name")
+    if not isinstance(name, str):
+        return False
+    return MODEL_DISPLAY_NAMES.get(name, name) in _FM_DISPLAY_SET
+
+
+def foundation_eval_modes(results: list[dict[str, tp.Any]]) -> list[str]:
+    """Distinct adaptation strategies among FM results, in canonical order."""
+    modes = {
+        str(row.get("eval_mode") or "finetune")
+        for row in results
+        if _result_is_foundation(row)
+    }
+    return sorted(modes, key=lambda m: AdaptationMode.parse(m).sort_key)
+
+
+def filter_results_for_eval_mode(
+    results: list[dict[str, tp.Any]], eval_mode: str
+) -> list[dict[str, tp.Any]]:
+    """Keep FM rows at *eval_mode* plus every non-FM row, as a shared reference."""
+    return [
+        row
+        for row in results
+        if not _result_is_foundation(row)
+        or str(row.get("eval_mode") or "finetune") == eval_mode
+    ]
+
+
 def build_results_df(
     results: list[dict[str, tp.Any]],
     loss_to_metric_mapping: dict[str, str],
+    *,
+    suffix_eval_mode: bool = True,
 ) -> pd.DataFrame:
-    """Transform raw experiment dicts into a plot-ready DataFrame."""
+    """Transform raw experiment dicts into a plot-ready DataFrame.
+
+    With ``suffix_eval_mode`` and several strategies present, foundation-model
+    names carry their strategy (``"REVE (LoRA r32)"``) so each stays a distinct
+    entry; pass ``False`` for frames already holding a single strategy.
+    """
     df = pd.DataFrame(results)
     df = _collapse_feature_based_baselines(df)
     df["model_name"] = df["brain_model_name"].map(
         lambda name: MODEL_DISPLAY_NAMES.get(name, name)
     )
+    # cached results predating eval_mode are all finetunes
+    if "eval_mode" not in df.columns:
+        df["eval_mode"] = "finetune"
+    else:
+        df["eval_mode"] = df["eval_mode"].fillna("finetune")
+    if suffix_eval_mode and df["eval_mode"].nunique() > 1:
+        is_fm = df["model_name"].isin(_FM_DISPLAY_SET)
+        df.loc[is_fm, "model_name"] = df.loc[is_fm, "model_name"] + df.loc[
+            is_fm, "eval_mode"
+        ].map(eval_mode_suffix).fillna("")
     df = _disambiguate_model_variants(df)
     df["loss_name"] = df.loss.apply(pd.Series).name
     df["metric_name"] = df.loss_name.map(loss_to_metric_mapping)

--- a/neuralbench-repo/neuralbench/plots/tables.py
+++ b/neuralbench-repo/neuralbench/plots/tables.py
@@ -189,22 +189,26 @@ def build_results_df(
 ) -> pd.DataFrame:
     """Transform raw experiment dicts into a plot-ready DataFrame.
 
-    With ``suffix_eval_mode`` and several strategies present, foundation-model
+    With ``suffix_eval_mode`` and several FM strategies present, foundation-model
     names carry their strategy (``"REVE (LoRA r32)"``) so each stays a distinct
     entry; pass ``False`` for frames already holding a single strategy.
+    ``base_model_name`` always holds the unsuffixed display name.
     """
     df = pd.DataFrame(results)
     df = _collapse_feature_based_baselines(df)
     df["model_name"] = df["brain_model_name"].map(
         lambda name: MODEL_DISPLAY_NAMES.get(name, name)
     )
+    # the plain display name, kept so consumers need not parse it back out
+    df["base_model_name"] = df["model_name"]
     # cached results predating eval_mode are all finetunes
     if "eval_mode" not in df.columns:
         df["eval_mode"] = "finetune"
     else:
         df["eval_mode"] = df["eval_mode"].fillna("finetune")
-    if suffix_eval_mode and df["eval_mode"].nunique() > 1:
-        is_fm = df["model_name"].isin(_FM_DISPLAY_SET)
+    is_fm = df["base_model_name"].isin(_FM_DISPLAY_SET)
+    # only FMs are swept over strategies, so only their tags decide suffixing
+    if suffix_eval_mode and df.loc[is_fm, "eval_mode"].nunique() > 1:
         df.loc[is_fm, "model_name"] = df.loc[is_fm, "model_name"] + df.loc[
             is_fm, "eval_mode"
         ].map(eval_mode_suffix).fillna("")

--- a/neuralbench-repo/neuralbench/plots/test_constants.py
+++ b/neuralbench-repo/neuralbench/plots/test_constants.py
@@ -1,0 +1,29 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests for :mod:`neuralbench.plots._constants`."""
+
+from __future__ import annotations
+
+import pytest
+
+from neuralbench.plots._constants import AdaptationMode
+
+
+@pytest.mark.parametrize(
+    "tag",
+    [
+        "finetune",
+        "finetune_mean",
+        "linear_probe_flatten",
+        "attentive_probe",
+        "lora_r4",
+        "lora_r32_mean",
+        "some_future_strategy",
+    ],
+)
+def test_adaptation_mode_round_trips(tag: str) -> None:
+    assert AdaptationMode.parse(tag).tag == tag

--- a/neuralbench-repo/neuralbench/plots/test_tables.py
+++ b/neuralbench-repo/neuralbench/plots/test_tables.py
@@ -114,6 +114,36 @@ def test_build_results_df_multi_eval_mode_suffixes_model_name():
         "REVE (LoRA r4 flatten)",
     }
     assert set(df["model_name"]) == expected
+    assert df["base_model_name"].unique().tolist() == ["REVE"]
+
+
+def test_build_results_df_non_fm_eval_mode_does_not_suffix_foundation_models():
+    results = [
+        _row(
+            loss_name="MultiLoss",
+            brain_model_name="NtReve",
+            eval_mode="finetune_mean",
+            seed=0,
+            **{"test/bmae": 1.0},
+        ),
+        _row(
+            loss_name="MultiLoss",
+            brain_model_name="NtReve",
+            eval_mode="finetune_mean",
+            seed=1,
+            **{"test/bmae": 2.0},
+        ),
+        _row(
+            loss_name="MultiLoss",
+            brain_model_name="EEGNet",
+            eval_mode="linear_probe_mean",
+            **{"test/bmae": 3.0},
+        ),
+    ]
+    df = build_results_df(results, _DEFAULT_MAPPING)
+    assert set(df["model_name"]) == {"REVE", "EEGNet"}, (
+        "only foundation-model strategies should decide suffixing"
+    )
 
 
 def test_build_results_df_defaults_missing_eval_mode_to_finetune():

--- a/neuralbench-repo/neuralbench/plots/test_tables.py
+++ b/neuralbench-repo/neuralbench/plots/test_tables.py
@@ -11,21 +11,40 @@ from __future__ import annotations
 import pytest
 
 from neuralbench.aggregator import BenchmarkAggregator
-from neuralbench.plots.tables import build_results_df
+from neuralbench.plots.tables import (
+    build_results_df,
+    filter_results_for_eval_mode,
+    foundation_eval_modes,
+)
 
 _DEFAULT_MAPPING: dict[str, str] = BenchmarkAggregator.model_fields[
     "loss_to_metric_mapping"
 ].default
 
 
-def _row(*, loss_name: str, **metric_values: float) -> dict:
-    """Build one synthetic result row with the columns ``build_results_df`` reads."""
-    return {
+def _row(
+    *,
+    loss_name: str,
+    brain_model_name: str = "EEGNet",
+    eval_mode: str | None = None,
+    seed: int = 0,
+    **metric_values: float,
+) -> dict:
+    """Build one synthetic result row with the columns ``build_results_df`` reads.
+
+    ``seed`` distinguishes replicate rows so they aren't flagged as colliding
+    configs by ``build_results_df``'s collision guard.
+    """
+    row: dict = {
         "loss": {"name": loss_name},
-        "brain_model_name": "EEGNet",
+        "brain_model_name": brain_model_name,
         "task_name": "sleep_onset",
+        "seed": seed,
         **metric_values,
     }
+    if eval_mode is not None:
+        row["eval_mode"] = eval_mode
+    return row
 
 
 def test_build_results_df_resolves_multi_loss_to_bmae():
@@ -41,3 +60,164 @@ def test_build_results_df_raises_for_unmapped_loss():
     results = [_row(loss_name="NewlyAddedLoss", **{"test/something": 1.0})]
     with pytest.raises(KeyError, match="NewlyAddedLoss"):
         build_results_df(results, _DEFAULT_MAPPING)
+
+
+def test_build_results_df_single_eval_mode_keeps_bare_model_name():
+    results = [
+        _row(loss_name="MultiLoss", eval_mode="finetune", seed=0, **{"test/bmae": 1.0}),
+        _row(loss_name="MultiLoss", eval_mode="finetune", seed=1, **{"test/bmae": 2.0}),
+    ]
+    df = build_results_df(results, _DEFAULT_MAPPING)
+    assert df["model_name"].unique().tolist() == ["EEGNet"]
+
+
+def test_build_results_df_multi_eval_mode_suffixes_model_name():
+    results = [
+        _row(
+            loss_name="MultiLoss",
+            brain_model_name="NtReve",
+            eval_mode="finetune_mean",
+            **{"test/bmae": 1.0},
+        ),
+        _row(
+            loss_name="MultiLoss",
+            brain_model_name="NtReve",
+            eval_mode="linear_probe_flatten",
+            **{"test/bmae": 2.0},
+        ),
+        _row(
+            loss_name="MultiLoss",
+            brain_model_name="NtReve",
+            eval_mode="linear_probe_mean",
+            **{"test/bmae": 3.0},
+        ),
+        _row(
+            loss_name="MultiLoss",
+            brain_model_name="NtReve",
+            eval_mode="lora_r4_flatten",
+            **{"test/bmae": 4.0},
+        ),
+        _row(
+            loss_name="MultiLoss",
+            brain_model_name="NtReve",
+            eval_mode="attentive_probe",
+            **{"test/bmae": 5.0},
+        ),
+    ]
+    df = build_results_df(results, _DEFAULT_MAPPING)
+    # REVE is the display name for NtReve
+    expected = {
+        "REVE (FT mean)",
+        "REVE (LP flatten)",
+        "REVE (LP mean)",
+        "REVE (AP)",
+        "REVE (LoRA r4 flatten)",
+    }
+    assert set(df["model_name"]) == expected
+
+
+def test_build_results_df_defaults_missing_eval_mode_to_finetune():
+    results = [
+        _row(loss_name="MultiLoss", brain_model_name="NtReve", **{"test/bmae": 1.0}),
+        _row(
+            loss_name="MultiLoss",
+            brain_model_name="NtReve",
+            eval_mode="linear_probe",
+            **{"test/bmae": 2.0},
+        ),
+    ]
+    df = build_results_df(results, _DEFAULT_MAPPING)
+    assert set(df["model_name"]) == {"REVE (FT)", "REVE (LP)"}, (
+        "a legacy row must be rebranded finetune, not suffixed '(nan)'"
+    )
+
+
+def test_build_results_df_suffixes_only_foundation_models():
+    results = [
+        _row(
+            loss_name="MultiLoss",
+            brain_model_name="NtReve",
+            eval_mode="finetune",
+            **{"test/bmae": 1.0},
+        ),
+        _row(
+            loss_name="MultiLoss",
+            brain_model_name="NtReve",
+            eval_mode="linear_probe",
+            **{"test/bmae": 2.0},
+        ),
+        _row(
+            loss_name="MultiLoss",
+            brain_model_name="EEGNet",
+            eval_mode="finetune",
+            **{"test/bmae": 3.0},
+        ),
+    ]
+    df = build_results_df(results, _DEFAULT_MAPPING)
+    assert set(df["model_name"]) == {"REVE (FT)", "REVE (LP)", "EEGNet"}
+
+
+def test_foundation_eval_modes_orders_and_ignores_non_fm():
+    results = [
+        _row(
+            loss_name="MultiLoss",
+            brain_model_name="NtReve",
+            eval_mode="lora_r32_flatten",
+        ),
+        _row(
+            loss_name="MultiLoss",
+            brain_model_name="NtReve",
+            eval_mode="linear_probe_mean",
+        ),
+        _row(
+            loss_name="MultiLoss",
+            brain_model_name="NtReve",
+            eval_mode="lora_r4_flatten",
+        ),
+        _row(
+            loss_name="MultiLoss",
+            brain_model_name="NtReve",
+            eval_mode="attentive_probe",
+        ),
+        _row(
+            loss_name="MultiLoss",
+            brain_model_name="NtReve",
+            eval_mode="linear_probe_flatten",
+        ),
+        # non-FM: must not contribute "finetune"
+        _row(loss_name="MultiLoss", brain_model_name="EEGNet", eval_mode="finetune"),
+    ]
+    assert foundation_eval_modes(results) == [
+        "linear_probe_flatten",
+        "linear_probe_mean",
+        "attentive_probe",
+        "lora_r4_flatten",
+        "lora_r32_flatten",
+    ]
+
+
+def test_filter_results_for_eval_mode_keeps_non_fm_reference():
+    results = [
+        _row(
+            loss_name="MultiLoss",
+            brain_model_name="NtReve",
+            eval_mode="linear_probe",
+            **{"test/bmae": 1.0},
+        ),
+        _row(
+            loss_name="MultiLoss",
+            brain_model_name="NtReve",
+            eval_mode="finetune",
+            **{"test/bmae": 2.0},
+        ),
+        _row(
+            loss_name="MultiLoss",
+            brain_model_name="EEGNet",
+            eval_mode="finetune",
+            **{"test/bmae": 3.0},
+        ),
+    ]
+    subset = filter_results_for_eval_mode(results, "linear_probe")
+    df = build_results_df(subset, _DEFAULT_MAPPING, suffix_eval_mode=False)
+    # NtReve@finetune dropped; NtReve@linear_probe + EEGNet kept, both bare.
+    assert set(df["model_name"]) == {"REVE", "EEGNet"}

--- a/neuralbench-repo/neuralbench/test_aggregator.py
+++ b/neuralbench-repo/neuralbench/test_aggregator.py
@@ -1,0 +1,33 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests for :mod:`neuralbench.aggregator`."""
+
+import typing as tp
+from types import SimpleNamespace
+
+from .aggregator import _infer_eval_mode
+from .modules import DownstreamWrapper
+from .registry import ALL_DOWNSTREAM_WRAPPERS
+
+
+def _eval_mode(wrapper: DownstreamWrapper | None) -> str:
+    return _infer_eval_mode(
+        tp.cast(tp.Any, SimpleNamespace(downstream_model_wrapper=wrapper))
+    )
+
+
+def test_infer_eval_mode_tags_each_shipped_preset_distinctly():
+    modes = {
+        name: _eval_mode(DownstreamWrapper(**preset["downstream_model_wrapper"]))
+        for name, preset in ALL_DOWNSTREAM_WRAPPERS.items()
+    }
+    # presets sharing a tag would merge everywhere downstream: plots, tables, folders
+    assert modes == {name: name for name in ALL_DOWNSTREAM_WRAPPERS}
+
+
+def test_infer_eval_mode_without_wrapper_is_finetune():
+    assert _eval_mode(None) == "finetune"

--- a/neuralbench-repo/neuralbench/test_experiment_config.py
+++ b/neuralbench-repo/neuralbench/test_experiment_config.py
@@ -1,0 +1,88 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import functools
+
+import pytest
+from exca import ConfDict
+
+from neuralbench.experiment_config import _expand_grid
+from neuralbench.registry import (
+    ALL_DOWNSTREAM_WRAPPERS,
+    DEFAULTS_DIR,
+    FM_MODELS,
+    _resolve_model_config_path,
+    load_yaml_config,
+)
+from neuraltrain.optimizers.base import LightningOptimizer
+
+
+def _expand(config: dict, grid: dict, debug: bool = False):
+    return _expand_grid(
+        ConfDict(config),
+        ConfDict(grid),
+        device="eeg",
+        task_name="dummy",
+        use_task_grid=False,
+        prepare=False,
+        debug=debug,
+        quiet=True,
+    )
+
+
+def test_expand_grid_adaptation_overlay_merges_atomically():
+    base = {"seed": 0, "downstream_model_wrapper": {"aggregation": "mean"}}
+    overlays = [
+        {
+            "downstream_model_wrapper": {
+                "aggregation": "flatten",
+                "probe_config": "linear",
+            },
+            "lightning_optimizer_config": {"optimizer": {"lr": 5.0e-4}},
+        },
+        {"downstream_model_wrapper": {"aggregation": "attention"}},
+    ]
+    configs = _expand(base, {"seed": [0, 1], "_adaptation_overlay": overlays})
+
+    assert len(configs) == 4, "2 seeds x 2 overlays; the overlay list stays one axis"
+    for cfg in configs:
+        assert "_adaptation_overlay" not in cfg.flat()
+
+    flatten_cfgs = [
+        c for c in configs if c["downstream_model_wrapper.aggregation"] == "flatten"
+    ]
+    assert len(flatten_cfgs) == 2
+    for c in flatten_cfgs:
+        # all keys of the overlay land together
+        assert c["downstream_model_wrapper.probe_config"] == "linear"
+        assert c["lightning_optimizer_config.optimizer.lr"] == 5.0e-4
+
+
+def test_expand_grid_debug_renulls_scheduler_after_overlay():
+    base = {"seed": 0}
+    overlays = [
+        {"lightning_optimizer_config": {"scheduler": {"kwargs": {"max_lr": 1.0}}}}
+    ]
+    configs = _expand(base, {"_adaptation_overlay": overlays}, debug=True)
+
+    assert len(configs) == 1
+    assert configs[0]["lightning_optimizer_config.scheduler"] is None
+
+
+@functools.cache
+def _base_and_model_config(model_name: str) -> ConfDict:
+    config = ConfDict(load_yaml_config(DEFAULTS_DIR / "config.yaml"))
+    config.update(load_yaml_config(_resolve_model_config_path(model_name)))
+    return config
+
+
+@pytest.mark.parametrize("preset", list(ALL_DOWNSTREAM_WRAPPERS))
+@pytest.mark.parametrize("model_name", FM_MODELS)
+def test_adaptation_overlay_leaves_a_valid_optimizer(model_name: str, preset: str):
+    config = _base_and_model_config(model_name).copy()
+    config.update(ALL_DOWNSTREAM_WRAPPERS[preset])
+    # a model YAML with scheduler=null would come back nameless: overlays set only max_lr
+    LightningOptimizer(**dict(config["lightning_optimizer_config"]))

--- a/neuralbench-repo/neuralbench/test_modules.py
+++ b/neuralbench-repo/neuralbench/test_modules.py
@@ -6,9 +6,9 @@
 
 """Tests for :mod:`neuralbench.modules`.
 
-Covers ``DownstreamWrapper`` / ``DownstreamWrapperModel`` (preprocessor and
-channel-adapter wiring, dict-output routing) and ``ChannelProjection``
-(identity and bipolar inits, validation, end-to-end shape + numerics).
+Covers ``DownstreamWrapper`` / ``DownstreamWrapperModel`` (aggregation, probe
+head, probe_layer capture, preprocessor / channel-adapter wiring, dict-output
+routing, LoRA injection) and ``ChannelProjection`` (identity / bipolar inits).
 """
 
 import pytest
@@ -18,27 +18,24 @@ from torch import nn
 from neuraltrain.models.common import ChannelMerger, FourierEmb
 from neuraltrain.models.preprocessor import OnTheFlyPreprocessor
 
-from .modules import ChannelProjection, DownstreamWrapper, DownstreamWrapperModel
+from .modules import (
+    ChannelProjection,
+    DownstreamWrapper,
+    DownstreamWrapperModel,
+    LoraConfig,
+)
 
 # ---------------------------------------------------------------------------
-# DownstreamWrapper
+# DownstreamWrapper -- basic + probe_layer
 # ---------------------------------------------------------------------------
 
 
 def test_downstream_wrapper():
     B, F, Fp = 8, 10, 3
-    model = nn.Linear(F, 4)
     dummy_batch = {"input": torch.randn(B, F)}
-    wrapped = DownstreamWrapper().build(model, dummy_batch, Fp)
-
+    wrapped = DownstreamWrapper().build(nn.Linear(F, 4), dummy_batch, Fp)
     assert isinstance(wrapped, DownstreamWrapperModel)
-    out = wrapped(**dummy_batch)
-    assert out.shape == (B, Fp)
-
-
-# ---------------------------------------------------------------------------
-# DownstreamWrapper probe_layer
-# ---------------------------------------------------------------------------
+    assert wrapped(**dummy_batch).shape == (B, Fp)
 
 
 def test_downstream_wrapper_probe_layer():
@@ -46,11 +43,9 @@ def test_downstream_wrapper_probe_layer():
     model = nn.Sequential(nn.Linear(F, 16), nn.Linear(16, 4))
     dummy_batch = {"input": torch.Tensor(B, F)}
     wrapped = DownstreamWrapper(probe_layer="0").build(model, dummy_batch, Fp)
-
-    # Probe is sized from layer "0"'s output (16) — not the final layer (4).
+    # Probe is sized from layer "0"'s output (16), not the final layer (4).
     assert wrapped.probe.in_features == 16
-    out = wrapped(**dummy_batch)
-    assert out.shape == (B, Fp)
+    assert wrapped(**dummy_batch).shape == (B, Fp)
 
 
 def test_downstream_wrapper_probe_layer_invalid():
@@ -72,7 +67,7 @@ def test_downstream_wrapper_probe_batch_dim_requires_probe_layer():
 
 
 def test_downstream_wrapper_probe_layer_rejects_tuple_capture():
-    # nn.RNN returns (output, h_n); probing it must raise.
+    # nn.RNN returns (output, h_n); probing a non-tensor capture must raise.
     model = nn.RNN(input_size=10, hidden_size=8, batch_first=True)
     with pytest.raises(TypeError, match="tensor-returning"):
         DownstreamWrapper(probe_layer="").build(
@@ -105,24 +100,24 @@ class _SeqFirstProbeNet(nn.Module):
 
 @pytest.mark.parametrize("aggregation", ["mean", "flatten", "first"])
 def test_downstream_wrapper_probe_layer_seq_first(aggregation):
-    # A sequence-first (T, B, D) capture is auto-detected and moved to
-    # batch-first, so the standard aggregations apply with no special-casing.
+    # A (T, B, D) capture is auto-detected and moved to batch-first, so the
+    # standard aggregations apply with no special-casing.
     B, T, F, D, Fp = 8, 5, 10, 6, 3
-    model = _SeqFirstProbeNet(F, D)
     wrapped = DownstreamWrapper(probe_layer="enc", aggregation=aggregation).build(
-        model, {"x": torch.Tensor(B, T, F)}, Fp
+        _SeqFirstProbeNet(F, D), {"x": torch.Tensor(B, T, F)}, Fp
     )
-    expected_in = {"mean": D, "flatten": T * D, "first": D}[aggregation]
-    assert wrapped.probe.in_features == expected_in
+    assert (
+        wrapped.probe.in_features
+        == {"mean": D, "flatten": T * D, "first": D}[aggregation]
+    )
     assert wrapped(x=torch.Tensor(B, T, F)).shape == (B, Fp)
 
 
 def test_downstream_wrapper_probe_layer_batch_seq_collision():
     # Two-pass detection resolves the batch axis even when batch == seq length.
     n, F, D, Fp = 5, 10, 6, 3
-    model = _SeqFirstProbeNet(F, D)
     wrapped = DownstreamWrapper(probe_layer="enc", aggregation="mean").build(
-        model, {"x": torch.Tensor(n, n, F)}, Fp
+        _SeqFirstProbeNet(F, D), {"x": torch.Tensor(n, n, F)}, Fp
     )
     assert wrapped.probe.in_features == D
     assert wrapped(x=torch.Tensor(n, n, F)).shape == (n, Fp)
@@ -131,20 +126,68 @@ def test_downstream_wrapper_probe_layer_batch_seq_collision():
 def test_downstream_wrapper_probe_layer_batch_dim_override():
     # Explicit probe_batch_dim=1 skips auto-detection for the (T, B, D) capture.
     B, T, F, D, Fp = 8, 5, 10, 6, 3
-    model = _SeqFirstProbeNet(F, D)
     wrapped = DownstreamWrapper(
         probe_layer="enc", aggregation="mean", probe_batch_dim=1
-    ).build(model, {"x": torch.Tensor(B, T, F)}, Fp)
+    ).build(_SeqFirstProbeNet(F, D), {"x": torch.Tensor(B, T, F)}, Fp)
     assert wrapped.probe.in_features == D
     assert wrapped(x=torch.Tensor(B, T, F)).shape == (B, Fp)
 
 
-class LinearOutDict(nn.Module):
-    """Linear layer whose forward returns ``{"key1": Wx, "key2": 2 * Wx}``.
+# ---------------------------------------------------------------------------
+# Probe head
+# ---------------------------------------------------------------------------
 
-    Used to verify that ``DownstreamWrapper(model_output_key=...)`` routes the
-    correct dictionary entry to downstream aggregation / probe.
-    """
+
+class _TokenModel2D(nn.Module):
+    """Returns 2-D per-sample token embeddings ``(B, n_patches, emb)``."""
+
+    def __init__(self, n_in: int, n_patches: int, emb: int):
+        super().__init__()
+        self.n_patches, self.emb = n_patches, emb
+        self.lin = nn.Linear(n_in, n_patches * emb)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.lin(x).reshape(x.shape[0], self.n_patches, self.emb)
+
+
+class _TokenModel3D(nn.Module):
+    """Returns 3-D per-sample token embeddings ``(B, n_chans, n_patches, emb)``."""
+
+    def __init__(self, n_in: int, n_chans: int, n_patches: int, emb: int):
+        super().__init__()
+        self.shape = (n_chans, n_patches, emb)
+        self.lin = nn.Linear(n_in, n_chans * n_patches * emb)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.lin(x).reshape(x.shape[0], *self.shape)
+
+
+@pytest.mark.parametrize("ndim", [2, 3])
+def test_attention_probe_is_trainable_on_frozen_backbone(ndim):
+    B, F, C, P, E, Fp = 8, 10, 3, 4, 5, 3
+    model = _TokenModel2D(F, P, E) if ndim == 2 else _TokenModel3D(F, C, P, E)
+    dummy = {"x": torch.randn(B, F)}
+    wrapped = DownstreamWrapper(
+        aggregation=None, probe_config="attention", layers_to_unfreeze=[""]
+    ).build(model, dummy, Fp)
+    probe_params = list(wrapped.probe.parameters())
+    assert not any(p.requires_grad for p in wrapped.wrapped_model.parameters())
+    assert probe_params and all(p.requires_grad for p in probe_params)
+    assert wrapped(**dummy).shape == (B, Fp)
+
+
+def test_attention_probe_requires_no_aggregation():
+    with pytest.raises(ValueError, match="requires aggregation=None"):
+        DownstreamWrapper(aggregation="mean", probe_config="attention")
+
+
+# ---------------------------------------------------------------------------
+# DownstreamWrapper -- output-key routing, preprocessor, channel adapters
+# ---------------------------------------------------------------------------
+
+
+class LinearOutDict(nn.Module):
+    """Linear layer returning ``{"key1": Wx, "key2": 2 * Wx}`` to test key routing."""
 
     def __init__(self, n_inputs: int, n_outputs: int):
         super().__init__()
@@ -152,146 +195,105 @@ class LinearOutDict(nn.Module):
 
     def forward(self, x: torch.Tensor) -> dict[str, torch.Tensor]:
         out = self.linear(x)
-        return {
-            "key1": out,
-            "key2": out * 2,
-        }
+        return {"key1": out, "key2": out * 2}
 
 
 def test_downstream_wrapper_routes_selected_dict_key():
-    """``model_output_key='key2'`` must surface ``key2``'s value, not ``key1``.
-
-    With ``probe_config=None`` and ``aggregation='flatten'``, the wrapper's
-    output equals the routed tensor flattened over non-batch dims, so the
-    numerical relationship ``out_key2 == 2 * out_key1`` lets us pin the
-    routing rather than just the shape.
-    """
     B, F, n_outputs = 8, 10, 4
     inner = LinearOutDict(F, n_outputs)
-    x = torch.randn(B, F)
-    dummy_batch = {"x": x}
+    dummy_batch = {"x": torch.randn(B, F)}
 
-    wrapped_key1 = DownstreamWrapper(
+    out_key1 = DownstreamWrapper(
         model_output_key="key1", aggregation="flatten", probe_config=None
-    ).build(inner, dummy_batch, n_outputs)
-    wrapped_key2 = DownstreamWrapper(
+    ).build(inner, dummy_batch, n_outputs)(**dummy_batch)
+    out_key2 = DownstreamWrapper(
         model_output_key="key2", aggregation="flatten", probe_config=None
-    ).build(inner, dummy_batch, n_outputs)
+    ).build(inner, dummy_batch, n_outputs)(**dummy_batch)
 
-    out_key1 = wrapped_key1(**dummy_batch)
-    out_key2 = wrapped_key2(**dummy_batch)
     assert out_key1.shape == (B, n_outputs)
+    # key2 == 2*key1 pins routing to the value, not just the shape.
     assert torch.allclose(out_key2, 2 * out_key1)
 
 
 def test_downstream_wrapper_with_preprocessor():
-    """On-the-fly preprocessing is applied inside the wrapper and changes output."""
     B, C, T, Fp = 4, 18, 200, 3
-    model = nn.Identity()
     raw_input = torch.randn(B, C, T) * 1000.0
     dummy_batch = {"input": raw_input.clone()}
 
-    preprocessor_config = OnTheFlyPreprocessor(
-        scaler="StandardScaler",
-        scale_dim=-1,
-    )
-    wrapper = DownstreamWrapper(
-        on_the_fly_preprocessor=preprocessor_config,
+    wrapped = DownstreamWrapper(
+        on_the_fly_preprocessor=OnTheFlyPreprocessor(
+            scaler="StandardScaler", scale_dim=-1
+        ),
         aggregation="flatten",
-    )
-    wrapped_model = wrapper.build(model, dummy_batch, Fp)
-
-    assert isinstance(wrapped_model, DownstreamWrapperModel)
-    assert wrapped_model.preprocessor is not None
-    out = wrapped_model(**{"input": raw_input.clone()})
+    ).build(nn.Identity(), dummy_batch, Fp)
+    assert wrapped.preprocessor is not None
+    out = wrapped(**{"input": raw_input.clone()})
     assert out.shape == (B, Fp)
 
-    wrapper_no_preproc = DownstreamWrapper(aggregation="flatten")
-    model_no_preproc = wrapper_no_preproc.build(nn.Identity(), dummy_batch, Fp)
-    out_no_preproc = model_no_preproc(**{"input": raw_input.clone()})
-    msg = "Preprocessor should have modified the data going through the wrapper"
-    assert not torch.allclose(out, out_no_preproc), msg
+    no_preproc = DownstreamWrapper(aggregation="flatten").build(
+        nn.Identity(), dummy_batch, Fp
+    )
+    out_no_preproc = no_preproc(**{"input": raw_input.clone()})
+    assert not torch.allclose(out, out_no_preproc), "preprocessor did not alter output"
 
 
 def test_downstream_wrapper_with_channel_merger():
-    """``ChannelMerger`` projects channels before the inner model and uses positions."""
-    B, C_in, T = 4, 32, 200
-    C_virtual = 8
-
-    model = nn.Identity()
+    B, C_in, T, C_virtual = 4, 32, 200, 8
     channel_positions = torch.rand(B, C_in, 3)
     subject_ids = torch.zeros(B, dtype=torch.long)
     raw_input = torch.randn(B, C_in, T)
-
     dummy_batch = {
         "input": raw_input.clone(),
         "channel_positions": channel_positions,
         "subject_ids": subject_ids,
     }
 
-    merger_config = ChannelMerger(
-        n_virtual_channels=C_virtual,
-        per_subject=False,
-        fourier_emb_config=FourierEmb(n_dims=3),
-    )
-    wrapper = DownstreamWrapper(
-        channel_adapter_config=merger_config,
+    wrapped = DownstreamWrapper(
+        channel_adapter_config=ChannelMerger(
+            n_virtual_channels=C_virtual,
+            per_subject=False,
+            fourier_emb_config=FourierEmb(n_dims=3),
+        ),
         aggregation="flatten",
         probe_config=None,
-    )
-    n_outputs = C_virtual * T
-    wrapped_model = wrapper.build(model, dummy_batch, n_outputs)
+    ).build(nn.Identity(), dummy_batch, C_virtual * T)
+    assert wrapped.channel_adapter is not None
+    assert wrapped._adapter_needs_positions
 
-    assert isinstance(wrapped_model, DownstreamWrapperModel)
-    assert wrapped_model.channel_adapter is not None
-    assert wrapped_model._adapter_needs_positions
-
-    out = wrapped_model(
+    out = wrapped(
         input=raw_input.clone(),
         channel_positions=channel_positions,
         subject_ids=subject_ids,
     )
     assert out.shape == (B, C_virtual * T)
-
-    # Behavioural check: the merger is position-conditioned, so different
-    # channel positions must produce a different output for the same input.
-    other_positions = torch.rand(B, C_in, 3)
-    out_other = wrapped_model(
+    # The merger is position-conditioned: different positions -> different output.
+    out_other = wrapped(
         input=raw_input.clone(),
-        channel_positions=other_positions,
+        channel_positions=torch.rand(B, C_in, 3),
         subject_ids=subject_ids,
     )
     assert not torch.allclose(out, out_other)
 
 
 def test_downstream_wrapper_with_channel_projection():
-    """``ChannelProjection`` projects channels via Conv1d, ignoring positions."""
-    B, C_in, T = 4, 32, 200
-    C_target = 18
-
-    model = nn.Identity()
+    B, C_in, T, C_target = 4, 32, 200, 18
     raw_input = torch.randn(B, C_in, T)
     dummy_batch = {"input": raw_input.clone()}
 
-    proj_config = ChannelProjection(n_target_channels=C_target, max_norm=1.0)
-    wrapper = DownstreamWrapper(
-        channel_adapter_config=proj_config,
+    wrapped = DownstreamWrapper(
+        channel_adapter_config=ChannelProjection(
+            n_target_channels=C_target, max_norm=1.0
+        ),
         aggregation="flatten",
         probe_config=None,
-    )
-    n_outputs = C_target * T
-    wrapped_model = wrapper.build(model, dummy_batch, n_outputs)
-
-    assert isinstance(wrapped_model, DownstreamWrapperModel)
-    assert wrapped_model.channel_adapter is not None
-    assert not wrapped_model._adapter_needs_positions
-
-    out = wrapped_model(**{"input": raw_input.clone()})
-    assert out.shape == (B, C_target * T)
+    ).build(nn.Identity(), dummy_batch, C_target * T)
+    assert wrapped.channel_adapter is not None
+    assert not wrapped._adapter_needs_positions
+    assert wrapped(**{"input": raw_input.clone()}).shape == (B, C_target * T)
 
 
 # ---------------------------------------------------------------------------
-# ChannelProjection -- identity init
+# ChannelProjection -- identity / bipolar init
 # ---------------------------------------------------------------------------
 
 
@@ -300,7 +302,7 @@ def _identity_expected(
     inputs: list[str],
     rename: dict[str, str] | None = None,
 ) -> torch.Tensor:
-    """Compute the one-hot weight pattern the identity init should produce."""
+    """One-hot weight pattern the identity init should produce."""
     canon_inputs = [(rename or {}).get(n, n).upper() for n in inputs]
     target_upper = [t.upper() for t in target]
     weight = torch.zeros(len(target), len(inputs), 1)
@@ -338,23 +340,10 @@ def _identity_expected(
             None,
             id="rename_and_case_insensitive",
         ),
-        pytest.param(
-            ["A", "B", "C"],
-            ["A", "B", "C"],
-            None,
-            1.0,
-            id="with_max_norm",
-        ),
+        pytest.param(["A", "B", "C"], ["A", "B", "C"], None, 1.0, id="with_max_norm"),
     ],
 )
 def test_channel_projection_identity_patterns(target, inputs, rename, max_norm):
-    """Identity init sets the expected one-hot pattern and zeros the bias.
-
-    Covers exact-match, reorder+zero-pad-missing, rename/case-insensitive
-    canonicalisation, and the ``Conv1dWithConstraint`` parametrize hook.
-    A row for a covered target exposes its matched input through the
-    forward pass; missing targets emit zeros.
-    """
     proj = ChannelProjection(
         n_target_channels=len(target),
         init="identity",
@@ -369,6 +358,7 @@ def test_channel_projection_identity_patterns(target, inputs, rename, max_norm):
     assert conv.bias is not None
     assert torch.allclose(conv.bias, torch.zeros_like(conv.bias))
 
+    # A covered target row exposes its matched input; a missing target emits zeros.
     x = torch.randn(2, len(inputs), 10)
     out = conv(x)
     for i in range(len(target)):
@@ -379,65 +369,12 @@ def test_channel_projection_identity_patterns(target, inputs, rename, max_norm):
             assert torch.allclose(out[:, i, :], torch.zeros_like(out[:, i, :]))
 
 
-def test_channel_projection_identity_rejects_wrong_target_length():
-    """``n_target_channels`` and ``target_channel_names`` must agree at construction."""
-    with pytest.raises(ValueError, match="target_channel_names"):
-        ChannelProjection(
-            init="identity",
-            max_norm=None,
-            n_target_channels=3,
-            target_channel_names=["A", "B"],
-        )
-
-
-def test_channel_projection_identity_requires_input_names_at_build():
-    """``init='identity'`` needs ``input_channel_names`` at ``build`` time."""
-    proj = ChannelProjection(
-        init="identity",
-        max_norm=None,
-        n_target_channels=2,
-        target_channel_names=["A", "B"],
-    )
-    with pytest.raises(ValueError, match="input_channel_names"):
-        proj.build(n_in_channels=2)
-
-
-def test_channel_projection_identity_end_to_end():
-    """Identity-init adapter is a pass-through inside a DownstreamWrapper."""
-    target = ["Fp1", "Fp2", "Cz", "O1"]
-    B, T = 3, 20
-    raw_input = torch.randn(B, len(target), T)
-    dummy_batch = {"input": raw_input.clone()}
-
-    proj_config = ChannelProjection(
-        n_target_channels=len(target),
-        init="identity",
-        target_channel_names=target,
-        max_norm=None,
-    )
-    wrapper = DownstreamWrapper(
-        channel_adapter_config=proj_config,
-        aggregation="flatten",
-        probe_config=None,
-    )
-    wrapped_model = wrapper.build(
-        nn.Identity(), dummy_batch, len(target) * T, input_channel_names=target
-    )
-    out = wrapped_model(**{"input": raw_input.clone()})
-    assert torch.allclose(out, raw_input.flatten(1))
-
-
-# ---------------------------------------------------------------------------
-# ChannelProjection -- bipolar init
-# ---------------------------------------------------------------------------
-
-
 def _bipolar_expected(
     target: list[str],
     inputs: list[str],
     rename: dict[str, str] | None = None,
 ) -> torch.Tensor:
-    """Compute the +1/-1 pattern the bipolar init should *add* to Kaiming."""
+    """+1/-1 pattern the bipolar init should *add* to the Kaiming baseline."""
     canon_inputs = [(rename or {}).get(n, n).upper() for n in inputs]
     canon_to_idx: dict[str, int] = {}
     for j, cn in enumerate(canon_inputs):
@@ -476,34 +413,22 @@ def _bipolar_expected(
             id="rename",
         ),
         pytest.param(
-            ["FP1-F7", "F7-T7"],
-            ["UNK_0", "UNK_1", "UNK_2"],
-            None,
-            id="no_match",
+            ["FP1-F7", "F7-T7"], ["UNK_0", "UNK_1", "UNK_2"], None, id="no_match"
         ),
         pytest.param(
-            ["Fp1", "FP1-F7"],
-            ["Fp1", "F7"],
-            None,
-            id="unipolar_and_bipolar_mix",
+            ["Fp1", "FP1-F7"], ["Fp1", "F7"], None, id="unipolar_and_bipolar_mix"
         ),
     ],
 )
 def test_channel_projection_bipolar_patterns(target, inputs, rename):
-    """Bipolar init adds the +1/-1 pattern on top of the Kaiming baseline.
-
-    Verified by building the same-shape adapter with ``init='random'`` under
-    the same torch seed and asserting ``W_bipolar - W_kaiming == pattern``.
-    Fully missing rows stay at the Kaiming baseline so the forward output
-    (and therefore the gradient through ``|STFT|``) is non-zero.
-    """
+    # Build the same-shape adapter with init='random' under the same seed and
+    # assert W_bipolar - W_kaiming == pattern.
     kwargs: dict = dict(
         n_target_channels=len(target),
         target_channel_names=target,
         rename_mapping=rename,
         max_norm=None,
     )
-
     torch.manual_seed(0)
     bipolar = ChannelProjection(init="bipolar", **kwargs).build(
         n_in_channels=len(inputs), input_channel_names=inputs
@@ -516,65 +441,228 @@ def test_channel_projection_bipolar_patterns(target, inputs, rename):
     assert bipolar.bias is not None
     assert torch.allclose(bipolar.bias, torch.zeros_like(bipolar.bias))
 
-    # Rows left at the Kaiming baseline (partial / fully missing) must stay
-    # non-zero -- otherwise BIOT's |STFT(0)| would freeze their gradient.
+    # Rows left at the Kaiming baseline must stay non-zero, else BIOT's
+    # |STFT(0)| would freeze their gradient.
     pattern_row_abs = expected.abs().sum(dim=(1, 2))
     for i in range(len(target)):
         if pattern_row_abs[i] == 0:
             assert bipolar.weight[i].abs().sum() > 0
 
 
-def test_channel_projection_bipolar_rejects_wrong_target_length():
-    """``n_target_channels`` and ``target_channel_names`` must agree at construction."""
+@pytest.mark.parametrize(
+    "init,target_names",
+    [("identity", ["A", "B"]), ("bipolar", ["A-B", "C-D"])],
+)
+def test_channel_projection_rejects_wrong_target_length(init, target_names):
     with pytest.raises(ValueError, match="target_channel_names"):
         ChannelProjection(
-            init="bipolar",
+            init=init,
             max_norm=None,
             n_target_channels=3,
-            target_channel_names=["A-B", "C-D"],
+            target_channel_names=target_names,
         )
 
 
-def test_channel_projection_bipolar_requires_input_names_at_build():
-    """``init='bipolar'`` needs ``input_channel_names`` at ``build`` time."""
+@pytest.mark.parametrize(
+    "init,target_names",
+    [("identity", ["A", "B"]), ("bipolar", ["A-B", "C-D"])],
+)
+def test_channel_projection_requires_input_names_at_build(init, target_names):
     proj = ChannelProjection(
-        init="bipolar",
+        init=init,
         max_norm=None,
-        n_target_channels=2,
-        target_channel_names=["A-B", "C-D"],
+        n_target_channels=len(target_names),
+        target_channel_names=target_names,
     )
     with pytest.raises(ValueError, match="input_channel_names"):
-        proj.build(n_in_channels=4)
+        proj.build(n_in_channels=2)
+
+
+def test_channel_projection_identity_end_to_end():
+    # Identity-init adapter is a pass-through inside a DownstreamWrapper.
+    target = ["Fp1", "Fp2", "Cz", "O1"]
+    B, T = 3, 20
+    raw_input = torch.randn(B, len(target), T)
+    dummy_batch = {"input": raw_input.clone()}
+
+    wrapped = DownstreamWrapper(
+        channel_adapter_config=ChannelProjection(
+            n_target_channels=len(target),
+            init="identity",
+            target_channel_names=target,
+            max_norm=None,
+        ),
+        aggregation="flatten",
+        probe_config=None,
+    ).build(nn.Identity(), dummy_batch, len(target) * T, input_channel_names=target)
+    out = wrapped(**{"input": raw_input.clone()})
+    assert torch.allclose(out, raw_input.flatten(1))
 
 
 def test_channel_projection_bipolar_end_to_end():
-    """Bipolar-init adapter computes (A - B) for covered pairs end-to-end."""
+    # Bipolar-init adapter computes (A - B) for covered pairs end-to-end.
     target = ["FP1-F7", "F7-T7"]
     inputs = ["Fp1", "F7", "T7"]
     B, T = 3, 20
     raw_input = torch.randn(B, len(inputs), T)
     dummy_batch = {"input": raw_input.clone()}
 
-    proj_config = ChannelProjection(
-        n_target_channels=len(target),
-        init="bipolar",
-        target_channel_names=target,
-        max_norm=None,
-    )
-    wrapper = DownstreamWrapper(
-        channel_adapter_config=proj_config,
+    wrapped = DownstreamWrapper(
+        channel_adapter_config=ChannelProjection(
+            n_target_channels=len(target),
+            init="bipolar",
+            target_channel_names=target,
+            max_norm=None,
+        ),
         aggregation="flatten",
         probe_config=None,
-    )
-    wrapped_model = wrapper.build(
-        nn.Identity(), dummy_batch, len(target) * T, input_channel_names=inputs
-    )
-    adapter = wrapped_model.channel_adapter
+    ).build(nn.Identity(), dummy_batch, len(target) * T, input_channel_names=inputs)
+    adapter = wrapped.channel_adapter
     assert adapter is not None
-    # Strip the Kaiming baseline to isolate the bipolar pattern's contribution,
-    # then verify the adapter computes (A - B) for each covered pair.
+    # Strip the Kaiming baseline to isolate the bipolar pattern's contribution.
     with torch.no_grad():
         adapter.weight.copy_(_bipolar_expected(target, inputs))
-    out = wrapped_model(**{"input": raw_input.clone()}).reshape(B, len(target), T)
+    out = wrapped(**{"input": raw_input.clone()}).reshape(B, len(target), T)
     assert torch.allclose(out[:, 0, :], raw_input[:, 0, :] - raw_input[:, 1, :])
     assert torch.allclose(out[:, 1, :], raw_input[:, 1, :] - raw_input[:, 2, :])
+
+
+# ---------------------------------------------------------------------------
+# DownstreamWrapper -- LoRA injection
+# ---------------------------------------------------------------------------
+
+
+class _TinyAttn(nn.Module):
+    """Toy attention block with named Q/K/V/O ``nn.Linear`` leaves.
+
+    PEFT matches ``target_modules`` on leaf names, so only the names matter.
+    """
+
+    def __init__(self, d: int = 16):
+        super().__init__()
+        self.to_q = nn.Linear(d, d)
+        self.to_k = nn.Linear(d, d)
+        self.to_v = nn.Linear(d, d)
+        self.to_out = nn.Linear(d, d)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.to_out(self.to_q(x) + self.to_k(x) + self.to_v(x))
+
+
+_QKVO = ["to_q", "to_k", "to_v", "to_out"]
+
+
+def _lora_wrapper(*, targets, r=4, target_modules=None) -> DownstreamWrapper:
+    """A frozen-backbone LoRA wrapper; only the target lists vary between tests."""
+    return DownstreamWrapper(
+        layers_to_unfreeze=[""],
+        aggregation="mean",
+        probe_config="linear",
+        lora_config=LoraConfig(
+            r=r, lora_alpha=2 * r, lora_dropout=0.0, target_modules=target_modules
+        ),
+        lora_target_modules=targets,
+    )
+
+
+def _lora_leaf_names(wrapped) -> set[str]:
+    """Leaf-module names that received a LoRA adapter."""
+    parents = {
+        name.split(".lora_")[0]
+        for name, _ in wrapped.wrapped_model.named_parameters()
+        if "lora_A" in name or "lora_B" in name
+    }
+    return {p.rsplit(".", 1)[-1] for p in parents}
+
+
+def _lora_params(wrapped) -> dict[str, torch.nn.Parameter]:
+    return {
+        n: p
+        for n, p in wrapped.wrapped_model.named_parameters()
+        if "lora_A" in n or "lora_B" in n
+    }
+
+
+def test_downstream_wrapper_lora_wraps_freezes_and_trains():
+    B, d, n_out = 2, 16, 3
+    dummy_batch = {"x": torch.randn(B, 5, d)}
+    wrapped = _lora_wrapper(targets=_QKVO).build(_TinyAttn(d=d), dummy_batch, n_out)
+
+    assert _lora_leaf_names(wrapped) == set(_QKVO)
+    # inside wrapped_model only the adapters train; the probe sits outside
+    inner_trainable = {
+        n for n, p in wrapped.wrapped_model.named_parameters() if p.requires_grad
+    }
+    assert inner_trainable and all(
+        ("lora_A" in n or "lora_B" in n) for n in inner_trainable
+    )
+    assert any(p.requires_grad for p in wrapped.probe.parameters())
+
+    # 4 Linears of 16->16: per module 16r (A) + 16r (B); total 128r, so r reaches peft
+    assert sum(p.numel() for p in _lora_params(wrapped).values()) == 128 * 4
+    doubled = _lora_wrapper(targets=_QKVO, r=8).build(_TinyAttn(d=d), dummy_batch, n_out)
+    assert sum(p.numel() for p in _lora_params(doubled).values()) == 128 * 8
+
+    out = wrapped(**dummy_batch)
+    assert out.shape == (B, n_out)
+
+    # lora_B is zero-init, so a non-zero grad proves it is wired into autograd
+    out.pow(2).mean().backward()
+    grads = {n: p.grad for n, p in _lora_params(wrapped).items()}
+    assert grads and all(g is not None for g in grads.values())
+    assert all(g.abs().sum() > 0 for n, g in grads.items() if "lora_B" in n)
+
+
+def test_downstream_wrapper_lora_target_module_resolution():
+    # Missing targets raise; an explicit lora_config subset wins over the YAML list.
+    dummy_batch = {"x": torch.randn(2, 5, 16)}
+
+    with pytest.raises(ValueError, match="LoRA requires target_modules"):
+        _lora_wrapper(targets=None).build(_TinyAttn(), dummy_batch, 3)
+
+    override = _lora_wrapper(targets=_QKVO, target_modules=["to_q"])
+    assert _lora_leaf_names(override.build(_TinyAttn(), dummy_batch, 3)) == {"to_q"}
+
+
+class _QkvProjAttn(nn.Module):
+    """Attention with ``qkv`` + ``proj`` linear leaves (the LoRA targets)."""
+
+    def __init__(self, d: int):
+        super().__init__()
+        self.qkv = nn.Linear(d, 3 * d)
+        self.proj = nn.Linear(d, d)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        d = x.shape[-1]
+        return self.proj(self.qkv(x)[..., :d])
+
+
+class _AttnWithDecoyProj(nn.Module):
+    """``attn.qkv``/``attn.proj`` beside decoy ``proj`` leaves that must be skipped.
+
+    Mirrors EEGPT, where a bare ``proj`` would also match a patch-embed Conv2d.
+    """
+
+    def __init__(self, d: int = 16):
+        super().__init__()
+        self.attn = _QkvProjAttn(d)
+        self.patch_embed = nn.Module()
+        self.patch_embed.proj = nn.Conv2d(1, 1, 1)
+        self.tokenizer = nn.Module()
+        self.tokenizer.proj = nn.Identity()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.attn(x)
+
+
+def test_downstream_wrapper_lora_dotted_target_skips_decoy_proj():
+    dummy_batch = {"x": torch.randn(2, 5, 16)}
+    wrapped = _lora_wrapper(targets=["qkv", "attn.proj"]).build(
+        _AttnWithDecoyProj(), dummy_batch, 3
+    )
+
+    lora_names = [n for n, _ in wrapped.wrapped_model.named_parameters() if "lora_" in n]
+    assert any("attn.qkv." in n for n in lora_names)
+    assert any("attn.proj." in n for n in lora_names)
+    assert not any("patch_embed" in n for n in lora_names)
+    assert not any("tokenizer" in n for n in lora_names)

--- a/neuralbench-repo/pyproject.toml
+++ b/neuralbench-repo/pyproject.toml
@@ -18,6 +18,9 @@ dependencies = [
   "neuraltrain",
   "exca",
   "lightning>=2.0.8",
+  "peft>=0.13",
+  # peft imports EncoderDecoderCache (transformers>=4.43) but declares no floor
+  "transformers>=4.43",
   "pyriemann>=0.6",
   "seaborn",
   "torchinfo",


### PR DESCRIPTION
## Summary

Foundation models could only be evaluated one way: fine-tuned end-to-end together with the downstream head. That makes it impossible to ask how much of a model's benchmark score comes from the pretrained representation versus from adapting all of its weights to the task.

This adds adaptation strategy presets, selectable with `-w`, so a single run can compare how a backbone is adapted while holding the task, data, and head fixed:

| Preset | Backbone | What trains |
|---|---|---|
| `linear_probe_flatten`, `linear_probe_mean` | frozen | linear head only |
| `attentive_probe` | frozen | attentive-pooling head |
| `lora_r4_flatten`, `lora_r32_flatten` | frozen | low-rank adapters on the attention projections, plus the head |
| `finetune_mean`, `finetune_flatten` | trainable | everything |

The two probe/fine-tune variants differ in how the backbone's token output is reduced before the head (`flatten` concatenates tokens, `mean` averages them), which materially changes results for some models, so they are kept as distinct presets rather than one default.

Each preset is a config overlay applied to **foundation models only** — classic task-specific models have no pretrained backbone to freeze, so they run unchanged. `-w all` sweeps every preset.

## Reporting

Results carry an adaptation tag, so plots and tables report strategies separately instead of averaging across them. Tagging and parsing share one `AdaptationMode` type, so the tag grammar has a single home and every shipped preset maps to a distinct tag (previously, presets differing only in aggregation would have silently merged into one row). A new `plots/adaptation.py` renders the cross-strategy comparison, and when a run covers multiple strategies the outputs are additionally split per strategy.

## Dependencies

`peft` becomes a dependency of `neuralbench`, needed by the LoRA presets. It is a base dependency rather than an extra so that `-w all` cannot fail partway through a sweep, but it is worth being explicit that this is a **new install-time cost for everyone**, and that it pulls in the `transformers` stack.

`peft` imports `EncoderDecoderCache` at module load, which requires `transformers>=4.43`, but declares no floor of its own — so the floor is declared here. The CI pin moves from `4.41.0` to `4.57.6` to satisfy it; without that bump, the LoRA tests fail on import.

## Test plan

- [x] `ruff check` / `ruff format --check` clean
- [x] `mypy neuralbench` clean
- [x] `pytest neuralbench` — 259 passed
- [x] New tests: every shipped preset maps to a distinct tag; adaptation tags round-trip through parse/render; the overlay leaves a schema-valid optimizer for every foundation model x preset combination
- [x] Debug CLI run, `-m reve -w linear_probe_flatten` — trains, validates, and tests end to end; the frozen-backbone overlay is visible in the resolved config
- [x] Debug CLI run, `-m reve -w lora_r4_flatten` — wraps the backbone in a `LoraModel` with 393,220 trainable against 69,312,002 frozen parameters
- [x] Default invocations (no `-w`) resolve to the same experiments as before, so cached fine-tuning results are not invalidated

Made with [Cursor](https://cursor.com)