### PR TITLE
HuggingFacePCA: bound and self-clear the staging folder

### DIFF
--- a/neuralset-repo/neuralset/extractors/meta.py
+++ b/neuralset-repo/neuralset/extractors/meta.py
@@ -6,8 +6,9 @@
 
 import hashlib
 import logging
-import tempfile
+import shutil
 import typing as tp
+from pathlib import Path
 
 import exca
 import numpy as np
@@ -308,22 +309,27 @@ class HuggingFacePCA(ExtractorPCA):
 
     def prepare(self, obj: tp.Any) -> None:
         pca_events = self._prepare_pca_uid(obj)
+        if not isinstance(self.extractor, HuggingFaceMixin):  # for typing
+            raise TypeError("Only HuggingFaceText and HuggingFaceImage are supported")
+        basefolder = Path(self.extractor.infra.folder)
+        # uid-keyed (events + extractor): retries reuse it, other models can't rmtree it
+        uid_folder = self.extractor.infra.uid_folder()
+        staging = basefolder / f"HF-PCA-tmp-{self._uid},{uid_folder.name}"
         if not pca_events:
             logger.debug("In %r, all events for uid=%r are cached", self, self._uid)
+            if self.use_tmp_cache:
+                shutil.rmtree(staging, ignore_errors=True)  # kill leftover
             return  # all done
 
         from sklearn.decomposition import PCA
 
         # Note: all the PCA has to be done on prepare (in the main thread)
         # because it cannot be split and distributed onto many machines
-        if not isinstance(self.extractor, HuggingFaceMixin):  # for typing
-            raise TypeError("Only HuggingFaceText and HuggingFaceImage are supported")
         events = list(pca_events.values())
-        basefolder = self.extractor.infra.folder
-        with tempfile.TemporaryDirectory(prefix="HF-PCA-tmp", dir=basefolder) as tmp:
-            # change to a temporary folder folder that will be deleted
-            feat_folder = tmp if self.use_tmp_cache else basefolder
-            feat = self.extractor.infra.clone_obj(**{"infra.folder": feat_folder})
+        feat_folder = staging if self.use_tmp_cache else basefolder
+        feat = self.extractor.infra.clone_obj(**{"infra.folder": feat_folder})
+        embds: list[np.ndarray] = []
+        try:
             feat.prepare(events)
             embds = list(feat._get_data(events))  # N x Layer x *Embd
             # note: this may be too big to keep in memory, so we dont turn it to array
@@ -335,8 +341,9 @@ class HuggingFacePCA(ExtractorPCA):
                 pca = PCA(n_components=self.n_components, whiten=self.whiten)
                 layers.append(pca.fit_transform(layer))
                 del layer  # free memory if need be
+        finally:
+            # open fd + a peer's rmtree -> ".nfs*" ghost ("Device or resource busy")
             embds.clear()
-            # avoid keeping files open, explicitly delete cache
             del feat.infra._state.cache_dict
             del feat
         # back to N * Layer * prod(*Embd)
@@ -350,6 +357,9 @@ class HuggingFacePCA(ExtractorPCA):
                 if i_uid not in done:
                     w[i_uid] = d
                     done.add(i_uid)
+        # failures skip this: staging survives for the retry
+        if self.use_tmp_cache:
+            shutil.rmtree(staging, ignore_errors=True)
         logger.debug("%r.prepare finished with uid=%r", self, self._uid)
 
     def _get_timed_arrays(

--- a/neuralset-repo/neuralset/extractors/test_meta.py
+++ b/neuralset-repo/neuralset/extractors/test_meta.py
@@ -6,6 +6,7 @@
 
 import typing as tp
 from pathlib import Path
+from unittest import mock
 
 import numpy as np
 import pytest
@@ -167,6 +168,14 @@ def test_hf_pca(tmp_path: Path) -> None:
     for w in ["Hello", "world", "blublu", "whatever"]:
         c = w if w != "Hello" else ("blublu " * 64 + w)  # trigger key shortening
         events.append(etypes.Word(text=w, context=c, **kwargs))
+    with mock.patch("sklearn.decomposition.PCA", side_effect=RuntimeError("boom")):
+        with pytest.raises(RuntimeError):
+            feat.prepare(events)
+    staged = list(tmp_path.glob("HF-PCA-tmp-*"))
+    assert len(staged) == 1, "failure should keep one uid-keyed staging folder"
+    assert list(staged[0].rglob("*HuggingFaceText*")), "extraction was discarded"
+    msg = "staging must be keyed on the extractor, else another model shares it"
+    assert "cache_n_layers=3" in staged[0].name, msg
     feat.prepare(events)
     folder = feat.infra.uid_folder()
     assert folder is not None
@@ -182,6 +191,10 @@ def test_hf_pca(tmp_path: Path) -> None:
     assert len(dirs) == 1
     dirs = [f.name for f in folder.parent.iterdir()]
     assert len(dirs) == 1
+    # same folder as above: layers is excluded from the cached uid
+    (tmp_path / staged[0].name).mkdir()  # kill before the rmtree
+    feat.prepare(events)
+    assert not list(tmp_path.glob("HF-PCA-tmp-*")), "kill leftover not cleared"
 
 
 @pytest.mark.parametrize("offset", [0, 1.0])


### PR DESCRIPTION
## What does this PR do?

`HuggingFacePCA.prepare` staged its intermediate embeddings in a `tempfile.TemporaryDirectory`, which nothing cleans up after a SIGKILL (Slurm timeout, OOM, preemption). The name was random, so every killed attempt left another `HF-PCA-tmp*` folder behind — thousands of them in practice.

- Name the staging folder after the prepare uid *and* the extractor's `uid_folder()`. That bounds the leak to one folder per (event set, extractor): a retry lands on the same folder and reuses the extraction, while a different model gets its own and cannot `rmtree` a peer's.
- Release the extractor cache in a `finally`. `del feat.infra._state.cache_dict` only ran on the success path, so a failed prepare left an fd open on a staged file — deleting a still-open file over NFS is what leaves `.nfs*` entries and `[Errno 16] Device or resource busy`.
- Clear the staging folder once the PCA is cached, including the everything-already-cached early return, so leftovers from a killed run go away.

## Checklist

- [x] Tests added or updated
- [x] Docstrings updated for any changed public APIs
- [x] `pytest` and `mypy` pass locally

Co-authored-by: Sophia Houhamdi <151393783+shouhamdi@users.noreply.github.com>