### PR TITLE
neuralbench: unify torch floor with neuralset/neuraltrain

### DIFF
--- a/neuralbench-repo/neuralbench/cli.py
+++ b/neuralbench-repo/neuralbench/cli.py
@@ -23,6 +23,7 @@ from exca import ConfDict
 
 from neuralbench.experiment_config import (
     _warn_slurm_partition,
+    _warn_unsupported_gpu,
     prepare_task_configs,
 )
 from neuralbench.registry import (
@@ -130,6 +131,7 @@ def run_benchmark(
     _ensure_initialized()
     _validate_inputs(device, task, model, downstream_wrapper)
     _warn_slurm_partition(debug, prepare=prepare, download=download)
+    _warn_unsupported_gpu()
 
     # --- base config & grid ---
     default_config = load_yaml_config(DEFAULTS_DIR / "config.yaml")

--- a/neuralbench-repo/neuralbench/experiment_config.py
+++ b/neuralbench-repo/neuralbench/experiment_config.py
@@ -17,6 +17,7 @@ from itertools import product
 from pathlib import Path
 from warnings import warn
 
+import torch
 import yaml
 from exca import ConfDict
 
@@ -329,4 +330,49 @@ def _warn_slurm_partition(
             f"in your neuralbench config ({config_path}). Non-debug runs will "
             f"fail when submitting jobs. Either set SLURM_PARTITION in "
             f'{config_path}, set "CLUSTER": null to run locally, or use --debug.'
+        )
+
+
+# ---------------------------------------------------------------------------
+# GPU capability warning
+# ---------------------------------------------------------------------------
+
+
+def _warn_unsupported_gpu() -> None:
+    """Warn when a visible GPU is absent from the installed torch's arch list."""
+    if not torch.cuda.is_available():
+        return
+    # Release wheels are SASS-only (no PTX JIT), so a device needs a listed
+    # arch of its own major with minor <= its own.
+    built = {
+        (int(sm[:-1]), int(sm[-1]))
+        for arch in torch.cuda.get_arch_list()
+        if (sm := arch.removeprefix("sm_")).isdigit()
+    }
+    if not built:
+        return
+    warned: set[tuple[int, int]] = set()
+    for index in range(torch.cuda.device_count()):
+        capability = torch.cuda.get_device_capability(index)
+        major, minor = capability
+        if capability in warned or any(
+            major == bmajor and minor >= bminor for bmajor, bminor in built
+        ):
+            continue
+        warned.add(capability)
+        # sm_50-sm_60 survive only in the CUDA 12.6 wheels; PyPI's default build
+        # tracks the newest CUDA, which drops them.
+        if capability < min(built):
+            fix = (
+                "reinstall from a CUDA 12.6 build, which still ships sm_50-sm_90: "
+                "pip install --force-reinstall torch torchvision torchaudio "
+                "--index-url https://download.pytorch.org/whl/cu126"
+            )
+        else:
+            fix = "upgrade torch: pip install --upgrade torch torchvision torchaudio"
+        warn(
+            f"{torch.cuda.get_device_name(index)} has CUDA capability "
+            f"sm_{major}{minor}, which torch {torch.__version__} was not built for "
+            f"(built for {', '.join(f'sm_{a}{b}' for a, b in sorted(built))}). "
+            f"GPU runs will fail; to fix, {fix}"
         )

--- a/neuralbench-repo/neuralbench/test_cli.py
+++ b/neuralbench-repo/neuralbench/test_cli.py
@@ -10,6 +10,7 @@ import warnings
 from collections.abc import Callable
 
 import pytest
+import torch
 from exca import ConfDict
 
 import neuralset as ns
@@ -19,6 +20,7 @@ from .cli import run_benchmark
 from .experiment_config import (
     _apply_prepare_overlay,
     _warn_slurm_partition,
+    _warn_unsupported_gpu,
     prepare_task_configs,
 )
 from .main import Data
@@ -187,6 +189,40 @@ def test_warn_slurm_partition_fires_without_partition(
     monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/srun")
     with pytest.warns(UserWarning, match="SLURM is available"):
         _warn_slurm_partition(debug=False)
+
+
+@pytest.mark.parametrize(
+    "capability,arch_list,remedy",
+    [
+        ((6, 0), ["sm_75", "sm_80", "sm_90"], "--index-url"),
+        ((12, 0), ["sm_50", "sm_60", "sm_90"], "--upgrade"),
+        ((9, 0), ["sm_75", "sm_80", "sm_90"], None),
+        ((8, 6), ["sm_80", "compute_80"], None),
+    ],
+)
+def test_warn_unsupported_gpu(
+    monkeypatch: pytest.MonkeyPatch,
+    capability: tuple[int, int],
+    arch_list: list[str],
+    remedy: str | None,
+) -> None:
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 2)
+    monkeypatch.setattr(torch.cuda, "get_arch_list", lambda: arch_list)
+    monkeypatch.setattr(
+        torch.cuda, "get_device_capability", lambda index=None: capability
+    )
+    monkeypatch.setattr(torch.cuda, "get_device_name", lambda index=None: "TestGPU")
+    if remedy is None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            _warn_unsupported_gpu()
+        return
+    with pytest.warns(UserWarning, match="not built for") as record:
+        _warn_unsupported_gpu()
+    assert len(record) == 1, "identical GPUs must warn once, not once per device"
+    message = str(record[0].message)
+    assert remedy in message, f"remedy must suit sm_{capability[0]}{capability[1]}"
 
 
 def test_run_benchmark_cli_help_smoke(

--- a/neuralbench-repo/pyproject.toml
+++ b/neuralbench-repo/pyproject.toml
@@ -26,10 +26,9 @@ dependencies = [
   "pyriemann>=0.6",
   "seaborn",
   "torchinfo",
-  # Pinning torch version to ensure support for CUDA capability sm_60
-  "torch==2.6",
-  "torchaudio==2.6",
-  "torchvision==0.21",
+  "torch>=2.5.1",
+  "torchaudio>=2.5.1",
+  "torchvision>=0.20.1",
 ]
 
 [project.urls]


### PR DESCRIPTION
`neuralbench` pins `torch==2.6` / `torchaudio==2.6` / `torchvision==0.21` to keep CUDA
capability `sm_60` (Pascal) available. That forces every install of the package onto
exactly that stack, while `neuralset` and `neuraltrain` ask only for `torch>=2.5.1`.

The pin is the wrong lever: arch coverage comes from the wheel's CUDA variant, not the
torch version. From PyTorch's build matrix for 2.14.0 (x86_64):

| CUDA build | Architectures shipped | `sm_60` |
|---|---|---|
| 12.6 | 50, 60, 70, 75, 80, 86, 90 | yes |
| 13.0 / 13.2 | 75, 80, 86, 90, 100, 120 | no |

The `cu126` index publishes builds for every release through 2.14.0, all retaining
`sm_60`. What strands Pascal users is that PyPI's default wheel tracks the newest CUDA
(`CUDA_STABLE` is 13.0), so a plain `pip install torch` quietly gets a Pascal-less
build — as the 2.8.0 release notes put it, "If you need support for these
architectures, please utilize CUDA 12.6 instead."

So the three pins become the same floors as the sibling packages, and
`_warn_unsupported_gpu()` runs at CLI startup beside `_warn_slurm_partition`. It
compares each visible device's compute capability against the installed build's arch
list and names the remedy by direction: the `cu126` index for cards below the range, a
torch upgrade for cards above it. Release wheels are SASS-only, so the check applies
same-major / minor-not-greater compatibility rather than assuming PTX JIT.

Verified on a dual Quadro GP100 host. With the current `2.6.0+cu124` build (arch list
includes `sm_60`) the check is silent — no false positive. Against a simulated CUDA 13
arch list it emits one warning for the pair, deduplicated by capability:

> Quadro GP100 has CUDA capability sm_60, which torch 2.6.0+cu124 was not built for
> (built for sm_75, sm_80, sm_86, sm_90, sm_100, sm_120). GPU runs will fail; to fix,
> reinstall from a CUDA 12.6 build, which still ships sm_50-sm_90:
> `pip install --force-reinstall torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu126`

One consequence worth flagging for review: with no ceiling, CI resolves to the newest
torch whenever the monthly venv cache rotates, and the suite has not been run against
2.14. A `<3` bound would hedge that, at the cost of diverging from the siblings again.
