### PR TITLE
Fix timeline infra in chains

### DIFF
--- a/neuralset-repo/neuralset/events/study.py
+++ b/neuralset-repo/neuralset/events/study.py
@@ -255,7 +255,7 @@ class TimelineLoader(base.Step):
 
     CACHE_TYPE: tp.ClassVar[str | None] = "ValidatedParquet"  # preserves str dtypes
 
-    # Study.model_post_init reverts this to None when no cache folder resolves
+    # Study._body downgrades this to inline when no cache folder resolves
     infra: backends.Backend | None = backends.ProcessPool(keep_in_ram=True)
 
     def _run(self, events: pd.DataFrame) -> pd.DataFrame:
@@ -319,6 +319,7 @@ class Study(patterns.Scatter, base.Step):  # type: ignore[misc]
     _timelines: list[dict[str, tp.Any]] | None = (
         None  # iter_timelines() memo; dropped at pickle
     )
+    _inline_loader: TimelineLoader | None = None
 
     # Class level info
     _info: tp.ClassVar[None | StudyInfo] = None  # for easy testing
@@ -509,10 +510,6 @@ class Study(patterns.Scatter, base.Step):  # type: ignore[misc]
             self.path = self.path / name
         STUDY_PATHS[self.__class__.__name__] = self.path  # record for path lookup
 
-        if "infra" not in self.timelines.model_fields_set:
-            if self.infra is None or self.infra.folder is None:
-                self.timelines.infra = None  # a backend needs a folder
-
     def __init_subclass__(cls, **kwargs: tp.Any) -> None:
         name = cls.__name__
         super().__init_subclass__(**kwargs)
@@ -615,6 +612,17 @@ class Study(patterns.Scatter, base.Step):  # type: ignore[misc]
             raise RuntimeError(msg)
         self._timelines = tls
         return tls
+
+    def _body(self) -> base.Step:
+        """The timeline loader, inline when no cache folder resolves."""
+        loader = self.timelines
+        if "infra" in loader.model_fields_set or loader.infra is None:
+            return loader  # explicit choice
+        if loader.infra.folder is not None:
+            return loader
+        if self._inline_loader is None:
+            self._inline_loader = loader.model_copy(update={"infra": None})
+        return self._inline_loader
 
     def branches(self, item: tp.Any) -> list[dict[str, tp.Any]]:
         """Query-selected timeline dicts to load, one per branch (``item`` is unused)."""

--- a/neuralset-repo/neuralset/events/test_study.py
+++ b/neuralset-repo/neuralset/events/test_study.py
@@ -460,6 +460,7 @@ def test_raw_studychain(tmp_path: Path, as_dict: bool) -> None:
         {
             "name": "Test2023Meg",
             "path": tmp_path / "data",
+            "timelines": {"infra": None},  # no multiproc in tests
         },
         {"name": "FakeChapter", "path": tmp_path, "infra": infra},  # cache
         {"name": "ChunkEvents", "event_type_to_chunk": "Audio", "max_duration": 5.0},
@@ -487,6 +488,7 @@ def test_bad_transform(tmp_path: Path):
         {
             "name": "FakeData2025",
             "path": tmp_path,
+            "timelines": {"infra": None},
         },
         {"name": "BadEnhancer"},
     ]
@@ -527,21 +529,19 @@ def test_study_discovery(tmp_path: Path) -> None:
 def test_intermediary_study_cache(tmp_path: Path) -> None:
     infra: tp.Any = {"backend": "Cached", "folder": tmp_path}
     steps: list[tp.Any] = [
-        # cache after study as it can be slow
         {
             "name": "Fake2025Meg",
             "path": ns.CACHE_FOLDER,
-            "infra": infra,
-            "timelines": {"infra": {"backend": "Cached"}},
+            "infra": infra,  # cache after study as it can be slow
+            "timelines": {"infra": {"backend": "Cached"}},  # no multiproc in tests
         },
-        #  Cache after chunking - useful if chunking is slow
         {
             "name": "ChunkEvents",
             "event_type_to_chunk": "Audio",
             "max_duration": 5.0,
-            "infra": infra,
+            "infra": infra,  # cache: useful if chunking is slow
         },
-        # Step 4: Cache after chunking - useful if chunking is slow
+        # Step 4: fast filtering -> no caching
         {"name": "QueryEvents", "query": "type in ['Audio', 'Word', 'Meg']"},
     ]
     chain = ns.Chain(steps=steps, infra=infra)
@@ -562,9 +562,18 @@ def test_intermediary_study_cache(tmp_path: Path) -> None:
     assert chain_caches == {study, chunk, query, loader}
 
 
+def test_timelines_cache_with_chain_folder(tmp_path: Path) -> None:
+    steps: tp.Any = [{"name": "Fake2025Meg", "path": ns.CACHE_FOLDER}]
+    infra: tp.Any = {"backend": "Cached", "folder": tmp_path}
+    ns.Chain(steps=steps, infra=infra).run()
+    caches = set(extract_cache_folders(tmp_path))
+    loader = "version=v3,name=Fake2025Meg-ff4b4eb4/name=TimelineLoader-99bb1625"
+    assert loader in caches, f"chain folder must reach the loader, got {caches}"
+
+
 def test_validate_events_in_steps(tmp_path: Path) -> None:
     steps: list[tp.Any] = [
-        {"name": "Fake2025Meg", "path": ns.CACHE_FOLDER},
+        {"name": "Fake2025Meg", "path": ns.CACHE_FOLDER, "timelines": {"infra": None}},
         {"name": "ChunkEvents", "event_type_to_chunk": "Audio", "max_duration": 5.0},
     ]
     infra: tp.Any = {"backend": "Cached", "folder": tmp_path}
@@ -583,7 +592,7 @@ def test_sub_chain(tmp_path) -> None:
     # Main chain that uses the sub-chain
     steps = [
         # Step 1: Load the study
-        {"name": "Fake2025Meg", "path": ns.CACHE_FOLDER},
+        {"name": "Fake2025Meg", "path": ns.CACHE_FOLDER, "timelines": {"infra": None}},
         # Step 2: Apply audio preprocessing sub-chain
         audio_subchain,
         # Step 3: Filter to relevant events

--- a/neuralset-repo/neuralset/events/transforms/test_transforms.py
+++ b/neuralset-repo/neuralset/events/transforms/test_transforms.py
@@ -834,7 +834,8 @@ def _custom_study(test_data_path: Path, tmp_path: Path) -> ns.Chain:
 
     create_wav(tmp_path / "noise.wav", fs=44100, duration=10)
     steps: list[tp.Any] = [
-        {"name": "Test2023Meg", "path": test_data_path},
+        # no multiproc in tests
+        {"name": "Test2023Meg", "path": test_data_path, "timelines": {"infra": None}},
         FakeChapter(path=tmp_path, infra="Cached"),  # type: ignore
         "Nothing",
         _transf.ChunkEvents(event_type_to_chunk="Audio", max_duration=5.0),


### PR DESCRIPTION
## Problem
`Study.model_post_init` decided `timelines.infra` at construction, dropping the
per-timeline backend whenever no folder had resolved yet. A Study inside a Chain
gets its folder propagated *after* construction, so the backend was silently
discarded: timelines loaded sequentially and uncached, with no warning.

## Fix
`Study._body()` makes the choice when the body is used, returning a memoized
inline variant instead of assigning `timelines.infra`. Assignment would break on
frozen trees, and would alter the `exclude_defaults` dump and trip the uid
collision check; a variant keeps the dumped config exactly as validated.
Cache folders are unchanged: `timelines` is excluded from the Study uid and
`infra` from the loader's, so all `timelines.infra` settings share one tree.

## Checklist

- [x] Tests added or updated
- [x] Docstrings updated for any changed public APIs
- [x] `pytest` and `mypy` pass locally