### PR TITLE
neuralbench: depend on neuralfetch[quickstart] instead of a datasets extra

### DIFF
--- a/docs/neuralbench/install.md
+++ b/docs/neuralbench/install.md
@@ -41,11 +41,12 @@ pre-commit install
 
 ## Optional dependencies
 
-Extra dependency groups are available for dataset downloading and
-model loading:
+Dataset downloading is covered by the base install, which pulls in
+`neuralfetch[quickstart]`. The `models` extra adds what is needed to load
+pretrained model weights:
 
 ```bash
-pip install 'neuralbench-repo/.[datasets,models]'
+pip install 'neuralbench-repo/.[models]'
 ```
 
 ## First-run configuration

--- a/neuralbench-repo/pyproject.toml
+++ b/neuralbench-repo/pyproject.toml
@@ -14,6 +14,8 @@ classifiers = [
 dependencies = [
   "adjustText",
   "braindecode>=1.5.2",
+  # Study catalog: registered through an entry point, never imported directly
+  "neuralfetch[quickstart]",
   "neuralset",
   "neuraltrain",
   "exca",
@@ -35,14 +37,6 @@ dependencies = [
   Tracker = "https://github.com/facebookresearch/neuroai/issues"
 
 [project.optional-dependencies]
-    datasets = [
-        # Download
-        "boto3",
-        "botocore",
-        "gdown",
-        "openneuro-py>=2025.2.0",
-        "synapseclient",
-    ]
     models = [
         "huggingface_hub",
         "safetensors",

--- a/neuralfetch-repo/neuralfetch/download.py
+++ b/neuralfetch-repo/neuralfetch/download.py
@@ -1294,8 +1294,7 @@ How to generate a Synapse auth token:
 class Synapse(BaseDownload):
     """Download datasets from Synapse.
 
-    Requires `synapseclient`. Install with `pip install synapseclient`
-    or `pip install "neuralset[all]"`.
+    Requires `synapseclient`, which ships with `neuralfetch[quickstart]`.
     """
 
     study_id: str  # Project SynID
@@ -1316,8 +1315,8 @@ class Synapse(BaseDownload):
     def _download(self, overwrite: bool = False) -> None:
         # ``overwrite`` is best-effort: syncFromSynapse manages its own local
         # cache and refetches changed/missing entities on each sync.
-        import synapseclient  # type: ignore[import-not-found]
-        import synapseutils  # type: ignore[import-not-found]
+        import synapseclient
+        import synapseutils
 
         syn = synapseclient.Synapse()
         syn.login(authToken=self._auth_token)

--- a/neuralfetch-repo/pyproject.toml
+++ b/neuralfetch-repo/pyproject.toml
@@ -22,12 +22,13 @@ dependencies = [
 [project.optional-dependencies]
 all = ["neuralset[all]", "matplotlib"]
 quickstart = [
-  "openneuro-py",
+  "openneuro-py>=2026.4.0",
   "praatio",
   "pyunpack",
   "boto3",
   "osfclient>=0.0.5",
   "awscli",
+  "synapseclient",
 ]
 
 # Value: root module scanned for Study subclasses (see neuralset.events.study).
@@ -59,6 +60,7 @@ extend = "../pyproject.toml"
   'mne', 'mne.io', 'mne.io.constants', 'mne.io.fiff', 'mne.datasets', 'mne.utils', 'mne_bids',
   'scipy.*', 'nibabel', 'h5py',
   'osfclient', 'boto3', 'botocore', 'openneuro', 'pyunpack',
+  'synapseclient', 'synapseutils',
   'moviepy',
   'hcp_utils',
   'nilearn',


### PR DESCRIPTION
## Problem

`neuralbench`'s task configs reference 104 study names. 103 of them are defined
in `neuralfetch`; only `Mne2013SampleEeg` comes from `neuralset`. Since
`neuralfetch` was not a dependency, a plain `pip install neuralbench` could run
exactly one task (`eeg audiovisual_stimulus`).

The `datasets` extra did not fix this: it listed download backends
(`boto3`, `botocore`, `gdown`, `openneuro-py`, `synapseclient`) but never the
package that registers the studies, so even `pip install 'neuralbench[datasets]'`
left 103 of the 104 study names unresolvable.

## Change

Make `neuralfetch[quickstart]` a base dependency of `neuralbench` and remove the
`datasets` extra:

- `quickstart` already carries the download backends (`openneuro-py`, `praatio`,
  `pyunpack`, `boto3`, `osfclient`, `awscli`), so the extra had nothing left to
  contribute.
- `synapseclient` moves to `neuralfetch[quickstart]`, next to the `Synapse`
  downloader that requires it.
- `gdown` is dropped: nothing in the monorepo imports it or declares it in a
  `requirements` tuple.
- `botocore` is dropped as an explicit requirement. It is a hard transitive
  dependency of `boto3`, and `_check_requirements` resolves through
  `importlib.util.find_spec`, so `S3Downloader`'s `("boto3", "botocore")` stays
  satisfied.
- The `openneuro-py` floor becomes `>=2026.4.0` in `quickstart`. The `datasets`
  extra pinned `>=2025.2.0` while `quickstart` was unpinned, so moving as-is
  would have dropped the floor; `>=2026.4.0` is what the `Openneuro` downloader
  itself declares.

The comment on the new dependency records why it exists, since `neuralbench`
never imports `neuralfetch` — the study catalog arrives through the
`neuralset.studies` entry point.

`docs/neuralbench/install.md` was the only doc referencing the extra; its
"Optional dependencies" section now points at `[models]` and states that dataset
downloading ships with the base install.

## Validation

- Built both wheels and checked `METADATA`: `Requires-Dist: neuralfetch[quickstart]`
  with no `extra` marker, no `Provides-Extra: datasets`, and `quickstart` carrying
  `synapseclient` plus the `openneuro-py>=2026.4.0` floor.
- `ruff check .` and `ruff format --check .` pass.
- No source or test changes, so no pytest/mypy impact. Docs are not collected by
  `pytest neuralbench` (`pytest-markdown-docs` is not enabled via `addopts`).

## Compatibility

`pip install 'neuralbench[datasets]'` now warns about an unknown extra instead of
failing, and installs the same set of packages the extra used to provide (plus
`neuralfetch` itself).

CI is unaffected: `setup-python-env` installs `neuralbench-repo/.[dev,wandb,models]`
and has never used `datasets`, and the wheel smoke test installs with `--no-deps`.

Supersedes #218, which identified the same problem but added `neuralfetch` to the
`datasets` extra and a packaging-metadata regression test.
