### PR TITLE
neuralbench: add a Bring-Your-Own-Model evaluation API

### DIFF
--- a/docs/neuralbench/api.rst
+++ b/docs/neuralbench/api.rst
@@ -30,17 +30,23 @@ Core
 
    BrainModule
 
-CLI
----
+Running the benchmark
+---------------------
 
-.. currentmodule:: neuralbench.cli
+Three entry points onto the same experiments -- the ``neuralbench`` command, the
+same selections from Python, and one model you built over a selection.  They are
+compared in the :doc:`quickstart <auto_examples/quickstart/index>`.
+
+.. currentmodule:: neuralbench
 
 .. autosummary::
    :toctree: generated/
    :nosignatures:
 
-   run_benchmark
    run_benchmark_cli
+   run_benchmark
+   check_model
+   evaluate_model
 
 Events Transforms
 -----------------

--- a/docs/neuralbench/index.rst
+++ b/docs/neuralbench/index.rst
@@ -73,12 +73,12 @@ comparison figures and tables from the stored results (no retraining):
    :gutter: 2
 
    .. grid-item-card:: :fas:`rocket` Quickstart
-      :link: auto_examples/quickstart/01_run_first_task
+      :link: auto_examples/quickstart/index
       :link-type: doc
       :class-card: sd-shadow-sm
 
-      Run your first benchmark task: CLI usage, debug mode, model
-      switching, and hyperparameter grids.
+      Run your first benchmark task, three ways: the CLI, the same
+      selections from Python, and a model of your own.
 
    .. grid-item-card:: :fas:`chart-bar` Visualizing Results
       :link: auto_examples/results/plot_visualize_results

--- a/docs/neuralbench/tutorials/01_quickstart/01_run_first_task.py
+++ b/docs/neuralbench/tutorials/01_quickstart/01_run_first_task.py
@@ -222,6 +222,12 @@ results programmatically.
 # Next steps
 # ----------
 #
+# - :doc:`Drive the same runs from Python
+#   </neuralbench/auto_examples/quickstart/02_using_python_api>` when the
+#   benchmark is one step of a scripted workflow.
+# - :doc:`Evaluate a model of your own
+#   </neuralbench/auto_examples/quickstart/03_evaluate_your_own_model>`, with no
+#   config in this repo.
 # - :doc:`Visualize results
 #   </neuralbench/auto_examples/results/plot_visualize_results>` from
 #   completed experiments.

--- a/docs/neuralbench/tutorials/01_quickstart/02_using_python_api.py
+++ b/docs/neuralbench/tutorials/01_quickstart/02_using_python_api.py
@@ -2,13 +2,16 @@
 Using the Python API
 =====================
 
-As an alternative to the :doc:`CLI
-</neuralbench/auto_examples/quickstart/01_run_first_task>`,
-NeuralBench also exposes a Python function
-:func:`~neuralbench.run_benchmark` that lets you launch experiments
-directly from a script or notebook.  This is convenient when you want
-to integrate benchmark runs into a larger workflow or inspect results
-programmatically without parsing log files.
+:func:`~neuralbench.run_benchmark` launches the same experiments as the
+:doc:`CLI </neuralbench/auto_examples/quickstart/01_run_first_task>` -- same
+YAML configs, same selections, same cache -- from a script or notebook.  Reach
+for it when a benchmark run is one step of a larger workflow you are scripting.
+
+Two things it is not.  It takes a model *name*, so a model of your own goes
+through :doc:`evaluate_model
+</neuralbench/auto_examples/quickstart/03_evaluate_your_own_model>` instead.
+And it launches runs rather than collecting them, which the :doc:`results
+tutorial </neuralbench/auto_examples/results/plot_visualize_results>` covers.
 """
 
 # %%
@@ -41,15 +44,38 @@ programmatically without parsing log files.
 #
 #    from neuralbench import run_benchmark
 #
-#    results = run_benchmark(
+#    run_benchmark(
 #        device="eeg",
 #        task="audiovisual_stimulus",
 #        debug=True,
 #    )
 #
-#    print(f"Got {len(results)} result(s)")
-#    for r in results:
-#        print(r)
+
+# %%
+# What comes back
+# ---------------
+#
+# Nothing, in every mode but one: the call launches experiments and returns an
+# empty list, the results being written to the results folder under each
+# experiment's UID.  Two ways to get them in hand:
+#
+# - ``plot_cached=True`` returns the cached results it plotted, and runs
+#   nothing.  This is the CLI's ``--plot-cached``.
+# - ``BenchmarkAggregator`` collects them directly, which is what the
+#   :doc:`results tutorial
+#   </neuralbench/auto_examples/results/plot_visualize_results>` uses for
+#   comparison plots and tables.
+#
+# .. code-block:: python
+#
+#    results = run_benchmark(
+#        device="eeg",
+#        task="audiovisual_stimulus",
+#        plot_cached=True,
+#    )
+#
+# :func:`~neuralbench.evaluate_model` is the entry point that returns results
+# from the runs it launched, as a frame.
 #
 
 # %%
@@ -79,34 +105,31 @@ programmatically without parsing log files.
 #
 # .. code-block:: python
 #
-#    results = run_benchmark(
+#    run_benchmark(
 #        device="eeg",
 #        task=["audiovisual_stimulus", "sex"],
 #        model=["eegnet", "deep4net"],
 #        debug=True,
 #    )
 #
-#    print(f"Ran {len(results)} experiment(s)")
-#
 
 # %%
-# Controlling random seeds
-# ------------------------
+# Sweeping seeds
+# --------------
 #
-# The ``seeds`` parameter overrides the grid's seed list (default
-# ``[33]``).  Passing multiple seeds generates one experiment per
-# seed, which is useful for estimating variance.
+# Seeds come from the grid rather than from a parameter: ``grid=True`` expands
+# the task's ``grid.yaml`` on top of ``defaults/grid.yaml``, whose default
+# sweep is the seed list ``[33, 34, 35]``.  That gives one experiment per seed,
+# which is what a variance estimate needs.
 #
 # .. code-block:: python
 #
-#    results = run_benchmark(
+#    run_benchmark(
 #        device="eeg",
 #        task="audiovisual_stimulus",
-#        debug=True,
-#        seeds=[33, 34, 35],
+#        model="reve",
+#        grid=True,
 #    )
-#
-#    print(f"Ran {len(results)} experiment(s) (one per seed)")
 #
 
 # %%

--- a/docs/neuralbench/tutorials/01_quickstart/03_evaluate_your_own_model.py
+++ b/docs/neuralbench/tutorials/01_quickstart/03_evaluate_your_own_model.py
@@ -1,0 +1,306 @@
+"""
+Evaluating your own model
+=========================
+
+The :doc:`CLI </neuralbench/auto_examples/quickstart/01_run_first_task>` and
+:func:`~neuralbench.run_benchmark` both take a model *name*, which means the
+model has to live in this repo with a ``models/*.yaml`` beside it.  When your
+model lives in your own codebase, use :func:`~neuralbench.evaluate_model`
+instead: it takes the model itself and needs no files here.
+
+It takes your model *already built*, weights and all.  One instance then serves
+every task in the selection, which is only possible for a model that adapts to
+its input, so this path asks two things of it:
+
+* it accepts any channel count and any window length, since tasks differ in
+  montage and epoch length -- from a 3-electrode sensorimotor strip to a
+  128-channel cap;
+* it reads channel identity in ``forward`` rather than from a montage fixed at
+  construction.  ``channel_positions`` is always passed; a ``forward`` that
+  also names ``ch_names`` is handed the dataset's electrode names, which is
+  what a model keyed by name rather than by coordinate needs.
+
+What it does *not* need is a classifier head.  NeuralBench wraps your model in a
+probe sized to each task's number of classes, so the same backbone can serve a
+4-class motor imagery task and a 2-class P300 task unchanged.
+"""
+
+# %%
+# A model to evaluate
+# -------------------
+#
+# This one encodes each channel's time course into tokens, adds a per-channel
+# embedding derived from that channel's 3D position, then pools over channels.
+# The output keeps a time axis -- ``(batch, tokens, width)``, the usual shape a
+# transformer encoder produces -- and the number of tokens follows the input
+# length, which is fine: the probe pools over them.
+
+from torch import nn
+
+
+class TinyFm(nn.Module):
+    """A small position-conditioned encoder, adaptive in channels and time."""
+
+    def __init__(self, width: int = 64) -> None:
+        super().__init__()
+        self.width = width
+        # Channel identity comes from the position, so an unseen montage needs
+        # no new parameters -- which is what lets one instance span datasets.
+        self.pos_embedding = nn.Linear(3, width)
+        self.encoder = nn.Conv1d(1, width, kernel_size=17, stride=8, padding=8)
+        self.norm = nn.LayerNorm(width)
+
+    def forward(self, x, channel_positions):
+        # x: (batch, channels, samples)
+        # channel_positions: (batch, channels, 3)
+        batch, channels, samples = x.shape
+
+        # Encode every channel with the same temporal filters.
+        tokens = self.encoder(x.reshape(batch * channels, 1, samples))
+        tokens = tokens.reshape(batch, channels, self.width, -1)
+        tokens = tokens.permute(0, 1, 3, 2)  # (batch, channels, tokens, width)
+
+        tokens = tokens + self.pos_embedding(channel_positions).unsqueeze(2)
+        return self.norm(tokens.mean(1))  # (batch, tokens, width)
+
+
+# %%
+# Check it before you queue anything
+# ----------------------------------
+#
+# :func:`~neuralbench.check_model` pushes a synthetic batch of the selection's
+# shapes through the model, at several montage widths. It reads only YAML, so it
+# takes seconds and needs no downloaded data -- which is the point, since the
+# alternative is discovering a shape bug an hour into a real run.
+#
+# .. code-block:: python
+#
+#    from neuralbench import check_model
+#
+#    print(check_model(TinyFm(), "eeg", "motor_imagery"))
+#
+# ::
+#
+#             task  n_spatial_locations  n_temporal_samples status  output_shape
+#    0  motor_imagery                 3                 480     ok  (2, 60, 64)
+#    1  motor_imagery                19                 480     ok  (2, 60, 64)
+#    2  motor_imagery                64                 480     ok  (2, 60, 64)
+#    3  motor_imagery               128                 480     ok  (2, 60, 64)
+#
+# A model that only handles one montage width shows up as ``ok`` on one row and
+# ``forward failed: ...`` on the others. Pass the same ``task`` and ``dataset``
+# you intend to run: dataset variants can shorten a task's window, and each
+# distinct window gets its own rows.
+#
+# A ``forward`` that does not accept ``channel_positions`` at all raises instead
+# of filling the ``status`` column, being a property of the model rather than of
+# any one task.
+
+# %%
+# Run it
+# ------
+#
+# ``device`` and ``task`` mean what they mean on the CLI, so ``task="all"``
+# runs every validated task for the device. Start with ``debug=True``: it runs
+# locally on a reduced config (2 epochs, 5 batches, a data subset).
+#
+# .. code-block:: python
+#
+#    from neuralbench import evaluate_model
+#
+#    scores = evaluate_model(
+#        TinyFm(),
+#        "eeg",
+#        "motor_imagery",
+#        name="tiny-fm",
+#        dataset=["schalk2004bci2000", "leeb2007"],
+#        debug=True,
+#    )
+#    print(scores[["dataset_name", "test/bal_acc", "n_total_params",
+#                  "n_trainable_params"]])
+#
+# ::
+#
+#            dataset_name  test/bal_acc  n_total_params  n_trainable_params
+#    0  Schalk2004Bci2000         0.258             900                 132
+#    1      Leeb2007Brain         0.475             834                  66
+#
+# Those two datasets have 64 and 3 channels respectively, and one instance
+# served both. The parameter counts show the split: the backbone is identical
+# across the rows, and only the probe differs -- 132 trainable parameters for
+# Schalk's 4 classes against 66 for Leeb's 2.
+#
+# Build the model however you normally would -- ``model.load_state_dict(...)``
+# and all -- and ``evaluate_model`` takes it from there. The instance is
+# serialized once to the cache folder and reloaded fresh for each experiment, so
+# weights that one run fine-tunes never leak into the next, and the weights
+# themselves take part in the cache key: change them and you get new runs rather
+# than stale cached results.
+
+# %%
+# How your model is adapted to each task
+# --------------------------------------
+#
+# ``downstream_wrapper`` chooses the adaptation strategy, and with it where the
+# task's classifier head comes from. The default, ``linear_probe_mean``, freezes
+# your model and trains a linear probe on its mean-pooled output.
+#
+# .. code-block:: python
+#
+#    scores = evaluate_model(
+#        TinyFm(), "eeg", "all", downstream_wrapper="finetune_mean"
+#    )
+#
+# Prefer the ``_mean`` presets here. ``flatten`` builds the probe from the
+# flattened output instead, which for an adaptive model makes the probe's size a
+# function of the dataset -- on the run above it would be 8196 trainable
+# parameters for the 64-channel dataset against 194 for the 3-channel one. It
+# works, but head capacity then varies with montage density and window length,
+# which is not something you want varying underneath a benchmark number.
+
+# %%
+# Suites
+# ------
+#
+# The dataset selection decides which suite you are running, exactly as it does
+# on the CLI (see :ref:`Benchmark suites <benchmark-suites>`):
+#
+# .. list-table::
+#    :header-rows: 1
+#    :widths: 40 60
+#
+#    * - Call
+#      - Suite
+#    * - ``evaluate_model(m, "eeg", "all")``
+#      - ``NeuralBench-EEG-Core`` (one dataset per task)
+#    * - ``evaluate_model(m, "eeg", "all", dataset="all")``
+#      - ``NeuralBench-EEG-Full`` (every dataset per task)
+
+# %%
+# Downloading, caching, and where the runs happen
+# -----------------------------------------------
+#
+# Two things have to happen before an experiment can train, and neither is
+# automatic: the dataset has to be on disk, and the preprocessed data has to be
+# in the cache.  :func:`~neuralbench.evaluate_model` does both first, in that
+# order, because preprocessing needs the downloaded files.  Once warm, both
+# phases are a cheap status check, so leave them on; turn them off only when you
+# know the state of the cache.  Warming it for a whole device takes hours, and
+# it is the same work the CLI does with ``--download`` and ``--prepare``, so a
+# cache warmed either way serves the other.
+#
+# Everything then runs in the current process, which is usually what you want in
+# a notebook, and which means a full suite can take a very long time. Pass
+# ``cluster="auto"`` to fan the experiments out to SLURM where one is available:
+#
+# .. code-block:: python
+#
+#    scores = evaluate_model(
+#        TinyFm(), "eeg", "all", name="my-fm", cluster="auto",
+#        download=False,   # datasets already on disk
+#        prepare=False,    # caches already warm
+#    )
+#
+# That call returns as soon as the jobs are queued, so the frame holds whatever
+# had already finished -- nothing, the first time. Call it again with the same
+# arguments to collect: completed experiments are not resubmitted, exactly as
+# when re-running the CLI. With ``prepare=True`` the first call queues the cache
+# warm-up alone and stops there, since the experiments would otherwise race it.
+#
+# Results never raise on a failed experiment. You get the rows that exist, and
+# the rest are reported in a printed table where ``!n`` marks jobs that errored
+# out as opposed to ones still pending.
+
+# %%
+# Changing the protocol
+# ---------------------
+#
+# ``overrides`` takes any config key, as dotted keys or nested dicts, and is
+# applied on top of the defaults and the task config:
+#
+# .. code-block:: python
+#
+#    scores = evaluate_model(
+#        TinyFm(),
+#        "eeg",
+#        "all",
+#        overrides={
+#            "data.neuro.frequency": 200.0,                    # preprocessing
+#            "lightning_optimizer_config.optimizer.lr": 1e-4,  # optimization
+#            "trainer_config.n_epochs": 50,
+#        },
+#    )
+#
+# Whatever you pass is recorded in the frame's ``overrides`` column, so a run
+# with a changed protocol is never mistaken for a stock one.
+#
+# Be careful with keys that define *what a task measures* -- the epoch window
+# (``data.start`` / ``data.duration``), the target extractor, the splits, the
+# loss, the metrics.  Changing those produces a number that is not comparable
+# to any other entry on the suite, including the published baselines.
+
+# %%
+# A worked example: pretrained REVE
+# ---------------------------------
+#
+# The foundation models the benchmark ships with are ordinary modules too, so
+# one of them makes a good end-to-end example.  REVE is a braindecode model and
+# ``NtReve`` is the config that builds it: ``n_outputs=None`` asks for the
+# encoder alone, since the probe supplies the head, and the width and window
+# length only size the build -- the instance reads the montage it actually gets
+# from ``channel_positions`` on every call.
+#
+# .. note::
+#    The weights are pulled from the Hugging Face hub at build time, so the
+#    first build needs a Hugging Face account: run ``huggingface-cli login``, or
+#    set ``HF_TOKEN`` in the environment, beforehand.  Later builds read them
+#    from the local hub cache and need no network.
+#
+# .. code-block:: python
+#
+#    from neuraltrain.models.reve import NtReve
+#
+#    model = NtReve(from_pretrained_name="brain-bzh/reve-base").build(
+#        n_spatial_locations=64,
+#        n_temporal_samples=400,
+#        n_outputs=None,
+#    )
+#
+# A pretrained model expects the preprocessing it was trained with rather than
+# the task default, which is what ``overrides`` is for.  These values are
+# REVE's, read off ``models/reve.yaml``:
+#
+# .. code-block:: python
+#
+#    scores = evaluate_model(
+#        model,
+#        "eeg",
+#        "motor_imagery",
+#        name="reve-base",
+#        overrides={
+#            "data.neuro.frequency": 200.0,
+#            "data.neuro.filter": [0.5, 99.5],
+#            "data.neuro.notch_filter": None,
+#            "data.neuro.baseline": None,
+#            "data.neuro.scaler": "StandardScaler",
+#            "data.neuro.clamp": 15,
+#            # REVE's position bank is in head-frame metres, not normalised.
+#            "data.channel_positions.normalize": False,
+#        },
+#        debug=True,
+#    )
+#
+# Same configuration, same number as the CLI.  The call above matches ``-m reve
+# -w linear_probe_mean`` rather than a bare ``-m reve``, which reads its
+# adaptation strategy and its channel mapping from ``models/reve.yaml`` instead.
+
+# %%
+# What the Slurm jobs need
+# ------------------------
+#
+# Off ``debug=True``, experiments run as Slurm jobs in separate processes, which
+# rebuild the model from the serialized instance. Classes defined in a script, a
+# notebook or an uninstalled checkout are stored in it whole, so there is
+# nothing to package and nothing to put on the jobs' ``PYTHONPATH``. Code from
+# *installed* packages is stored by import path instead: a model that imports,
+# say, ``timm`` needs ``timm`` in the environment the jobs run in.

--- a/docs/neuralbench/tutorials/01_quickstart/GALLERY_HEADER.rst
+++ b/docs/neuralbench/tutorials/01_quickstart/GALLERY_HEADER.rst
@@ -3,5 +3,42 @@ Quickstart
 
 Run your first neuralbench evaluation in a few commands.
 
+Which entry point?
+------------------
+
+The same experiments are reachable three ways -- same YAML configs, same cache,
+same results folder.  What decides between them is where your model lives and
+what you want handed back.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 16 28 28 28
+
+   * -
+     - ``neuralbench`` CLI
+     - ``run_benchmark()``
+     - ``evaluate_model()``
+   * - Names the model
+     - registered name (``-m reve``)
+     - registered name (``model="reve"``)
+     - an ``nn.Module`` you built
+   * - Covers
+     - tasks x datasets x models x grid
+     - the same selections
+     - one instance, over tasks and datasets
+   * - Hands back
+     - results on disk; ``--plot-cached`` for figures and tables
+     - the same, from Python
+     - the results, as a ``DataFrame``
+   * - Runs on
+     - Slurm, or locally with ``--debug``
+     - the same
+     - this process, or Slurm with ``cluster="auto"``
+
+Reach for the CLI to run or reproduce the benchmark, for
+:func:`~neuralbench.run_benchmark` to drive those same runs from a script, and
+for :func:`~neuralbench.evaluate_model` while developing a model that has no
+config in this repo.  The three tutorials below follow that order.
+
 .. note::
    📥 **You can download these tutorials with the buttons at the bottom of each page.**

--- a/neuralbench-repo/README.md
+++ b/neuralbench-repo/README.md
@@ -68,6 +68,24 @@ neuralbench fmri image --debug          # fMRI image retrieval in debug mode
 neuralbench emg typing -m emg2qwerty --debug   # EMG → keystroke CTC decoding (emg2qwerty)
 ```
 
+## Three ways to run it
+
+The CLI, `run_benchmark()` and `evaluate_model()` launch the same experiments, from the same YAML configs and against the same cache. Which one you want depends on where your model lives and what you want handed back:
+
+- **`neuralbench eeg <task>`** — run or reproduce the benchmark with a model registered in this repo. Results land in the results folder; `--plot-cached` turns them into figures and tables.
+- **`run_benchmark(device="eeg", task=...)`** — the same selections from a script or notebook, launched the same way.
+- **`evaluate_model(model, "eeg", ...)`** — a `torch.nn.Module` you built, weights and all, with no config in this repo. One instance serves every task in the selection, and the results come back as a DataFrame.
+
+```python
+from neuralbench import check_model, evaluate_model
+
+print(check_model(my_model, "eeg", "motor_imagery"))  # shapes only: seconds, no data
+scores = evaluate_model(my_model, "eeg", "motor_imagery", name="my-fm", debug=True)
+```
+
+> [!TIP]
+> The [quickstart tutorials](https://facebookresearch.github.io/neuroai/neuralbench/auto_examples/quickstart/index.html) compare the three side by side, one tutorial each.
+
 ## Running the full EEG benchmark
 
 To run all 36 EEG tasks end-to-end:

--- a/neuralbench-repo/neuralbench/__init__.py
+++ b/neuralbench-repo/neuralbench/__init__.py
@@ -7,12 +7,16 @@
 from . import (
     baselines as _baselines,  # noqa: F401  # registers fit-once baseline configs
 )
+from . import (
+    external as _external,  # noqa: F401  # registers the ExternalModel config
+)
 from . import metrics as _metrics  # noqa: F401  # registers custom metric configs
 from . import (
     transforms as _transforms,  # noqa: F401  # registers custom Event/Step subclasses
 )
 from .cli import run_benchmark, run_benchmark_cli
 from .data import get_default_dataloaders
+from .evaluate import check_model, evaluate_model
 from .utils import SequenceLabelEncoder
 
 # ``SequenceLabelEncoder`` is re-exported so importing ``neuralbench``
@@ -21,7 +25,9 @@ from .utils import SequenceLabelEncoder
 # without an explicit import.
 __all__ = [
     "SequenceLabelEncoder",
+    "check_model",
+    "evaluate_model",
+    "get_default_dataloaders",
     "run_benchmark",
     "run_benchmark_cli",
-    "get_default_dataloaders",
 ]

--- a/neuralbench-repo/neuralbench/aggregator.py
+++ b/neuralbench-repo/neuralbench/aggregator.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import logging
 import typing as tp
+from collections import Counter
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
@@ -171,12 +172,16 @@ class BenchmarkAggregator(ns.BaseModel):
     @staticmethod
     def _process_one_experiment(
         experiment: "Experiment", cached_only: bool
-    ) -> tuple[dict[str, tp.Any] | None, str, str]:
-        """Process one experiment, returning ``(result_or_None, task, model)``."""
+    ) -> tuple[dict[str, tp.Any] | None, str, str, str]:
+        """Process one experiment, returning ``(result_or_None, task, model, status)``.
+
+        The status distinguishes an experiment that errored out from one that
+        simply has not run yet, which otherwise look identical in the table.
+        """
         task = experiment.task_name
         model = experiment.brain_model_name
-        if cached_only and experiment.infra.status() != "completed":
-            return None, task, model
+        if cached_only and (status := experiment.infra.status()) != "completed":
+            return None, task, model, status
         out = experiment.run()
         out["task_name"] = experiment.task_name
         study = experiment.data.study
@@ -189,7 +194,7 @@ class BenchmarkAggregator(ns.BaseModel):
         out["loss"] = {"name": type(experiment.loss).__name__}
         out["seed"] = experiment.seed
         out["eval_mode"] = _infer_eval_mode(experiment)
-        return out, task, model
+        return out, task, model, "completed"
 
     def _collect_results(self, cached_only: bool = False) -> list[dict[str, tp.Any]]:
         """Gather experiment results, optionally skipping uncached ones.
@@ -201,49 +206,48 @@ class BenchmarkAggregator(ns.BaseModel):
             return self._collect_results_parallel()
         return self._collect_results_sequential(cached_only=False)
 
-    def _collect_results_sequential(
-        self, cached_only: bool = False
+    def _tally(
+        self, outcomes: tp.Iterable[tuple[dict[str, tp.Any] | None, str, str, str]]
     ) -> list[dict[str, tp.Any]]:
+        """Keep the results out of *outcomes*, tabling what was skipped."""
         results: list[dict[str, tp.Any]] = []
-        total: dict[tuple[str, str], int] = {}
-        skipped: dict[tuple[str, str], int] = {}
-        for experiment in self.experiments:
-            out, task, model = self._process_one_experiment(experiment, cached_only)
-            key = (task, model)
-            total[key] = total.get(key, 0) + 1
+        total: Counter[tuple[str, str]] = Counter()
+        skipped: Counter[tuple[str, str]] = Counter()
+        failed: Counter[tuple[str, str]] = Counter()
+        for out, task, model, status in outcomes:
+            total[task, model] += 1
             if out is None:
-                skipped[key] = skipped.get(key, 0) + 1
+                skipped[task, model] += 1
+                if status == "failed":
+                    failed[task, model] += 1
             else:
                 results.append(out)
         if skipped:
-            print_skip_table(total, skipped)
+            print_skip_table(total, skipped, failed)
         return results
 
+    def _collect_results_sequential(
+        self, cached_only: bool = False
+    ) -> list[dict[str, tp.Any]]:
+        return self._tally(
+            self._process_one_experiment(exp, cached_only) for exp in self.experiments
+        )
+
     def _collect_results_parallel(self) -> list[dict[str, tp.Any]]:
-        results: list[dict[str, tp.Any]] = []
-        total: dict[tuple[str, str], int] = {}
-        skipped: dict[tuple[str, str], int] = {}
         n_workers = min(self.collect_max_workers, len(self.experiments))
         with ThreadPoolExecutor(max_workers=n_workers) as pool:
-            futures = {
-                pool.submit(self._process_one_experiment, exp, True): exp
+            futures = [
+                pool.submit(self._process_one_experiment, exp, True)
                 for exp in self.experiments
-            }
-            for future in tqdm(
-                as_completed(futures),
-                total=len(futures),
-                desc="Collecting cached results",
-            ):
-                out, task, model = future.result()
-                key = (task, model)
-                total[key] = total.get(key, 0) + 1
-                if out is None:
-                    skipped[key] = skipped.get(key, 0) + 1
-                else:
-                    results.append(out)
-        if skipped:
-            print_skip_table(total, skipped)
-        return results
+            ]
+            return self._tally(
+                future.result()
+                for future in tqdm(
+                    as_completed(futures),
+                    total=len(futures),
+                    desc="Collecting cached results",
+                )
+            )
 
     def _save_computational_stats(self, results: list[dict[str, tp.Any]]) -> Path:
         """Write per-experiment computational stats to JSON for later analysis."""
@@ -270,6 +274,10 @@ class BenchmarkAggregator(ns.BaseModel):
             json.dump(stats, f, indent=2)
         LOGGER.info("Saved computational stats to %s", out_path)
         return out_path
+
+    def collect(self, cached_only: bool = True) -> list[dict[str, tp.Any]]:
+        """Gather results, without the plots, tables and stats files :meth:`run` writes."""
+        return self._collect_results(cached_only=cached_only)
 
     def run(self, cached_only: bool = False) -> list[dict[str, tp.Any]]:
         results = self._collect_results(cached_only=cached_only)

--- a/neuralbench-repo/neuralbench/cli.py
+++ b/neuralbench-repo/neuralbench/cli.py
@@ -19,28 +19,14 @@ import sys
 import traceback
 import typing as tp
 
-from exca import ConfDict
-
-from neuralbench.experiment_config import (
-    _warn_slurm_partition,
-    _warn_unsupported_gpu,
-    prepare_task_configs,
-)
+from neuralbench.experiment_config import build_experiment_configs
 from neuralbench.registry import (
     ALL_DEVICES,
     ALL_DOWNSTREAM_WRAPPERS,
     ALL_MODELS,
     ALL_TASKS,
     ALL_UNVALIDATED_TASKS,
-    DEFAULTS_DIR,
-    DEVICE_FM_MODELS,
-    FM_MODELS,
-    _expand_models,
     _format_datasets_epilog,
-    _resolve_datasets,
-    _resolve_tasks,
-    _validate_inputs,
-    load_yaml_config,
 )
 
 logger = logging.getLogger(__name__)
@@ -64,9 +50,10 @@ def run_benchmark(
 ) -> list[dict[str, tp.Any]]:
     """Run one or more NeuralBench experiments from Python.
 
-    This is the programmatic equivalent of the ``neuralbench`` CLI.
-    It assembles experiment configs from the same YAML files and returns
-    test-metric dictionaries when running in debug mode.
+    This is the programmatic equivalent of the ``neuralbench`` CLI: it
+    assembles experiment configs from the same YAML files and launches them.
+    For a model built outside this repo, and for the results of the runs in
+    hand, see :func:`neuralbench.evaluate_model`.
 
     Parameters
     ----------
@@ -105,8 +92,9 @@ def run_benchmark(
     Returns
     -------
     list of dict
-        One result dict per experiment (empty when experiments are
-        submitted asynchronously via Slurm).
+        One result dict per experiment, with ``plot_cached=True`` only.  Every
+        other mode launches experiments and returns an empty list, the results
+        being written to the results folder.
     """
     logging.basicConfig(level=logging.INFO)
     logging.getLogger("numexpr").setLevel(logging.WARNING)
@@ -126,100 +114,21 @@ def run_benchmark(
             "Cannot use force, retry, or prepare flags when plotting cached results."
         )
 
-    from neuralbench.config_manager import _ensure_initialized
-
-    _ensure_initialized()
-    _validate_inputs(device, task, model, downstream_wrapper)
-    _warn_slurm_partition(debug, prepare=prepare, download=download)
-    _warn_unsupported_gpu()
-
-    # --- base config & grid ---
-    default_config = load_yaml_config(DEFAULTS_DIR / "config.yaml")
-    config = ConfDict(default_config)
-
-    # Disable W&B entirely when no host is configured (blank WANDB_HOST), so the
-    # whole pipeline treats logging as off (mirrors the debug-mode overlay).
-    wandb_cfg = config.get("wandb_config")
-    host = wandb_cfg.get("host") if isinstance(wandb_cfg, dict) else None
-    if not host:
-        config["wandb_config"] = None
-
-    default_grid = load_yaml_config(DEFAULTS_DIR / "grid.yaml")
-    grid_conf = ConfDict(default_grid)
-
-    if prepare or debug:
-        grid_conf["seed"] = [grid_conf["seed"][0]]
-
-    if checkpoint is not None:
-        config["pretrained_weights_fname"] = checkpoint
-
-    # --- downstream wrappers ---
-    overlays: list[dict[str, tp.Any]] | None = None
-    if downstream_wrapper is not None:
-        wrappers = (
-            [downstream_wrapper]
-            if isinstance(downstream_wrapper, str)
-            else list(downstream_wrapper)
-        )
-        if wrappers == ["all"]:
-            wrappers = list(ALL_DOWNSTREAM_WRAPPERS.keys())
-        overlays = [ALL_DOWNSTREAM_WRAPPERS[name] for name in wrappers]
-
-    # --- tasks ---
-    tasks = _resolve_tasks(device, task)
-
-    # --- assemble experiment configs ---
-    configs: list[tp.Any] = []
-    task_iter: tp.Iterable[str] = tasks
-    if prepare and len(tasks) > 1:
-        from tqdm import tqdm
-
-        task_iter = tqdm(tasks, desc="Preparing tasks")
-
-    for task_name in task_iter:
-        # Resolve models per-task so the `all` / `all_baseline` aliases pick
-        # only the task-appropriate sklearn baseline (via FEATURE_BASED_BY_TASK)
-        # instead of launching every pipeline on every task.
-        models = _expand_models(model, device=device, task_name=task_name)
-        datasets = _resolve_datasets(device, task_name, dataset)
-        # adaptation needs a pretrained backbone: non-FMs get an overlay-free grid
-        model_groups: list[tuple[ConfDict, list[str | None]]]
-        if overlays is not None:
-            fm_names = set(DEVICE_FM_MODELS.get(device, FM_MODELS))
-            fm_models: list[str | None] = [m for m in models if m in fm_names]
-            other_models: list[str | None] = [m for m in models if m not in fm_names]
-            if not fm_models:
-                logger.warning(
-                    "Adaptation wrappers requested (-w) but no foundation model "
-                    "selected for task %r; running without adaptation.",
-                    task_name,
-                )
-            model_groups = []
-            if fm_models:
-                fm_grid = grid_conf.copy()
-                fm_grid["_adaptation_overlay"] = overlays
-                model_groups.append((fm_grid, fm_models))
-            if other_models:
-                model_groups.append((grid_conf, other_models))
-        else:
-            model_groups = [(grid_conf, models)]
-        for group_grid, group_models in model_groups:
-            task_configs = prepare_task_configs(
-                config.copy(),
-                group_grid,
-                device,
-                task_name,
-                grid,
-                debug,
-                force,
-                prepare,
-                download,
-                group_models,
-                datasets,
-                quiet=plot_cached,
-                retry=retry,
-            )
-            configs.extend(task_configs)
+    configs = build_experiment_configs(
+        device,
+        task,
+        model=model,
+        dataset=dataset,
+        checkpoint=checkpoint,
+        downstream_wrapper=downstream_wrapper,
+        grid=grid,
+        debug=debug,
+        force=force,
+        retry=retry,
+        prepare=prepare,
+        download=download,
+        quiet=plot_cached,
+    )
 
     if download:
         return []
@@ -230,7 +139,8 @@ def run_benchmark(
     from neuralbench.main import BenchmarkAggregator
 
     agg = BenchmarkAggregator(
-        experiments=configs,
+        # ConfDicts, which the pydantic model coerces into Experiment instances.
+        experiments=configs,  # type: ignore[arg-type]
         debug=debug,
     )
 

--- a/neuralbench-repo/neuralbench/evaluate.py
+++ b/neuralbench-repo/neuralbench/evaluate.py
@@ -1,0 +1,295 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Evaluate a model defined outside this repo.
+
+The CLI and :func:`~neuralbench.run_benchmark` take a model *name*, which means
+the model has to live in this repo with a ``models/*.yaml`` beside it.
+:func:`evaluate_model` takes the built instance instead::
+
+    scores = evaluate_model(my_pretrained_fm, "eeg", "all", name="my-eeg-fm")
+"""
+
+import copy
+import functools
+import inspect
+import logging
+import typing as tp
+from itertools import product
+from pathlib import Path
+
+import mne
+import pandas as pd
+import torch
+from exca import ConfDict
+from torch import nn
+
+from neuralbench.config_manager import get_config
+from neuralbench.experiment_config import (
+    _download_dataset,
+    apply_cluster,
+    build_experiment_configs,
+    merge_task_config,
+)
+from neuralbench.external import ExternalModel, check_forward, save_instance
+from neuralbench.registry import _resolve_datasets, _resolve_tasks
+
+LOGGER = logging.getLogger(__name__)
+
+#: Montage widths :func:`check_model` probes, spanning the range real EEG caps
+#: cover, so a model that handles only one width shows up as such.
+_PROBE_CHANNELS = (3, 19, 64, 128)
+
+
+def _external_config(model: nn.Module) -> ExternalModel:
+    """Serialize *model* to the cache folder and point a config at it."""
+    if not isinstance(model, nn.Module):
+        raise TypeError(
+            f"Expected an instantiated torch.nn.Module, got {model!r}. Build "
+            "your model first -- including loading any pretrained weights -- "
+            "and pass the instance."
+        )
+    check_forward(model)
+    folder = Path(get_config()["CACHE_DIR"]) / "external_models"
+    path, digest = save_instance(model, folder)
+    LOGGER.info("Serialized model to %s", path)
+    return ExternalModel(pickle_path=str(path), digest=digest)
+
+
+def _experiment_configs(
+    model_overlay: dict[str, tp.Any],
+    *,
+    overrides: tp.Mapping[str, tp.Any] | None,
+    cluster: str | None,
+    **selection: tp.Any,
+) -> list[ConfDict]:
+    configs = build_experiment_configs(model=model_overlay, quiet=True, **selection)
+    for config in configs:
+        # Last, because the debug and prepare overlays run after a model config
+        # is merged and would otherwise silently revert an override.
+        if overrides:
+            config.update(dict(overrides))
+        apply_cluster(config, cluster)
+    return configs
+
+
+def _run(configs: list[ConfDict], debug: bool) -> tp.Any:
+    """Submit *configs* and return the aggregator holding them."""
+    from neuralbench.main import BenchmarkAggregator
+
+    # ConfDicts, which the pydantic model coerces into Experiment instances.
+    agg = BenchmarkAggregator(experiments=configs, debug=debug)  # type: ignore[arg-type]
+    agg.prepare()
+    return agg
+
+
+def evaluate_model(
+    model: nn.Module,
+    device: str,
+    task: str | list[str],
+    *,
+    name: str = "external",
+    overrides: tp.Mapping[str, tp.Any] | None = None,
+    downstream_wrapper: str | list[str] = "linear_probe_mean",
+    download: bool = True,
+    prepare: bool = True,
+    cluster: str | None = None,
+    debug: bool = False,
+    **selection: tp.Any,
+) -> pd.DataFrame:
+    """Run *model* on a selection of tasks and return the results.
+
+    Runs in-process by default, which is usually what you want in a notebook
+    but means a full suite can take a very long time.  Pass ``cluster="auto"``
+    to fan the experiments out to SLURM instead; that call returns once they are
+    queued, so it yields whatever has finished (nothing, at first).  Call it
+    again with the same arguments to collect -- already-completed experiments
+    are not resubmitted, exactly as with re-running the CLI.
+
+    Parameters
+    ----------
+    model
+        An instantiated ``nn.Module`` accepting ``(batch, channels, samples)``
+        at any width and length, plus ``channel_positions``.  A ``forward``
+        that also names ``ch_names`` is given the dataset's channel names,
+        which is the only way to identify electrodes for a model keyed by name
+        (e.g. LaBraM).  It is serialized once to the cache folder and reloaded
+        fresh for each experiment.  Run :func:`check_model` first.
+    device, task
+        As on the CLI; ``task="all"`` runs every validated task for the device,
+        which with the default ``dataset=None`` is the device's Core suite and
+        with ``dataset="all"`` its Full suite.
+    name
+        Label for this model in the results frame.
+    overrides
+        Dotted-key or nested config overrides, applied last and recorded in the
+        frame's ``overrides`` column.
+    downstream_wrapper
+        Adaptation strategy, which is also what supplies the task's classifier
+        head; the default freezes the model and trains a linear probe on its
+        mean-pooled output.
+    download
+        Fetch the datasets first.  Nothing downloads on demand, so a missing
+        dataset otherwise fails deep inside ``Study``.  Cheap once present.
+    prepare
+        Warm the preprocessing caches first, by running one cut-down experiment
+        per task/dataset.  Hours on a cold cache for a whole device, a status
+        check when already warm.  Needs the data, hence after ``download``.
+        On a cluster the warm-up is queued rather than run, so the call returns
+        without submitting the experiments; call it again once it has finished.
+    cluster
+        ``None`` runs in-process; ``"auto"`` uses SLURM when available;
+        ``"slurm"`` requires it.  Applies to the runs and the caches alike.
+    debug
+        Reduce every experiment (2 epochs, 5 batches, a data subset) and run
+        locally.  For checking that a model trains at all, not for results.
+    **selection
+        Remaining :func:`neuralbench.cli.run_benchmark` arguments
+        (``dataset``, ``force``, ...).
+    """
+    config = _external_config(model)
+    overlay = {
+        "brain_model_name": name,
+        # =replace= so the external config supplants the default model rather
+        # than merging field-by-field with it.
+        "brain_model_config": {"=replace=": True, **config.model_dump()},
+    }
+    phase = dict(
+        device=device,
+        task=task,
+        overrides=overrides,
+        downstream_wrapper=downstream_wrapper,
+        cluster=cluster,
+        debug=debug,
+        **selection,
+    )
+    configs = _experiment_configs(overlay, **phase)
+
+    if download:
+        # Several configs share a study, and downloading is the same work for each.
+        for cfg in {c["data.study.source"]["name"]: c for c in configs}.values():
+            _download_dataset(cfg)
+    if prepare:
+        warming = _run(_experiment_configs(overlay, prepare=True, **phase), debug)
+        if cluster is not None and any(
+            exp.infra.status() != "completed" for exp in warming.experiments
+        ):
+            LOGGER.info("Warming the caches on %s; call again to run.", cluster)
+            # Submitting now would have every experiment race the warm-up it
+            # exists to avoid, and recompute the same caches once per seed.
+            return pd.DataFrame()
+
+    agg = _run(configs, debug)
+    # Debug experiments ran in-process and so never reach a `completed` exca
+    # status; their results come straight from the cache instead.
+    frame = pd.DataFrame(agg.collect(cached_only=not debug))
+    if not frame.empty and overrides:
+        flat = ConfDict(dict(overrides)).flat()
+        frame["overrides"] = ";".join(f"{k}={v!r}" for k, v in sorted(flat.items()))
+    return frame
+
+
+def check_model(
+    model: nn.Module,
+    device: str,
+    task: str | list[str],
+    *,
+    dataset: str | list[str] | None = None,
+    overrides: tp.Mapping[str, tp.Any] | None = None,
+    batch_size: int = 2,
+) -> pd.DataFrame:
+    """Push synthetic batches of a selection's shapes through *model*.
+
+    One instance runs the whole selection, so it has to survive every window
+    length and montage width in it.  Reads only YAML, so it takes seconds and
+    needs no downloaded data -- the alternative being to discover a shape bug
+    an hour into a real run.
+
+    Returns one row per (task, window, channel count) with ``status`` either
+    ``"ok"`` or the exception that would have surfaced during the run.  Raises
+    instead when ``forward`` cannot accept channel positions at all, since that
+    is a property of the model rather than of any one task.
+
+    The temporal width is computed from the task window and sampling rate and
+    may be off by a sample, and the channel counts are probes rather than the
+    widths a dataset will actually emit.  So this catches a model that cannot
+    handle a task's shapes at all, not an exact match with the dataloader.
+    Likewise the synthetic positions are random and the ``ch_names`` given to a
+    model that asks for them are 10-05 names: enough to exercise the shapes,
+    not a montage any dataset has.
+    """
+    check_forward(model)
+    # Probing must not touch the caller's object: a forward pass materializes
+    # lazy layers and, in train mode, updates normalization statistics.
+    probe = copy.deepcopy(model).eval()
+    flat_overrides = ConfDict(dict(overrides or {})).flat()
+
+    rows: list[dict[str, tp.Any]] = []
+    for task_name in _resolve_tasks(device, task):
+        # Dataset variants override the task window, so a selection can span
+        # several window lengths; only the distinct ones are worth probing.
+        windows: set[int] = set()
+        for dataset_name in _resolve_datasets(device, task_name, dataset):
+            flat = merge_task_config(device, task_name, dataset_name).flat()
+            flat.update(flat_overrides)
+            frequency = flat.get("data.neuro.frequency")
+            duration = flat.get("data.duration")
+            if frequency and duration:
+                windows.add(round(duration * frequency))
+        if not windows:
+            rows.append(
+                {"task": task_name, "status": "skipped: no fixed window or sampling rate"}
+            )
+        for samples, width in product(sorted(windows), _PROBE_CHANNELS):
+            rows.append(
+                {
+                    "task": task_name,
+                    "n_spatial_locations": width,
+                    "n_temporal_samples": samples,
+                    **_try_forward(probe, width, samples, batch_size),
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+@functools.lru_cache(maxsize=1)
+def _standard_ch_names() -> tuple[str, ...]:
+    """Electrode names to probe a model keyed by name, 10-20 ones first.
+
+    A model may only know part of the 10-05 system, so the widest probe still
+    spends some of its channels on names it drops; putting the classic ones
+    first keeps the narrower probes to names every EEG model knows.
+    """
+    names = mne.channels.make_standard_montage("standard_1005").ch_names
+    classic = set(mne.channels.make_standard_montage("standard_1020").ch_names)
+    return tuple(sorted(names, key=lambda name: name not in classic))
+
+
+def _try_forward(
+    model: nn.Module, channels: int, samples: int, batch_size: int
+) -> dict[str, tp.Any]:
+    x = torch.randn(batch_size, channels, samples)
+    inputs: dict[str, tp.Any] = {
+        "channel_positions": torch.randn(batch_size, channels, 3)
+    }
+    if "ch_names" in inspect.signature(model.forward).parameters:
+        inputs["ch_names"] = list(_standard_ch_names()[:channels])
+    try:
+        with torch.no_grad():
+            out = model(x, **inputs)
+    except Exception as e:  # noqa: BLE001 - reported, not raised
+        return {"status": f"forward failed: {type(e).__name__}: {e}"}
+
+    if not isinstance(out, torch.Tensor):
+        return {"status": f"output is {type(out).__name__}, expected a Tensor"}
+    if out.ndim < 2 or out.shape[0] != batch_size:
+        # The probe pools over everything but the batch axis, so a model that
+        # puts batch elsewhere would have its samples mixed together.
+        return {
+            "status": f"output {tuple(out.shape)} is not batch-first",
+            "output_shape": tuple(out.shape),
+        }
+    return {"status": "ok", "output_shape": tuple(out.shape)}

--- a/neuralbench-repo/neuralbench/experiment_config.py
+++ b/neuralbench-repo/neuralbench/experiment_config.py
@@ -13,6 +13,7 @@ configs ready for ``BenchmarkAggregator``.
 import logging
 import os
 import shutil
+import typing as tp
 from itertools import product
 from pathlib import Path
 from warnings import warn
@@ -32,21 +33,43 @@ from neuralbench.registry import (
 
 LOGGER = logging.getLogger(__name__)
 
+#: A registered model name, an inline config dict (:mod:`neuralbench.evaluate`),
+#: or ``None`` for the default model of ``defaults/config.yaml``.
+ModelSpec = str | dict[str, tp.Any] | None
+
 # ---------------------------------------------------------------------------
 # Mode overlays
 # ---------------------------------------------------------------------------
+
+
+def apply_cluster(config: ConfDict, cluster: str | None) -> None:
+    """Point every infra in *config* at *cluster*.
+
+    ``None`` computes in-process (exca maps it to submitit's debug executor, so
+    a job array runs inline and blocks); ``"auto"`` fans out to SLURM when one
+    is available and falls back to local otherwise.
+
+    The run and the extractor/target caches are set together: leaving a cache
+    on SLURM while the run is local, or the reverse, is never what a caller
+    means and fails confusingly on machines without a cluster.
+    """
+    config["infra.cluster"] = cluster
+    if "data" in config:
+        config["data.neuro.infra.cluster"] = cluster
+    target_cfg = config.get("data", {}).get("target", {})
+    if isinstance(target_cfg, dict) and "infra" in target_cfg:
+        config["data.target.infra.cluster"] = cluster
 
 
 def _apply_debug_overlay(config: ConfDict) -> None:
     """Apply debug-mode overrides: disable SLURM/W&B, reduce epochs and batches."""
     LOGGER.info("--- RUNNING IN DEBUG MODE ---")
     config["wandb_config"] = None
-    config["infra.cluster"] = None
+    apply_cluster(config, None)
     config["infra.gpus_per_node"] = 1
     config["infra.tasks_per_node"] = 1
     config["infra.slurm_use_srun"] = False
     if "data" in config:
-        config["data.neuro.infra.cluster"] = None
         config["data.batch_size"] = 8
         config["trainer_config"] = {
             "strategy": "auto",
@@ -64,20 +87,13 @@ def _apply_debug_overlay(config: ConfDict) -> None:
 def _apply_prepare_overlay(config: ConfDict) -> None:
     """Apply prepare-mode overrides: single run to warm the preprocessing cache."""
     LOGGER.info("--- RUNNING SINGLE EXPERIMENT TO PREPARE CACHE ---")
-    # Use the configured CLUSTER for both the run and the extractor/target
-    # caches. "auto" already fans out to SLURM when available (submitit's auto
-    # executor) and falls back to local otherwise, so we avoid hard-coding
-    # "slurm", which would fail on machines without a SLURM cluster.
-    cluster = get_config().get("CLUSTER", "auto")
-    config["infra.cluster"] = cluster
+    apply_cluster(config, get_config().get("CLUSTER", "auto"))
     config["infra.gpus_per_node"] = 1
     config["infra.tasks_per_node"] = 1
     config["infra.slurm_use_srun"] = False
-    config["data.neuro.infra.cluster"] = cluster
     config["data.neuro.infra.min_samples_per_job"] = 8
     target_cfg = config.get("data", {}).get("target", {})
     if isinstance(target_cfg, dict) and "infra" in target_cfg:
-        config["data.target.infra.cluster"] = cluster
         config["data.target.infra.min_samples_per_job"] = 8
     if "trainer_config" in config:
         config["trainer_config"] = {
@@ -248,7 +264,7 @@ def prepare_task_configs(
     force: bool,
     prepare: bool,
     download: bool,
-    models: list[str | None],
+    models: tp.Sequence[ModelSpec],
     datasets: list[str | None] | None = None,
     quiet: bool = False,
     retry: bool = False,
@@ -263,13 +279,19 @@ def prepare_task_configs(
     config = merge_task_config(device, task_name, base=config)
 
     configs = []
-    for model_name in models:
+    for model in models:
         exp_config = config.copy()
-        if model_name is not None:
+        if model is not None:
+            # A dict is an inline config: out-of-tree models reach the
+            # benchmark through neuralbench.evaluate and have no models/*.yaml.
+            if isinstance(model, dict):
+                model_config = model
+                label = model.get("brain_model_name", "inline config")
+            else:
+                model_config = load_yaml_config(_resolve_model_config_path(model)) or {}
+                label = model
             if not quiet:
-                LOGGER.info("--- USING MODEL %s ---", model_name)
-            model_config_fname = _resolve_model_config_path(model_name)
-            model_config = load_yaml_config(model_config_fname)
+                LOGGER.info("--- USING MODEL %s ---", label)
             exp_config.update(model_config)
 
         for dataset_name in datasets:
@@ -295,6 +317,139 @@ def prepare_task_configs(
             )
             configs.extend(exp_configs)
 
+    return configs
+
+
+def build_experiment_configs(
+    device: str,
+    task: str | list[str],
+    *,
+    model: str | list[str] | dict[str, tp.Any] | None = None,
+    dataset: str | list[str] | None = None,
+    checkpoint: str | None = None,
+    downstream_wrapper: str | list[str] | None = None,
+    grid: bool = False,
+    debug: bool = False,
+    force: bool = False,
+    retry: bool = False,
+    prepare: bool = False,
+    download: bool = False,
+    quiet: bool = False,
+) -> list[ConfDict]:
+    """Assemble one experiment config per (task, dataset, model, grid point).
+
+    The single home for turning benchmark selections into configs, shared by
+    :func:`neuralbench.cli.run_benchmark` and
+    :mod:`neuralbench.evaluate`.  *model* is a registered name (or ``"all"``
+    and friends) as on the CLI, or an already-loaded config dict for a model
+    with no ``models/*.yaml`` -- see :mod:`neuralbench.evaluate`.
+
+    Arguments mirror :func:`neuralbench.cli.run_benchmark`; see its docstring.
+    """
+    from neuralbench.config_manager import _ensure_initialized
+    from neuralbench.registry import (
+        ALL_DOWNSTREAM_WRAPPERS,
+        DEVICE_FM_MODELS,
+        FM_MODELS,
+        _expand_models,
+        _resolve_datasets,
+        _resolve_tasks,
+        _validate_inputs,
+    )
+
+    _ensure_initialized()
+    inline_model = model if isinstance(model, dict) else None
+    _validate_inputs(device, task, None if inline_model else model, downstream_wrapper)  # type: ignore[arg-type]
+    _warn_slurm_partition(debug, prepare=prepare, download=download)
+    _warn_unsupported_gpu()
+
+    config = ConfDict(load_yaml_config(DEFAULTS_DIR / "config.yaml"))
+    # A blank W&B host means logging is off for the whole pipeline (mirrors
+    # the debug-mode overlay).
+    wandb_cfg = config.get("wandb_config")
+    host = wandb_cfg.get("host") if isinstance(wandb_cfg, dict) else None
+    if not host:
+        config["wandb_config"] = None
+
+    grid_conf = ConfDict(load_yaml_config(DEFAULTS_DIR / "grid.yaml"))
+    if prepare or debug:
+        grid_conf["seed"] = [grid_conf["seed"][0]]
+
+    if checkpoint is not None:
+        config["pretrained_weights_fname"] = checkpoint
+
+    overlays: list[dict[str, tp.Any]] | None = None
+    if downstream_wrapper is not None:
+        wrappers = (
+            [downstream_wrapper]
+            if isinstance(downstream_wrapper, str)
+            else list(downstream_wrapper)
+        )
+        if wrappers == ["all"]:
+            wrappers = list(ALL_DOWNSTREAM_WRAPPERS.keys())
+        overlays = [ALL_DOWNSTREAM_WRAPPERS[name] for name in wrappers]
+
+    tasks = _resolve_tasks(device, task)
+
+    configs: list[ConfDict] = []
+    task_iter: tp.Iterable[str] = tasks
+    if prepare and len(tasks) > 1:
+        from tqdm import tqdm
+
+        task_iter = tqdm(tasks, desc="Preparing tasks")
+
+    for task_name in task_iter:
+        # Resolve models per-task so the `all` / `all_baseline` aliases pick
+        # only the task-appropriate sklearn baseline (via FEATURE_BASED_BY_TASK)
+        # instead of launching every pipeline on every task.
+        models: list[ModelSpec] = (
+            [inline_model]
+            if inline_model is not None
+            else list(_expand_models(model, device=device, task_name=task_name))  # type: ignore[arg-type]
+        )
+        datasets = _resolve_datasets(device, task_name, dataset)
+        # adaptation needs a pretrained backbone: non-FMs get an overlay-free grid
+        model_groups: list[tuple[ConfDict, list[ModelSpec]]]
+        if overlays is not None:
+            # An out-of-tree model is a backbone by assumption: it is not in the
+            # in-tree FM list, but adaptation is exactly why it is being run.
+            fm_names = set(DEVICE_FM_MODELS.get(device, FM_MODELS))
+            inline = inline_model is not None
+            fm_models = [m for m in models if inline or m in fm_names]
+            other_models = [m for m in models if not inline and m not in fm_names]
+            if not fm_models:
+                LOGGER.warning(
+                    "Adaptation wrappers requested (-w) but no foundation model "
+                    "selected for task %r; running without adaptation.",
+                    task_name,
+                )
+            model_groups = []
+            if fm_models:
+                fm_grid = grid_conf.copy()
+                fm_grid["_adaptation_overlay"] = overlays
+                model_groups.append((fm_grid, fm_models))
+            if other_models:
+                model_groups.append((grid_conf, other_models))
+        else:
+            model_groups = [(grid_conf, models)]
+        for group_grid, group_models in model_groups:
+            configs.extend(
+                prepare_task_configs(
+                    config.copy(),
+                    group_grid,
+                    device,
+                    task_name,
+                    grid,
+                    debug,
+                    force,
+                    prepare,
+                    download,
+                    group_models,
+                    datasets,
+                    quiet=quiet,
+                    retry=retry,
+                )
+            )
     return configs
 
 

--- a/neuralbench-repo/neuralbench/external.py
+++ b/neuralbench-repo/neuralbench/external.py
@@ -1,0 +1,124 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Model config for an instantiated model defined outside this repo."""
+
+import hashlib
+import importlib.metadata
+import inspect
+import io
+import sys
+import uuid
+from pathlib import Path
+
+import cloudpickle
+import torch
+from torch import nn
+
+from neuraltrain.models.base import BaseBrainModelConfig, BrainModelBuildContext
+
+
+def model_digest(model: nn.Module) -> str:
+    """Hash *model*'s layout and weights, identically in any process.
+
+    Not the serialized file: cloudpickle tags each class definition it stores
+    with a fresh id, so the bytes differ every run and a uid built from them
+    would never find the results of the previous call.
+    """
+    buffer = io.BytesIO()
+    torch.save(model.state_dict(), buffer)
+    return hashlib.sha256(str(model).encode() + buffer.getvalue()).hexdigest()
+
+
+def _pickle_code_by_value(model: nn.Module) -> None:
+    """Make the pickle carry the code of *model*'s classes, not just import paths.
+
+    Pickle stores a class by reference, which a worker resolves by importing it.
+    That works for an installed package, editable ones included, but a model
+    being tried out lives in a script or a plain checkout, importable from the
+    caller's ``sys.path`` alone.  Those modules are pickled by value instead, so
+    the job needs nothing on its ``PYTHONPATH``; the cost is that the classes it
+    rebuilds are not the ones the caller passed, which only ``isinstance`` in
+    the caller's own process would notice.
+    """
+    installed = importlib.metadata.packages_distributions()
+    for name in {type(module).__module__.split(".")[0] for module in model.modules()}:
+        module = sys.modules.get(name)
+        if module is not None and name not in installed:
+            cloudpickle.register_pickle_by_value(module)
+
+
+def save_instance(model: nn.Module, folder: Path) -> tuple[Path, str]:
+    """Serialize *model* under its digest, as ``(path, digest)``."""
+    folder.mkdir(parents=True, exist_ok=True)
+    _pickle_code_by_value(model)
+    # uuid4, not id(model): two processes can hold objects at one address, then
+    # interleave writes into one file and each read back the other's bytes.
+    tmp = folder / f".{uuid.uuid4().hex}.tmp"
+    torch.save(model, tmp, pickle_module=cloudpickle)
+    digest = model_digest(model)
+    path = folder / f"{digest}.pt"
+    tmp.replace(path)
+    return path, digest
+
+
+def check_forward(model: nn.Module) -> None:
+    """Raise unless *model* reads channel identity from ``forward``."""
+    params = inspect.signature(model.forward).parameters
+    if "channel_positions" in params or any(
+        p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values()
+    ):
+        return
+    raise ValueError(
+        f"forward() of {type(model).__name__} does not accept 'channel_positions', "
+        "so it cannot tell one montage from another. NeuralBench passes it by "
+        f"keyword as (batch, channels, 3), so the name must match exactly; got "
+        f"{sorted(params)}."
+    )
+
+
+class ExternalModel(BaseBrainModelConfig):
+    """An instantiated model built by out-of-tree code.
+
+    Parameters
+    ----------
+    pickle_path : str
+        Path to a serialized :class:`~torch.nn.Module`, as written by
+        :func:`save_instance`.
+    digest : str
+        :func:`model_digest` of that model, so the weights take part in the
+        cache uid rather than just the file name.
+    """
+
+    pickle_path: str
+    digest: str
+
+    def build_from_context(self, ctx: BrainModelBuildContext) -> nn.Module:
+        """Load a fresh copy of the instance, so fine-tuned weights never leak.
+
+        *ctx* is unused: the model adapts to the data rather than being built
+        for it, which is the condition for accepting an instance at all.
+        """
+        path = Path(self.pickle_path).expanduser()
+        if not path.exists():
+            raise FileNotFoundError(
+                f"Serialized model {path} not found. It is written to the "
+                "neuralbench cache folder, which must be reachable from the "
+                "worker running the experiment."
+            )
+        # weights_only=False: a whole pickled module, not a state dict.
+        model = torch.load(path, weights_only=False, map_location="cpu")
+        if not isinstance(model, nn.Module):
+            raise TypeError(
+                f"{path} contains {type(model).__name__}, expected a torch.nn.Module."
+            )
+        if (digest := model_digest(model)) != self.digest:
+            raise ValueError(
+                f"Model in {path} has digest {digest}, expected {self.digest}. "
+                "The file was overwritten with a different model."
+            )
+        check_forward(model)
+        return model

--- a/neuralbench-repo/neuralbench/main.py
+++ b/neuralbench-repo/neuralbench/main.py
@@ -157,7 +157,12 @@ class Experiment(BaseExperiment):
         # Seed before any model construction so wrapper/adapters/lazy init do
         # not depend on RNG already consumed by data preparation or setup.
         pl.seed_everything(self.seed, workers=True)
-        brain_model, self._n_total_params, self._n_trainable_params = build_brain_model(
+        (
+            brain_model,
+            self._n_total_params,
+            self._n_trainable_params,
+            ch_names,
+        ) = build_brain_model(
             brain_model_config=self.brain_model_config,
             downstream_model_wrapper=self.downstream_model_wrapper,
             pretrained_weights_fname=self.pretrained_weights_fname,
@@ -190,6 +195,7 @@ class Experiment(BaseExperiment):
 
         self._brain_module = BrainModule(
             model=brain_model,
+            ch_names=ch_names,
             target_scaler=self.target_scaler,
             augmentation=None if self.augmentation is None else self.augmentation.build(),
             loss=self.loss.build(**loss_kwargs),

--- a/neuralbench-repo/neuralbench/model_factory.py
+++ b/neuralbench-repo/neuralbench/model_factory.py
@@ -43,20 +43,23 @@ def build_dummy_batch(
     brain_model: torch.nn.Module,
     batch: tp.Any,
     downstream_model_wrapper: DownstreamWrapper | None,
-) -> tuple[dict[str, torch.Tensor | None], str]:
+    ch_names: list[str] | None = None,
+) -> tuple[dict[str, tp.Any], str]:
     """Build a single-sample dummy batch from *batch* for lazy-layer init and model summary.
 
     Returns the dummy batch dict and the name of the primary input parameter.
     """
     forward_sig = inspect.signature(brain_model.forward)
     input_name = list(forward_sig.parameters.keys())[0]
-    dummy_batch: dict[str, torch.Tensor | None] = {
+    dummy_batch: dict[str, tp.Any] = {
         input_name: batch.data["neuro"][:1].to("cpu"),
     }
     if "subject_ids" in forward_sig.parameters:
         dummy_batch["subject_ids"] = batch.data["subject_id"][:1].to("cpu")
     if "channel_positions" in forward_sig.parameters:
         dummy_batch["channel_positions"] = batch.data["channel_positions"][:1].to("cpu")
+    if ch_names is not None and "ch_names" in forward_sig.parameters:
+        dummy_batch["ch_names"] = ch_names
 
     # ChannelMerger-based adapters need channel_positions and subject_ids
     # even if the inner model doesn't require them.
@@ -75,7 +78,7 @@ def build_dummy_batch(
 
 def init_lazy_layers(
     brain_model: torch.nn.Module,
-    dummy_batch: dict[str, torch.Tensor | None],
+    dummy_batch: dict[str, tp.Any],
     input_name: str,
     downstream_model_wrapper: DownstreamWrapper | None,
 ) -> None:
@@ -118,7 +121,7 @@ def build_brain_model(
     val_loader: DataLoader | None = None,
     wandb_logger: WandbLogger | None = None,
     loss: BaseLoss | None = None,
-) -> tuple[torch.nn.Module, int, int]:
+) -> tuple[torch.nn.Module, int, int, list[str] | None]:
     """Build, initialise and optionally wrap a brain model.
 
     This is the main entry point that orchestrates braindecode/generic model
@@ -132,7 +135,10 @@ def build_brain_model(
     concatenation of the train and val splits so they see the same pool of
     labelled data as the DL models (which get val via early stopping).
 
-    Returns ``(model, n_total_params, n_trainable_params)``.
+    Returns ``(model, n_total_params, n_trainable_params, ch_names)``, the last
+    being the names of the channels the model receives (``None`` when the
+    dataset does not name them, or when a channel adapter reshapes them), for
+    models that read channel identity by name rather than by position.
     """
     batch = next(iter(train_loader))
     n_spatial_locations, n_temporal_samples = batch.data["neuro"].shape[1:]
@@ -278,7 +284,7 @@ def build_brain_model(
 
     # 2) Initialize lazy layers
     dummy_batch, input_name = build_dummy_batch(
-        brain_model, batch, downstream_model_wrapper
+        brain_model, batch, downstream_model_wrapper, ch_names
     )
     init_lazy_layers(brain_model, dummy_batch, input_name, downstream_model_wrapper)
 
@@ -296,10 +302,13 @@ def build_brain_model(
             input_channel_names=dataset_ch_names,
         )
 
-    # 5) Log model summary
+    # 5) Log model summary. torchinfo adds up the memory of everything in
+    # ``input_data``, so anything that is not a tensor (``ch_names``) has to
+    # reach the forward as a keyword argument instead.
     model_summary = summary(
         brain_model,
-        input_data=dummy_batch,
+        input_data={k: v for k, v in dummy_batch.items() if isinstance(v, torch.Tensor)},
+        **{k: v for k, v in dummy_batch.items() if not isinstance(v, torch.Tensor)},
         col_names=("output_size", "num_params", "trainable"),
         row_settings=("hide_recursive_layers",),
         verbose=0,
@@ -317,4 +326,4 @@ def build_brain_model(
             }
         )
 
-    return brain_model, n_total_params, n_trainable_params
+    return brain_model, n_total_params, n_trainable_params, ch_names

--- a/neuralbench-repo/neuralbench/models/reve.yaml
+++ b/neuralbench-repo/neuralbench/models/reve.yaml
@@ -15,6 +15,9 @@ data:
     scaler: StandardScaler
     scale_factor: null
     clamp: 15
+  channel_positions:
+    # REVE's pretrained position bank is in MNE head-frame metres.
+    normalize: false
 brain_model_config:
   =replace=: true
   name: NtReve

--- a/neuralbench-repo/neuralbench/modules.py
+++ b/neuralbench-repo/neuralbench/modules.py
@@ -542,7 +542,7 @@ class DownstreamWrapper(pydantic.BaseModel):
     def build(
         self,
         model: nn.Module,
-        dummy_batch: dict[str, torch.Tensor | None],
+        dummy_batch: dict[str, tp.Any],
         n_outputs: int,
         input_channel_names: list[str] | None = None,
     ) -> "DownstreamWrapperModel":

--- a/neuralbench-repo/neuralbench/pl_module.py
+++ b/neuralbench-repo/neuralbench/pl_module.py
@@ -44,6 +44,10 @@ class BrainModule(pl.LightningModule):
         A scaler to apply to the target values.
     augmentation : nn.Module | None, optional
         Augmentation applied to the neuro input during training only.
+    ch_names : list[str] | None, optional
+        Names of the channels the model receives, passed to every forward call
+        of a model that names ``ch_names`` -- models keyed by electrode name
+        (e.g. LaBraM) cannot get that from ``channel_positions``.
     """
 
     def __init__(
@@ -56,11 +60,13 @@ class BrainModule(pl.LightningModule):
         test_full_retrieval_metrics: dict[str, Metric] | None = None,
         target_scaler: StandardScaler | None = None,
         augmentation: nn.Module | None = None,
+        ch_names: list[str] | None = None,
     ):
         super().__init__()
         self._infer_forward_params(model)
         self.model = model
         self.augmentation = augmentation
+        self._ch_names = ch_names
 
         self.loss = loss
         self.target_scaler = target_scaler
@@ -106,6 +112,7 @@ class BrainModule(pl.LightningModule):
             or has_preprocessor
             or adapter_needs_positions
         )
+        self._requires_ch_names = "ch_names" in forward_sig.parameters
 
     @staticmethod
     def _update_metrics(
@@ -119,25 +126,25 @@ class BrainModule(pl.LightningModule):
             }
         )
 
-    def model_forward(self, batch: Batch) -> torch.Tensor:
+    def _forward_inputs(self, batch: Batch) -> dict[str, tp.Any]:
         neuro = batch.data["neuro"]
         if self.augmentation is not None and self.training:
             neuro = self.augmentation(neuro)
-        inputs = {self._input_name: neuro}
+        inputs: dict[str, tp.Any] = {self._input_name: neuro}
         if self._requires_subject:
             inputs["subject_ids"] = batch.data["subject_id"]
         if self._requires_channel_positions:
             inputs["channel_positions"] = batch.data["channel_positions"]
-        return self.model(**inputs)
+        if self._requires_ch_names and self._ch_names is not None:
+            inputs["ch_names"] = self._ch_names
+        return inputs
+
+    def model_forward(self, batch: Batch) -> torch.Tensor:
+        return self.model(**self._forward_inputs(batch))
 
     def model_forward_embedding(self, batch: Batch) -> torch.Tensor:
         """Forward pass returning the penultimate embedding (before the probe)."""
-        inputs = {self._input_name: batch.data["neuro"]}
-        if self._requires_subject:
-            inputs["subject_ids"] = batch.data["subject_id"]
-        if self._requires_channel_positions:
-            inputs["channel_positions"] = batch.data["channel_positions"]
-        return self.model(**inputs, return_embedding=True)
+        return self.model(**self._forward_inputs(batch), return_embedding=True)
 
     def _run_step(
         self, batch: Batch, step_name: str, batch_idx: int

--- a/neuralbench-repo/neuralbench/plots/tables.py
+++ b/neuralbench-repo/neuralbench/plots/tables.py
@@ -307,8 +307,14 @@ def make_full_table(
 def print_skip_table(
     total: dict[tuple[str, str], int],
     skipped: dict[tuple[str, str], int],
+    failed: dict[tuple[str, str], int] | None = None,
 ) -> None:
-    """Print a tasks x models table of included / total experiment counts."""
+    """Print a tasks x models table of included / total experiment counts.
+
+    *failed* is the subset of *skipped* whose job errored out, as opposed to
+    not having run yet; those counts are marked with a trailing ``!n``.
+    """
+    failed = failed or {}
     tasks = sorted({t for t, _ in total})
     models = sorted({m for _, m in total})
 
@@ -320,7 +326,10 @@ def print_skip_table(
             key = (task, model)
             n_total = total.get(key, 0)
             n_included = n_total - skipped.get(key, 0)
-            cells[key] = f"{n_included}/{n_total}" if n_total else "-"
+            n_failed = failed.get(key, 0)
+            cells[key] = "-" if not n_total else f"{n_included}/{n_total}"
+            if n_failed:
+                cells[key] += f"!{n_failed}"
             inc, tot = model_totals[model]
             model_totals[model] = (inc + n_included, tot + n_total)
             tinc, ttot = task_totals[task]
@@ -348,7 +357,9 @@ def print_skip_table(
 
     n_skip = sum(skipped.values())
     n_total = sum(total.values())
+    n_failed = sum(failed.values())
+    legend = f"\n!n = n experiment(s) failed ({n_failed} total)." if n_failed else ""
     print(
         f"\nExperiments with cached results ({n_total - n_skip}/{n_total} included):\n"
-        f"{table_df.to_string()}"
+        f"{table_df.to_string()}{legend}"
     )

--- a/neuralbench-repo/neuralbench/test_evaluate.py
+++ b/neuralbench-repo/neuralbench/test_evaluate.py
@@ -1,0 +1,244 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import typing as tp
+from collections.abc import Callable
+from functools import partial
+from pathlib import Path
+from types import SimpleNamespace
+
+import pydantic
+import pytest
+from exca import ConfDict
+
+from neuraltrain.optimizers import LightningOptimizer
+
+from .evaluate import _external_config, check_model, evaluate_model
+from .external import ExternalModel
+from .test_external import AdaptiveFm, FixedWidth, NoPositions, NotBatchFirst
+
+
+def test_instance_is_serialized(
+    patch_config: Callable[..., None], tmp_path: Path
+) -> None:
+    patch_config(CACHE_DIR=str(tmp_path))
+    model = AdaptiveFm()
+    config = _external_config(model)
+    assert config.pickle_path == str(tmp_path / "external_models" / f"{config.digest}.pt")
+    # Serializing is not byte-reproducible, so the digest has to come from the
+    # model itself; a call that reused nothing would resubmit everything.
+    assert _external_config(model).digest == config.digest
+    assert _external_config(AdaptiveFm()).digest != config.digest  # other weights
+
+
+def test_an_unusable_model_is_rejected_before_anything_is_submitted(
+    patch_config: Callable[..., None], tmp_path: Path
+) -> None:
+    patch_config(CACHE_DIR=str(tmp_path))
+    with pytest.raises(TypeError, match="Build your model first"):
+        _external_config(AdaptiveFm)  # type: ignore[arg-type]
+    # Otherwise the forward contract only fails once a worker loads the pickle.
+    with pytest.raises(ValueError, match="does not accept 'channel_positions'"):
+        _external_config(NoPositions())
+
+
+def _stub_aggregator(
+    monkeypatch: pytest.MonkeyPatch,
+    phases: list[list[ConfDict]],
+    status: list[str] | None = None,
+) -> None:
+    """Record the experiments of each phase instead of running them."""
+
+    class _FakeAggregator:
+        def __init__(self, experiments: list[ConfDict], debug: bool = False) -> None:
+            phases.append(experiments)
+            if status is None:
+                self.experiments = experiments
+            else:  # only the infra status is read from the warm-up phase
+                infra = SimpleNamespace(status=lambda: status[0])
+                self.experiments = [SimpleNamespace(infra=infra)]  # type: ignore[list-item]
+
+        def prepare(self) -> None:
+            pass
+
+        def collect(self, cached_only: bool = True) -> list[dict[str, tp.Any]]:
+            return []
+
+    monkeypatch.setattr("neuralbench.main.BenchmarkAggregator", _FakeAggregator)
+
+
+def _assembled(monkeypatch: pytest.MonkeyPatch, **kwargs: tp.Any) -> list[ConfDict]:
+    """Run against a stubbed aggregator, returning the configs it was handed."""
+    phases: list[list[ConfDict]] = []
+    _stub_aggregator(monkeypatch, phases)
+    kwargs.setdefault("dataset", "schalk2004bci2000")
+    kwargs.setdefault("download", False)
+    kwargs.setdefault("prepare", False)
+    evaluate_model(AdaptiveFm(), "eeg", "motor_imagery", **kwargs)
+    assert len(phases) == 1, "expected only the run phase"
+    assert phases[0]
+    return phases[0]
+
+
+def test_assembles_external_model_configs(
+    monkeypatch: pytest.MonkeyPatch, patch_config: Callable[..., None], tmp_path: Path
+) -> None:
+    patch_config(SLURM_PARTITION="dummy", CACHE_DIR=str(tmp_path))
+    configs = _assembled(
+        monkeypatch,
+        name="my-fm",
+        overrides={
+            "data.neuro.frequency": 200.0,
+            "lightning_optimizer_config.optimizer.lr": 1e-4,
+        },
+    )
+
+    for cfg in configs:
+        flat = cfg.flat()
+        assert flat["brain_model_name"] == "my-fm"
+        assert flat["brain_model_config.name"] == "ExternalModel"
+        assert flat["brain_model_config.pickle_path"].endswith(".pt")
+        # Overrides beat the task config they are layered onto.
+        assert flat["data.neuro.frequency"] == 200.0
+        assert flat["lightning_optimizer_config.optimizer.lr"] == 1e-4
+        # A fixed instance has a fixed output width, so the head comes from the
+        # wrapper for one model to span tasks of differing class counts.
+        assert flat["downstream_model_wrapper.aggregation"] == "mean"
+        assert flat["downstream_model_wrapper.probe_config"] == "linear"
+
+
+def test_runs_in_process_by_default(
+    monkeypatch: pytest.MonkeyPatch, patch_config: Callable[..., None], tmp_path: Path
+) -> None:
+    patch_config(SLURM_PARTITION="dummy", CLUSTER="slurm", CACHE_DIR=str(tmp_path))
+    for cfg in _assembled(monkeypatch):
+        assert cfg.flat()["infra.cluster"] is None
+        assert cfg.flat()["data.neuro.infra.cluster"] is None
+
+    for cfg in _assembled(monkeypatch, cluster="auto"):
+        assert cfg.flat()["infra.cluster"] == "auto"
+        assert cfg.flat()["data.neuro.infra.cluster"] == "auto"
+
+
+def test_overrides_survive_the_debug_overlay(
+    monkeypatch: pytest.MonkeyPatch, patch_config: Callable[..., None], tmp_path: Path
+) -> None:
+    # The overlays run after a model config is merged, so an override has to be
+    # applied later still or debug mode would silently revert it.
+    patch_config(SLURM_PARTITION="dummy", CACHE_DIR=str(tmp_path))
+    for cfg in _assembled(
+        monkeypatch, debug=True, overrides={"trainer_config.n_epochs": 7}
+    ):
+        assert cfg.flat()["trainer_config.n_epochs"] == 7
+
+
+def test_phases_run_in_order(
+    monkeypatch: pytest.MonkeyPatch, patch_config: Callable[..., None], tmp_path: Path
+) -> None:
+    patch_config(SLURM_PARTITION="dummy", CACHE_DIR=str(tmp_path))
+    phases: list[list[ConfDict]] = []
+    downloaded: list[str] = []
+    _stub_aggregator(monkeypatch, phases)
+    monkeypatch.setattr(
+        "neuralbench.evaluate._download_dataset",
+        lambda config: downloaded.append(config["task_name"]),
+    )
+    evaluate_model(
+        AdaptiveFm(), "eeg", "motor_imagery", dataset="schalk2004bci2000", prepare=True
+    )
+    assert downloaded == ["motor_imagery"], "downloads once per study, before running"
+    # A prepare pass is cut down to a single epoch; the real one is not.
+    epochs = [phase[0].flat()["trainer_config.n_epochs"] for phase in phases]
+    assert epochs[0] == 1 and epochs[1] != 1, "prepare pass, then the real one"
+
+
+def test_a_queued_cache_warm_up_holds_the_experiments_back(
+    monkeypatch: pytest.MonkeyPatch, patch_config: Callable[..., None], tmp_path: Path
+) -> None:
+    # On a cluster the warm-up is submitted, not run, so going straight on would
+    # have every experiment race it and recompute the caches once per seed.
+    patch_config(SLURM_PARTITION="dummy", CACHE_DIR=str(tmp_path))
+    phases: list[list[ConfDict]] = []
+    status = ["running"]
+    _stub_aggregator(monkeypatch, phases, status)
+    call = partial(
+        evaluate_model,
+        AdaptiveFm(),
+        "eeg",
+        "motor_imagery",
+        dataset="schalk2004bci2000",
+        download=False,
+        cluster="slurm",
+    )
+    assert call().empty
+    assert len(phases) == 1, "only the warm-up should have been submitted"
+
+    status[0] = "completed"
+    call()
+    assert len(phases) == 3, "a warm cache no longer holds the experiments back"
+
+
+def test_assembled_config_validates_against_the_real_models(
+    monkeypatch: pytest.MonkeyPatch, patch_config: Callable[..., None], tmp_path: Path
+) -> None:
+    # Assembly only merges dicts, so an override naming a field that does not
+    # exist is caught by pydantic rather than here; check the merged config
+    # against the models that will consume it.
+    patch_config(SLURM_PARTITION="dummy", CACHE_DIR=str(tmp_path))
+    configs = _assembled(
+        monkeypatch, overrides={"lightning_optimizer_config.optimizer.lr": 1e-4}
+    )
+    optimizer = LightningOptimizer(**configs[0]["lightning_optimizer_config"])
+    # Via the dump because `optimizer` is typed as the BaseOptimizer union.
+    assert optimizer.model_dump()["optimizer"]["lr"] == 1e-4
+    model_config = ExternalModel(**configs[0]["brain_model_config"])
+    assert model_config.pickle_path.endswith(".pt")
+
+    bad = _assembled(monkeypatch, overrides={"lightning_optimizer_config.lr": 1e-4})
+    with pytest.raises(pydantic.ValidationError, match="lr"):
+        LightningOptimizer(**bad[0]["lightning_optimizer_config"])
+
+
+def test_check_model_accepts_an_adaptive_model() -> None:
+    model = AdaptiveFm()
+    model.train()
+    rows = check_model(model, "eeg", "motor_imagery")
+    assert len(rows) == 4, "expected one row per probed channel count"
+    assert set(rows["status"]) == {"ok"}
+    # Pooled over channels, so the shape is the same at every width.
+    assert set(rows["output_shape"]) == {(2, 4)}
+    assert model.training, "probing left the caller's model in eval mode"
+
+
+def test_check_model_reports_what_it_could_not_run() -> None:
+    by_width = check_model(FixedWidth(), "eeg", "motor_imagery").set_index(
+        "n_spatial_locations"
+    )["status"]
+    assert by_width[64] == "ok"
+    assert by_width[19].startswith("forward failed:")
+
+    rows = check_model(NotBatchFirst(), "eeg", "motor_imagery")
+    assert rows["status"].str.startswith("output").all()
+
+    # A contract violation rather than a per-task shape problem, so it raises
+    # instead of filling every row with the same message.
+    with pytest.raises(ValueError, match="does not accept 'channel_positions'"):
+        check_model(NoPositions(), "eeg", "motor_imagery")
+
+
+def test_check_model_probes_the_shapes_the_run_will_use() -> None:
+    # motor_imagery uses a 4 s window, so an override of the sampling rate
+    # changes the width the model will see.
+    at_200hz = check_model(
+        AdaptiveFm(), "eeg", "motor_imagery", overrides={"data.neuro.frequency": 200.0}
+    )
+    assert at_200hz["n_temporal_samples"].eq(800).all()
+
+    # cvep's dataset variants cut the task's 4 s window to 2 s and 1 s, so
+    # probing the task config alone would miss the shapes the run will use.
+    rows = check_model(AdaptiveFm(), "eeg", "cvep", dataset="all")
+    assert set(rows["n_temporal_samples"]) == {480, 240, 120}
+    assert set(rows["status"]) == {"ok"}

--- a/neuralbench-repo/neuralbench/test_external.py
+++ b/neuralbench-repo/neuralbench/test_external.py
@@ -1,0 +1,145 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import importlib
+import importlib.util
+import sys
+import typing as tp
+from pathlib import Path
+
+import pytest
+import torch
+from torch import nn
+
+from neuraltrain.models.base import BrainModelBuildContext
+
+from .external import ExternalModel, check_forward, save_instance
+
+
+class AdaptiveFm(nn.Module):
+    """Any channel count, any window length, channels keyed by position."""
+
+    def __init__(self, width: int = 4) -> None:
+        super().__init__()
+        self.proj = nn.Linear(3, width)
+
+    def forward(self, x: torch.Tensor, channel_positions: torch.Tensor) -> torch.Tensor:
+        # (batch, channels, 1) * (batch, channels, width), pooled over channels.
+        return (x.mean(-1).unsqueeze(-1) * self.proj(channel_positions)).mean(1)
+
+
+class NoPositions(nn.Module):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x.mean(-1)
+
+
+class WithVarKwargs(nn.Module):
+    def forward(self, x: torch.Tensor, **kwargs: tp.Any) -> torch.Tensor:
+        return x.mean(-1)
+
+
+class FixedWidth(nn.Module):
+    """Only works at 64 channels -- stands in for a non-adaptive model."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.layer = nn.Linear(64, 4)
+
+    def forward(self, x: torch.Tensor, channel_positions: torch.Tensor) -> torch.Tensor:
+        return self.layer(x.transpose(1, 2)).mean(1)
+
+
+class NotBatchFirst(nn.Module):
+    def forward(self, x: torch.Tensor, channel_positions: torch.Tensor) -> torch.Tensor:
+        return x.mean(-1).transpose(0, 1)
+
+
+def context() -> BrainModelBuildContext:
+    return BrainModelBuildContext(
+        n_spatial_locations=3, n_temporal_samples=5, n_outputs=2
+    )
+
+
+def test_check_forward_requires_channel_positions() -> None:
+    check_forward(AdaptiveFm())
+    # **kwargs absorbs anything neuralbench passes by keyword.
+    check_forward(WithVarKwargs())
+
+    with pytest.raises(ValueError, match="does not accept 'channel_positions'"):
+        check_forward(NoPositions())
+
+
+def test_instance_roundtrip_and_digest_check(tmp_path: Path) -> None:
+    model = AdaptiveFm(width=3)
+    path, digest = save_instance(model, tmp_path)
+    assert path.name == f"{digest}.pt"
+
+    loaded = ExternalModel(pickle_path=str(path), digest=digest).build_from_context(
+        context()
+    )
+    assert isinstance(loaded, AdaptiveFm)
+    assert loaded is not model
+    torch.testing.assert_close(loaded.proj.weight, model.proj.weight)
+
+    stale = ExternalModel(pickle_path=str(path), digest="0" * 64)
+    with pytest.raises(ValueError, match="expected 0{64}"):
+        stale.build_from_context(context())
+
+    missing = ExternalModel(pickle_path=str(tmp_path / "absent.pt"), digest=digest)
+    with pytest.raises(FileNotFoundError, match="reachable from the"):
+        missing.build_from_context(context())
+
+
+def test_instance_reloads_fresh_per_build(tmp_path: Path) -> None:
+    model = AdaptiveFm(width=3)
+    path, digest = save_instance(model, tmp_path)
+    config = ExternalModel(pickle_path=str(path), digest=digest)
+
+    first = config.build_from_context(context())
+    assert isinstance(first, AdaptiveFm)  # also narrows the type below
+    with torch.no_grad():
+        first.proj.weight.add_(1.0)  # stand in for fine-tuning
+
+    second = config.build_from_context(context())
+    assert isinstance(second, AdaptiveFm)
+    torch.testing.assert_close(second.proj.weight, model.proj.weight)
+
+
+def test_a_model_from_an_uninstalled_module_loads_without_that_module(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A worker gets neither the caller's ``sys.path`` nor its working directory."""
+    (tmp_path / "user_fm.py").write_text(
+        "from torch import nn\n\n"
+        "class UserFm(nn.Module):\n"
+        "    def forward(self, x, channel_positions):\n"
+        "        return x.mean(-1)\n"
+    )
+    monkeypatch.syspath_prepend(tmp_path)
+    path, digest = save_instance(importlib.import_module("user_fm").UserFm(), tmp_path)
+
+    del sys.modules["user_fm"]
+    monkeypatch.undo()
+    assert importlib.util.find_spec("user_fm") is None
+
+    loaded = ExternalModel(pickle_path=str(path), digest=digest).build_from_context(
+        context()
+    )
+    assert type(loaded).__name__ == "UserFm"
+
+
+def test_build_rejects_a_pickle_it_cannot_use(tmp_path: Path) -> None:
+    not_a_module = tmp_path / "not_a_module.pt"
+    torch.save("just a string", not_a_module)
+    with pytest.raises(TypeError, match="expected a torch.nn.Module"):
+        ExternalModel(pickle_path=str(not_a_module), digest="0" * 64).build_from_context(
+            context()
+        )
+
+    # Re-checked after unpickling, since the worker never saw the caller's check.
+    path, digest = save_instance(NoPositions(), tmp_path)
+    with pytest.raises(ValueError, match="does not accept 'channel_positions'"):
+        ExternalModel(pickle_path=str(path), digest=digest).build_from_context(context())

--- a/neuralbench-repo/neuralbench/test_main.py
+++ b/neuralbench-repo/neuralbench/test_main.py
@@ -146,7 +146,7 @@ def _make_experiment_with_capturing_build(
         del kwargs
         build_draws.append(torch.rand(4))
         _ = torch.rand(11)
-        return nn.Identity(), 0, 0
+        return nn.Identity(), 0, 0, None
 
     monkeypatch.setattr("neuralbench.main.build_brain_model", fake_build_brain_model)
     monkeypatch.setattr("neuralbench.main.BrainModule", _DummyBrainModule)

--- a/neuralbench-repo/neuralbench/test_model_factory.py
+++ b/neuralbench-repo/neuralbench/test_model_factory.py
@@ -37,6 +37,49 @@ class _RecordHeadWidth(BaseBrainModelConfig):
         return nn.Identity()
 
 
+class _NameReader(nn.Module):
+    """Model reading channel identity by name, as LaBraM does."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.seen: list[str] | None = None
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        channel_positions: torch.Tensor | None = None,
+        ch_names: list[str] | None = None,
+    ) -> torch.Tensor:
+        self.seen = ch_names
+        return x
+
+
+class _NameReaderConfig(BaseBrainModelConfig):
+    """Config building a model whose ``forward`` names ``ch_names``."""
+
+    def build(self, n_spatial_locations: int, n_outputs: int | None = None) -> nn.Module:
+        return _NameReader()
+
+
+def test_build_brain_model_names_channels_for_a_model_that_reads_them(
+    build_data: Callable[..., Data],
+) -> None:
+    loader = build_data(seed=0).prepare()["train"]
+    ch_names = list(loader.dataset.extractors["neuro"]._channels.keys())  # type: ignore[attr-defined]
+
+    model, _, _, returned = build_brain_model(
+        brain_model_config=_NameReaderConfig(),
+        downstream_model_wrapper=None,
+        pretrained_weights_fname=None,
+        train_loader=loader,
+    )
+
+    # Returned for the training loop to pass on every batch, and already
+    # carried by the init pass: a model that asks for names never runs without.
+    assert returned == ch_names
+    assert tp.cast(_NameReader, model).seen == ch_names
+
+
 def test_build_brain_model_forwards_dataset_channel_names_to_adapter(
     build_data: Callable[..., Data],
 ) -> None:
@@ -54,7 +97,7 @@ def test_build_brain_model_forwards_dataset_channel_names_to_adapter(
         aggregation="flatten",
     )
 
-    model, _, _ = build_brain_model(
+    model, _, _, _ = build_brain_model(
         brain_model_config=_Passthrough(),
         downstream_model_wrapper=wrapper,
         pretrained_weights_fname=None,

--- a/neuralbench-repo/pyproject.toml
+++ b/neuralbench-repo/pyproject.toml
@@ -14,6 +14,7 @@ classifiers = [
 dependencies = [
   "adjustText",
   "braindecode>=1.8.1",
+  "cloudpickle",
   # Study catalog: registered through an entry point, never imported directly
   "neuralfetch[quickstart]",
   "neuralset",
@@ -93,7 +94,7 @@ namespaces = false
   plugins = ['pydantic.mypy']
   show_error_codes = true
 [[tool.mypy.overrides]]
-  module = ['pytest', 'setuptools', 'mne', 'torchvision', 'spacy', 'spacy.cli', 'osfclient', 'botocore', 'botocore.*', 'boto3', 'wordfreq', 'transformers', 'sklearn.*', 'scipy.*', 'torchmetrics', 'torchmetrics.*', 'braindecode', 'braindecode.*', 'lightning.pytorch.*', 'x_transformers', 'seaborn', 'seaborn.*', 'wandb', 'wandb.*', 'pyriemann', 'pyriemann.*', 'safetensors', 'safetensors.*', 'huggingface_hub']
+  module = ['pytest', 'setuptools', 'mne', 'cloudpickle', 'torchvision', 'spacy', 'spacy.cli', 'osfclient', 'botocore', 'botocore.*', 'boto3', 'wordfreq', 'transformers', 'sklearn.*', 'scipy.*', 'torchmetrics', 'torchmetrics.*', 'braindecode', 'braindecode.*', 'lightning.pytorch.*', 'x_transformers', 'seaborn', 'seaborn.*', 'wandb', 'wandb.*', 'pyriemann', 'pyriemann.*', 'safetensors', 'safetensors.*', 'huggingface_hub']
   ignore_missing_imports = true
 
 [tool.pydantic-mypy]

--- a/neuraltrain-repo/neuraltrain/models/labram.py
+++ b/neuraltrain-repo/neuraltrain/models/labram.py
@@ -10,10 +10,11 @@ Includes the following adaptations:
 
 * Channel name remapping via an explicit user-provided mapping.
 * Dynamic channel resolution at forward time using ``channel_positions`` to
-  detect which channels are valid per sample.
-* Temporal-embedding adaptation so pretrained weights can be reused with a
-  different ``n_times`` (truncation for fewer patches, linear interpolation
-  for more patches than the pretrained model).
+  detect which channels are valid per sample, and ``ch_names`` to name them
+  when the caller's montage differs from the one built with.
+* Dynamic temporal resolution at forward time, so one instance serves any
+  window length: the pretrained temporal embedding is sliced per call
+  (interpolated when a window needs more patches than pretraining had).
 """
 
 import logging
@@ -34,124 +35,261 @@ from .common import (
 logger = logging.getLogger(__name__)
 
 
+def _build_channel_remapping(
+    ch_names: list[str],
+    channel_mapping: dict[str, str] | None = None,
+) -> tuple[dict[str, str], set[str]]:
+    """Map dataset channel names to LaBraM channel names.
+
+    Mapping priority (per channel):
+
+    1. ``channel_mapping`` (explicit user override)
+    2. Direct case-insensitive name match against ``LABRAM_CHANNEL_ORDER`` --
+       the dataset name maps to the canonical LABRAM-cased version.
+    3. Bipolar fallback -- for names like ``"Fp1-F3"``, try matching the anode
+       (``"Fp1"``) against ``LABRAM_CHANNEL_ORDER``.
+
+    Returns
+    -------
+    remap : dict
+        Mapping from every matched channel name to its LaBraM counterpart
+        (always in ``LABRAM_CHANNEL_ORDER`` casing for cases 2 and 3;
+        whatever the user supplied for case 1).  Channels that cannot be
+        mapped are **not** included (they are then dropped by
+        :func:`_resolve_channels`).
+    positionless : set
+        Subset of ``remap`` keys for channels that are not expected to carry
+        montage positions -- i.e. those resolved via the bipolar anode
+        fallback (case 3) or explicit user ``channel_mapping`` (case 1).
+        Regular case-insensitive matches (case 2) are excluded because such
+        channels do have known positions and should be gated by the
+        per-sample position validity check at forward time.
+    """
+    from braindecode.models.labram import LABRAM_CHANNEL_ORDER
+
+    labram_upper = {ch.upper(): ch for ch in LABRAM_CHANNEL_ORDER}
+
+    result: dict[str, str] = {}
+    positionless: set[str] = set()
+    n_bipolar_fallback = 0
+    for name in ch_names:
+        if channel_mapping and name in channel_mapping:
+            result[name] = channel_mapping[name]
+            positionless.add(name)
+            continue
+        canonical = labram_upper.get(name.upper())
+        if canonical is not None:
+            result[name] = canonical
+            continue
+        pair = parse_bipolar_name(name)
+        if pair is not None:
+            anode_canonical = labram_upper.get(pair[0].upper())
+            if anode_canonical is not None:
+                result[name] = anode_canonical
+                positionless.add(name)
+                n_bipolar_fallback += 1
+
+    if n_bipolar_fallback:
+        logger.info(
+            "Mapped %d bipolar channel(s) to LaBraM via anode fallback.",
+            n_bipolar_fallback,
+        )
+
+    return result, positionless
+
+
+def _resolve_channels(
+    ch_names: list[str],
+    channel_mapping: dict[str, str] | None = None,
+) -> tuple[list[str], torch.Tensor, torch.Tensor]:
+    """Derive what :class:`_LabramChannelWrapper` needs from *ch_names*.
+
+    Returns, in the order of *ch_names*:
+
+    * ``labram_names`` -- the LaBraM-cased name to forward to the inner model
+      for each channel (channels with no LaBraM mapping keep their original
+      name; see ``known`` below for how those are then filtered out).
+    * ``positionless`` -- channels that have a valid LaBraM mapping but no
+      montage position (bipolar derivations resolved via anode fallback, or
+      channels added via an explicit ``channel_mapping``).  These are kept
+      regardless of their per-sample ``channel_positions`` row, so e.g.
+      SleepEDF's bipolar ``Fpz-Cz`` or Geodesic E-numbers reach LaBraM even
+      when ``set_montage`` could not assign them coordinates.
+    * ``known`` -- channels whose resolved name is in
+      ``LABRAM_CHANNEL_ORDER`` (case-insensitively).  Channels that fail this
+      check (e.g. unmapped EGI ``E5``, ``E7``, ...) are filtered out entirely
+      so braindecode never sees them.  This matters because braindecode
+      dropped its ``on_unknown_chs`` parameter in ``>=1.5`` and now
+      hard-raises a ``ValueError`` on the first unknown name; doing the
+      filtering here keeps the wrapper's behaviour ("warn-and-drop") stable
+      across braindecode versions.
+    """
+    from braindecode.models.labram import LABRAM_CHANNEL_ORDER
+
+    remap, positionless = _build_channel_remapping(ch_names, channel_mapping)
+    labram_names = [remap.get(name, name) for name in ch_names]
+
+    labram_upper = {ch.upper() for ch in LABRAM_CHANNEL_ORDER}
+    known = [name.upper() in labram_upper for name in labram_names]
+    if not all(known):
+        unknown = sorted({ch_names[i] for i, ok in enumerate(known) if not ok})
+        logger.warning(
+            "%d channel(s) not in LABRAM_CHANNEL_ORDER will be dropped at "
+            "forward time: %s",
+            len(unknown),
+            unknown,
+        )
+
+    return (
+        labram_names,
+        torch.tensor([name in positionless for name in ch_names], dtype=torch.bool),
+        torch.tensor(known, dtype=torch.bool),
+    )
+
+
 class _LabramChannelWrapper(nn.Module):
-    """Wraps a braindecode ``Labram`` to resolve channel names at forward time.
+    """Wraps a braindecode ``Labram`` to resolve its inputs at forward time.
 
-    Channel handling is precomputed in union-channel order:
+    braindecode addresses electrodes by name (``ch_names`` picks rows of the
+    channel embedding) and reads the patch count from build-time state, so a
+    bare ``Labram`` serves exactly the montage and window length it was built
+    for.  This wrapper resolves both per call instead.
 
-    * ``_labram_names`` -- the LaBraM-cased name to forward to the inner
-      model for each union channel (channels with no LaBraM mapping fall
-      back to their original name; see ``_known_mask`` below for how those
-      are then filtered out before reaching braindecode).
-    * ``_positionless_mask`` -- a boolean buffer marking channels that have
-      a valid LaBraM mapping but no montage position (bipolar derivations
-      resolved via anode fallback, or channels added via an explicit
-      ``channel_mapping``).  These are kept regardless of their per-sample
-      ``channel_positions`` row, so e.g. SleepEDF's bipolar ``Fpz-Cz`` or
-      Geodesic E-numbers reach LaBraM even when ``set_montage`` could not
-      assign them coordinates.
-    * ``_known_mask`` -- a boolean buffer marking channels whose
-      wrapper-resolved name is in :data:`LABRAM_CHANNEL_ORDER`
-      (case-insensitively).  Channels that fail this check (e.g. unmapped
-      EGI ``E5``, ``E7``, ...) are filtered out entirely so braindecode
-      never sees them.  This matters because braindecode dropped its
-      ``on_unknown_chs`` parameter in ``>=1.5`` and now hard-raises a
-      ``ValueError`` on the first unknown name; doing the filtering here
-      keeps the wrapper's behaviour ("warn-and-drop") stable across
-      braindecode versions.
+    **Channels.**  Names and masks come from :func:`_resolve_channels`,
+    memoized per name list so the common case -- every batch carrying the
+    montage built with -- resolves once.  At forward time the per-sample
+    position mask is OR-combined with the positionless mask, AND-combined
+    with the known mask, then intersected across the batch (LaBraM's
+    ``ch_names`` is per-batch, so heterogeneous batches fall back to the
+    channels valid in every sample).
 
-    At forward time the per-sample position mask is OR-combined with
-    ``_positionless_mask``, AND-combined with ``_known_mask``, then
-    intersected across the batch (LaBraM's ``ch_names`` is per-batch, so
-    heterogeneous batches fall back to the channels valid in every sample).
+    **Window length.**  ``temporal_embedding`` moves onto the wrapper so it
+    can be cut to the number of patches the input actually carries, while the
+    input itself is padded up to one patch or truncated to a whole number of
+    patches (:func:`compute_temporal_adjustment`).
 
     Parameters
     ----------
     model : nn.Module
         The braindecode ``Labram`` model instance.
     union_ch_names : list of str
-        Ordered channel names from the dataset union (matching the channel
-        dimension of the input tensor).
-    ch_name_to_labram : dict mapping str to str
-        Mapping from dataset channel names to LaBraM channel names, as
-        returned by :meth:`NtLabram._build_channel_remapping`.  Channels not
-        in this dict are dropped by the wrapper before the inner model
-        sees them.
-    positionless_ch_names : set of str, optional
-        Subset of ``ch_name_to_labram`` keys whose channels are not expected
-        to carry montage positions.  Defaults to an empty set.
-    pad_right, truncate_right : int
-        Time-axis padding/truncation applied just before the inner model
-        (see :func:`apply_temporal_adjustment`).
+        Ordered channel names from the dataset union, used for any forward
+        call that does not name its own channels.
+    channel_mapping : dict mapping str to str, optional
+        Explicit mapping from dataset channel names to LaBraM channel names,
+        passed to :func:`_build_channel_remapping`.
     """
+
+    temporal_embedding: nn.Parameter | None
 
     def __init__(
         self,
         model: nn.Module,
         union_ch_names: list[str],
-        ch_name_to_labram: dict[str, str],
-        positionless_ch_names: set[str] | None = None,
-        pad_right: int = 0,
-        truncate_right: int = 0,
+        channel_mapping: dict[str, str] | None = None,
     ) -> None:
         super().__init__()
-        self.model = model
-        self._pad_right = pad_right
-        self._truncate_right = truncate_right
-
-        positionless = set(positionless_ch_names) if positionless_ch_names else set()
-        self._labram_names: list[str] = [
-            ch_name_to_labram.get(name, name) for name in union_ch_names
-        ]
-        self.register_buffer(
-            "_positionless_mask",
-            torch.tensor(
-                [name in positionless for name in union_ch_names],
-                dtype=torch.bool,
-            ),
-        )
-        # ``_known_mask`` gates whether each union channel survives to the
-        # inner braindecode model.  Built lazily-imported because braindecode
-        # is an optional dependency at module-import time (model is
-        # instantiated only when present, so reaching here implies the
-        # import works).
-        from braindecode.models.labram import LABRAM_CHANNEL_ORDER
-
-        labram_upper = {ch.upper() for ch in LABRAM_CHANNEL_ORDER}
-        known = [name.upper() in labram_upper for name in self._labram_names]
-        if not all(known):
-            unknown = sorted({union_ch_names[i] for i, ok in enumerate(known) if not ok})
-            logger.warning(
-                "%d channel(s) not in LABRAM_CHANNEL_ORDER will be dropped "
-                "at forward time: %s",
-                len(unknown),
-                unknown,
+        # Forward-time adaptation reaches into private braindecode internals;
+        # guard the attributes we touch so a future braindecode rename
+        # surfaces here rather than as a confusing forward-time error.
+        for attr in ("patch_size", "patch_embed"):
+            if not hasattr(model, attr):
+                raise AttributeError(
+                    f"_LabramChannelWrapper: braindecode Labram has no "
+                    f"attribute {attr!r}.  Has braindecode's internal layout "
+                    f"changed?"
+                )
+        if not hasattr(model.patch_embed[0], "n_patchs"):  # type: ignore[index]
+            raise AttributeError(
+                "_LabramChannelWrapper: model.patch_embed[0] has no attribute "
+                "'n_patchs'.  Has braindecode's internal layout changed?"
             )
-        self.register_buffer("_known_mask", torch.tensor(known, dtype=torch.bool))
 
-    def forward(self, x: torch.Tensor, channel_positions: torch.Tensor) -> torch.Tensor:
-        """Forward pass with dynamic channel selection.
+        self.model = model
+        self.channel_mapping = channel_mapping
+        self.patch_size: int = model.patch_size  # type: ignore[assignment]
+        # Owned by the wrapper rather than by ``model`` so that a slice of it
+        # can be handed back per call; braindecode reads it as a plain
+        # attribute either way, and gradients still reach the full parameter.
+        self.temporal_embedding = model._parameters.pop("temporal_embedding", None)
+
+        self._union_ch_names = list(union_ch_names)
+        self._resolved: dict[
+            tuple[str, ...], tuple[list[str], torch.Tensor, torch.Tensor]
+        ] = {}
+        self._resolve(self._union_ch_names)
+
+    def _resolve(
+        self, ch_names: list[str]
+    ) -> tuple[list[str], torch.Tensor, torch.Tensor]:
+        key = tuple(ch_names)
+        if key not in self._resolved:
+            self._resolved[key] = _resolve_channels(ch_names, self.channel_mapping)
+        return self._resolved[key]
+
+    def _temporal_embedding(self, n_patches: int) -> torch.Tensor:
+        """The pretrained temporal embedding, cut or stretched to *n_patches*.
+
+        braindecode tiles ``temporal_embedding[:, :-1]`` across channels, so
+        its length is what fixes the number of time tokens.
+        """
+        embedding = tp.cast(torch.Tensor, self.temporal_embedding)
+        if n_patches + 1 <= embedding.shape[1]:
+            return embedding[:, : n_patches + 1]
+        patches = F.interpolate(
+            embedding[:, 1:].permute(0, 2, 1),
+            size=n_patches,
+            mode="linear",
+            align_corners=False,
+        ).permute(0, 2, 1)
+        return torch.cat([embedding[:, :1], patches], dim=1)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        channel_positions: torch.Tensor,
+        ch_names: list[str] | None = None,
+    ) -> torch.Tensor:
+        """Forward pass with dynamic channel and window-length selection.
 
         Parameters
         ----------
         x : (B, n_channels, n_times)
         channel_positions : (B, n_channels, n_spatial_dims)
+        ch_names : list of str, optional
+            Names of the channels of *x*, defaulting to the montage the
+            wrapper was built with.  Pass it whenever the incoming montage
+            differs -- LaBraM cannot name an electrode from its coordinates.
         """
+        labram_names, positionless, known = self._resolve(
+            ch_names if ch_names is not None else self._union_ch_names
+        )
+        if len(labram_names) != x.shape[1]:
+            raise ValueError(
+                f"Got {len(labram_names)} channel name(s) for {x.shape[1]} input "
+                "channels. LaBraM selects its channel embedding by name, so a "
+                "montage other than the one built with must be passed as "
+                "'ch_names' at forward time."
+            )
+
         valid = (channel_positions != INVALID_POS_VALUE).any(dim=-1)
-        valid = valid | self._positionless_mask  # type: ignore[operator]
-        valid = valid & self._known_mask  # type: ignore[operator]
+        valid = valid | positionless.to(valid.device)
+        valid = valid & known.to(valid.device)
         # Intersect across the batch: braindecode's ``ch_names`` is per-batch.
         common = valid.all(dim=0)
+        names = [labram_names[i] for i in common.nonzero(as_tuple=True)[0].tolist()]
 
-        indices = common.nonzero(as_tuple=True)[0].tolist()
-        ch_names = [self._labram_names[i] for i in indices]
-
-        x_valid = x[:, common, :]
-        x_valid = apply_temporal_adjustment(
-            x_valid, self._pad_right, self._truncate_right
+        pad_right, truncate_right = compute_temporal_adjustment(
+            x.shape[2], self.patch_size
         )
+        x_valid = apply_temporal_adjustment(x[:, common, :], pad_right, truncate_right)
 
-        return self.model(x_valid, ch_names=ch_names, return_all_tokens=True)
+        n_patches = x_valid.shape[2] // self.patch_size
+        self.model.patch_embed[0].n_patchs = n_patches  # type: ignore[index,union-attr]
+        if self.temporal_embedding is not None:
+            self.model.temporal_embedding = self._temporal_embedding(n_patches)
+
+        return self.model(x_valid, ch_names=names, return_all_tokens=True)
 
 
 class NtLabram(BaseBrainDecodeModel):
@@ -163,10 +301,10 @@ class NtLabram(BaseBrainDecodeModel):
        dataset channel names to LaBraM channel names.  Channels whose names
        already match ``LABRAM_CHANNEL_ORDER`` (case-insensitively) need no
        entry.
-    2. **Dynamic channel resolution** -- the model is wrapped in
-       :class:`_LabramChannelWrapper` so that valid channels are detected from
-       ``channel_positions`` at each forward call, then remapped and passed to
-       the inner braindecode model via ``ch_names``.
+    2. **Forward-time adaptation** -- the model is wrapped in
+       :class:`_LabramChannelWrapper`, which picks the valid channels and the
+       number of time patches from each batch, so one instance serves any
+       montage and window length.
 
     Parameters
     ----------
@@ -180,173 +318,6 @@ class NtLabram(BaseBrainDecodeModel):
     required_fields: tp.ClassVar[list[RequiredBuildField]] = ["ch_names", "n_times"]
     channel_mapping: dict[str, str] | None = None
 
-    def _build_channel_remapping(
-        self,
-        union_ch_names: list[str],
-    ) -> tuple[dict[str, str], set[str]]:
-        """Build a mapping from dataset channel names to LaBraM channel names.
-
-        Mapping priority (per channel):
-
-        1. ``self.channel_mapping`` (explicit user override)
-        2. Direct case-insensitive name match against
-           ``LABRAM_CHANNEL_ORDER`` -- the dataset name maps to the
-           canonical LABRAM-cased version.
-        3. Bipolar fallback -- for names like ``"Fp1-F3"``, try matching the
-           anode (``"Fp1"``) against ``LABRAM_CHANNEL_ORDER``.
-
-        Returns
-        -------
-        remap : dict
-            Mapping from every matched union channel name to its LaBraM
-            counterpart (always in ``LABRAM_CHANNEL_ORDER`` casing for cases
-            2 and 3; whatever the user supplied for case 1).  Channels that
-            cannot be mapped are **not** included (they will be passed
-            through as-is and handled by braindecode's ``on_unknown_chs``
-            policy).
-        positionless : set
-            Subset of ``remap`` keys for channels that are not expected to
-            carry montage positions -- i.e. those resolved via the bipolar
-            anode fallback (case 3) or explicit user ``channel_mapping``
-            (case 1).  Regular case-insensitive matches (case 2) are excluded
-            because such channels do have known positions and should be gated
-            by the per-sample position validity check at forward time.
-        """
-        from braindecode.models.labram import LABRAM_CHANNEL_ORDER
-
-        labram_upper = {ch.upper(): ch for ch in LABRAM_CHANNEL_ORDER}
-
-        result: dict[str, str] = {}
-        positionless: set[str] = set()
-        n_bipolar_fallback = 0
-        for name in union_ch_names:
-            if self.channel_mapping and name in self.channel_mapping:
-                result[name] = self.channel_mapping[name]
-                positionless.add(name)
-                continue
-            canonical = labram_upper.get(name.upper())
-            if canonical is not None:
-                result[name] = canonical
-                continue
-            pair = parse_bipolar_name(name)
-            if pair is not None:
-                anode_canonical = labram_upper.get(pair[0].upper())
-                if anode_canonical is not None:
-                    result[name] = anode_canonical
-                    positionless.add(name)
-                    n_bipolar_fallback += 1
-
-        if n_bipolar_fallback:
-            logger.info(
-                "Mapped %d bipolar channel(s) to LaBraM via anode fallback.",
-                n_bipolar_fallback,
-            )
-
-        return result, positionless
-
-    @staticmethod
-    def _adapt_pretrained_dimensions(model: nn.Module, n_times: int) -> tuple[int, int]:
-        """Adapt a pretrained LaBraM model to a different ``n_times`` in-place.
-
-        When the input ``n_times`` is not directly compatible with the model's
-        ``patch_size``, the method computes the effective number of time
-        samples to use (``effective_n_times``) and returns padding/truncation
-        hints so that the wrapper can adjust inputs at forward time:
-
-        * If ``n_times < patch_size``, the input will be zero-padded to
-          ``patch_size`` (1 patch).
-        * If ``n_times`` is not divisible by ``patch_size``, the input is
-          truncated to the largest multiple of ``patch_size`` that fits.
-        * If the resulting number of patches exceeds the pretrained model's
-          capacity, the temporal embedding is interpolated (linearly).
-        * If fewer patches are needed, the temporal embedding is truncated.
-
-        Returns ``(pad_right, truncate_right)`` -- exactly one is non-zero.
-        """
-        # Adaptation reaches into private braindecode internals; guard the
-        # attributes we touch so a future braindecode rename surfaces here
-        # rather than as a confusing forward-time error.
-        for attr in ("patch_size", "n_times", "patch_embed"):
-            if not hasattr(model, attr):
-                raise AttributeError(
-                    f"NtLabram._adapt_pretrained_dimensions: braindecode "
-                    f"Labram has no attribute {attr!r}.  Has braindecode's "
-                    f"internal layout changed?"
-                )
-        patch_embed_first = model.patch_embed[0]  # type: ignore[index]
-        if not hasattr(patch_embed_first, "n_patchs"):
-            raise AttributeError(
-                "NtLabram._adapt_pretrained_dimensions: "
-                "model.patch_embed[0] has no attribute 'n_patchs'.  Has "
-                "braindecode's internal layout changed?"
-            )
-
-        patch_size: int = model.patch_size  # type: ignore[assignment]
-
-        pad_right, truncate_right = compute_temporal_adjustment(n_times, patch_size)
-        effective_n_times = n_times + pad_right - truncate_right
-
-        if pad_right:
-            logger.info(
-                "n_times=%d < patch_size=%d; will zero-pad %d samples on "
-                "the right at forward time.",
-                n_times,
-                patch_size,
-                pad_right,
-            )
-        elif truncate_right:
-            logger.info(
-                "n_times=%d is not divisible by patch_size=%d; will "
-                "truncate %d samples on the right at forward time.",
-                n_times,
-                patch_size,
-                truncate_right,
-            )
-
-        actual_n_patches = effective_n_times // patch_size
-        pretrained_n_patches: int = patch_embed_first.n_patchs  # type: ignore[assignment]
-
-        if actual_n_patches == pretrained_n_patches:
-            return pad_right, truncate_right
-
-        logger.info(
-            "Adapting pretrained LaBraM from n_times=%d (%d patches) to "
-            "n_times=%d (%d patches)",
-            model.n_times,
-            pretrained_n_patches,
-            effective_n_times,
-            actual_n_patches,
-        )
-
-        if hasattr(model, "temporal_embedding"):
-            if actual_n_patches < pretrained_n_patches:
-                n_keep = actual_n_patches + 1
-                model.temporal_embedding = nn.Parameter(  # type: ignore[index]
-                    model.temporal_embedding.data[:, :n_keep, :]  # type: ignore[index]
-                )
-            else:
-                old_emb: torch.Tensor = model.temporal_embedding.data  # type: ignore[index,assignment]
-                cls_token = old_emb[:, :1, :]
-                patch_tokens = old_emb[:, 1:, :]
-                patch_tokens = patch_tokens.permute(0, 2, 1)
-                patch_tokens = F.interpolate(
-                    patch_tokens,
-                    size=actual_n_patches,
-                    mode="linear",
-                    align_corners=False,
-                )
-                patch_tokens = patch_tokens.permute(0, 2, 1)
-                model.temporal_embedding = nn.Parameter(
-                    torch.cat([cls_token, patch_tokens], dim=1)
-                )
-
-        model._n_times = effective_n_times  # type: ignore[assignment]
-        model.n_path = actual_n_patches  # type: ignore[assignment]
-        patch_embed_first.n_patchs = actual_n_patches  # type: ignore[assignment]
-        patch_embed_first.n_times = effective_n_times  # type: ignore[assignment,union-attr]
-
-        return pad_right, truncate_right
-
     def build(
         self,
         n_spatial_locations: int,
@@ -355,24 +326,10 @@ class NtLabram(BaseBrainDecodeModel):
         chs_info: list[dict[str, tp.Any]] | None = None,
         frequency: float | None = None,
     ) -> nn.Module:
-        # Precompute channel remapping
-        ch_name_to_labram: dict[str, str] = {}
-        positionless_ch_names: set[str] = set()
-        union_ch_names: list[str] = []
-        if chs_info is not None:
-            union_ch_names = [ch["ch_name"] for ch in chs_info]
-            ch_name_to_labram, positionless_ch_names = self._build_channel_remapping(
-                union_ch_names
-            )
-
-        pad_right = 0
-        truncate_right = 0
-
         if self.from_pretrained_name is not None:
+            # Built at the pretrained shape; the wrapper adapts every batch to
+            # it, so the requested one is not passed on.
             model = self._construct()
-            pad_right, truncate_right = self._adapt_pretrained_dimensions(
-                model, n_temporal_samples
-            )
         else:
             construct_kwargs: dict[str, tp.Any] = {
                 "n_chans": n_spatial_locations,
@@ -382,14 +339,11 @@ class NtLabram(BaseBrainDecodeModel):
                 construct_kwargs["n_outputs"] = n_outputs
             model = self._construct(**construct_kwargs)
 
-        if chs_info is not None:
-            model = _LabramChannelWrapper(
-                model,
-                union_ch_names,
-                ch_name_to_labram,
-                positionless_ch_names=positionless_ch_names,
-                pad_right=pad_right,
-                truncate_right=truncate_right,
-            )
+        if chs_info is None:
+            return model
 
-        return model
+        return _LabramChannelWrapper(
+            model,
+            [ch["ch_name"] for ch in chs_info],
+            channel_mapping=self.channel_mapping,
+        )

--- a/neuraltrain-repo/neuraltrain/models/reve.py
+++ b/neuraltrain-repo/neuraltrain/models/reve.py
@@ -11,6 +11,10 @@ Includes the following adaptations over the raw braindecode REVE model:
 * **Channel name remapping** -- an explicit ``channel_mapping`` dict maps
   dataset channel names to names recognised by REVE's position bank.
   Channels whose names already appear in the bank need no entry.
+* **Per-batch channel positions** -- the wrapper takes the dataset's
+  ``channel_positions`` as REVE's ``pos`` for any montage the build could not
+  resolve from the position bank, so one instance serves montages it was not
+  built for.
 * **Pretrained loading** -- REVE's ``__init__`` requires ``n_times`` and
   ``n_outputs`` to build its ``final_layer``, but
   :class:`BaseBrainDecodeModel.build` blocks ``n_times`` for pretrained
@@ -28,19 +32,27 @@ import torch
 import torch.nn as nn
 
 from .base import BaseBrainDecodeModel, RequiredBuildField
-from .common import parse_bipolar_name
+from .common import INVALID_POS_VALUE, parse_bipolar_name
 
 logger = logging.getLogger(__name__)
 
 
 class _ReveWrapper(nn.Module):
-    """Thin wrapper around REVE for channel subsetting and encoder-only output.
+    """Thin wrapper around REVE for channel handling and encoder-only output.
 
-    Combines two optional adaptations in a single module:
+    Combines three adaptations in a single module:
 
-    * **Channel subsetting** -- when *channel_indices* is not ``None``,
-      the input EEG tensor is sliced along the channel dimension before
-      forwarding to REVE.  No-op when ``None``.
+    * **Channel subsetting** -- when *channel_indices* is not ``None``, the EEG
+      tensor and the channel positions are sliced along the channel dimension
+      before forwarding to REVE.  No-op when ``None``.
+    * **Channel positions** -- when the build named every channel,
+      *bank_positions* wins: those are the coordinates REVE was pretrained
+      with, and using them keeps a result independent of how the montage was
+      digitised.  Otherwise the batch's ``channel_positions`` become REVE's
+      ``pos``, and channels the montage could not place (they arrive as
+      ``INVALID_POS_VALUE``) are dropped.  A bank only lines up with the
+      montage it was built from, so an instance that must span montages of the
+      same width should be built without ``chs_info``.
     * **Encoder-only output** -- when *encoder_only* is ``True``, the
       forward call passes ``return_output=True`` to REVE and returns the
       final transformer layer output (index ``-1``), bypassing REVE's
@@ -48,16 +60,19 @@ class _ReveWrapper(nn.Module):
     """
 
     channel_indices: torch.Tensor | None
+    bank_positions: torch.Tensor | None
 
     def __init__(
         self,
         model: nn.Module,
         channel_indices: list[int] | None = None,
         encoder_only: bool = False,
+        bank_positions: torch.Tensor | None = None,
     ):
         super().__init__()
         self.model = model
         self.encoder_only = encoder_only
+        self.register_buffer("bank_positions", bank_positions)
         if channel_indices is not None:
             self.register_buffer(
                 "channel_indices",
@@ -67,13 +82,27 @@ class _ReveWrapper(nn.Module):
             self.register_buffer("channel_indices", None)
 
     def forward(
-        self, eeg: torch.Tensor, pos: torch.Tensor | None = None, **kwargs: tp.Any
+        self,
+        eeg: torch.Tensor,
+        channel_positions: torch.Tensor | None = None,
+        **kwargs: tp.Any,
     ) -> torch.Tensor:
         if self.channel_indices is not None:
             eeg = eeg[:, self.channel_indices]
+            if channel_positions is not None:
+                channel_positions = channel_positions[:, self.channel_indices]
+        bank = self.bank_positions
+        if bank is not None and eeg.shape[1] == bank.shape[0]:
+            channel_positions = bank.to(eeg).expand(eeg.shape[0], -1, -1)
+        elif channel_positions is not None:
+            unplaced = (channel_positions == INVALID_POS_VALUE).all(dim=-1)
+            keep = ~unplaced.any(dim=0)
+            eeg, channel_positions = eeg[:, keep], channel_positions[:, keep]
         if self.encoder_only:
-            return self.model(eeg, pos=pos, return_output=True, **kwargs)[-1]
-        return self.model(eeg, pos=pos, **kwargs)
+            return self.model(eeg, pos=channel_positions, return_output=True, **kwargs)[
+                -1
+            ]
+        return self.model(eeg, pos=channel_positions, **kwargs)
 
 
 class NtReve(BaseBrainDecodeModel):
@@ -152,7 +181,8 @@ class NtReve(BaseBrainDecodeModel):
         n_chans = n_spatial_locations
 
         channel_indices: list[int] | None = None
-        custom_positions: torch.Tensor | None = None
+        bank_positions: torch.Tensor | None = None
+        n_derived = 0
 
         if chs_info is not None:
             from braindecode.models.reve import RevePositionBank
@@ -164,7 +194,6 @@ class NtReve(BaseBrainDecodeModel):
             valid_chs: list[dict[str, tp.Any]] = []
             positions: list[torch.Tensor] = []
             dropped: list[str] = []
-            n_derived = 0
 
             for i, ch in enumerate(chs_info):
                 name = ch["ch_name"]
@@ -213,14 +242,13 @@ class NtReve(BaseBrainDecodeModel):
                 n_derived,
             )
 
-            if n_derived > 0:
-                custom_positions = torch.stack(positions)
+            bank_positions = torch.stack(positions)
 
         build_kwargs: dict[str, tp.Any] = {
             "n_chans": n_chans,
             "n_times": n_temporal_samples,
         }
-        if chs_info is not None and custom_positions is None:
+        if chs_info is not None and n_derived == 0:
             build_kwargs["chs_info"] = chs_info
 
         encoder_only = n_outputs is None
@@ -232,7 +260,7 @@ class NtReve(BaseBrainDecodeModel):
 
         model = self._construct(**build_kwargs)
 
-        if custom_positions is not None:
-            model.default_pos = custom_positions
+        if bank_positions is not None and n_derived > 0:
+            model.default_pos = bank_positions
 
-        return _ReveWrapper(model, channel_indices, encoder_only)
+        return _ReveWrapper(model, channel_indices, encoder_only, bank_positions)

--- a/neuraltrain-repo/neuraltrain/models/test_labram.py
+++ b/neuraltrain-repo/neuraltrain/models/test_labram.py
@@ -8,9 +8,14 @@ import pytest
 import torch
 
 from .common import INVALID_POS_VALUE
-from .labram import NtLabram, _LabramChannelWrapper
+from .labram import (
+    NtLabram,
+    _build_channel_remapping,
+    _LabramChannelWrapper,
+)
 
 CH_NAMES = ["Fp1", "Fp2", "C3", "C4", "O1", "O2", "Fz", "Cz"]
+PATCH_SIZE = 50
 
 try:
     from braindecode.models.labram import (  # noqa: F401  # pylint: disable=unused-import
@@ -28,11 +33,16 @@ requires_labram_channel_order = pytest.mark.skipif(
 
 
 class _RecordingModel(torch.nn.Module):
-    """Thin nn.Module that records the ``ch_names`` and input shape it receives."""
+    """Stands in for a braindecode ``Labram``, recording what it receives."""
 
-    def __init__(self):
+    def __init__(self, n_patchs: int = 2):
         super().__init__()
         self.linear = torch.nn.Linear(1, 1)
+        self.patch_size = PATCH_SIZE
+        patch_embed = torch.nn.Module()
+        patch_embed.n_patchs = n_patchs  # type: ignore[assignment]
+        self.patch_embed = torch.nn.Sequential(patch_embed)
+        self.temporal_embedding = torch.nn.Parameter(torch.zeros(1, 16, 4))
         self.last_ch_names: list[str] | None = None
         self.last_x_shape: tuple[int, ...] | None = None
 
@@ -42,11 +52,9 @@ class _RecordingModel(torch.nn.Module):
         return x.mean(dim=(1, 2), keepdim=False).unsqueeze(-1)
 
 
-def _make_wrapper(names, remap=None):
-    if remap is None:
-        remap = {n: n for n in names}
+def _make_wrapper(names, channel_mapping=None):
     inner = _RecordingModel()
-    return _LabramChannelWrapper(inner, names, remap), inner
+    return _LabramChannelWrapper(inner, names, channel_mapping), inner
 
 
 # ---------------------------------------------------------------------------
@@ -67,7 +75,7 @@ def test_wrapper_filters_to_valid_channels():
 
     wrapper(x, pos)
 
-    assert inner.last_ch_names == ["Fp1", "C3", "O1"]
+    assert inner.last_ch_names == ["FP1", "C3", "O1"]
     assert inner.last_x_shape == (B, 3, T)
 
 
@@ -79,8 +87,7 @@ def test_wrapper_remapping_and_unknown_dropped():
     braindecode, because braindecode>=1.5 hard-raises on unknown names
     instead of silently dropping them.
     """
-    remap = {"Fp1": "FP1", "C3": "C3"}
-    wrapper, inner = _make_wrapper(["Fp1", "C3", "WEIRD_CH"], remap)
+    wrapper, inner = _make_wrapper(["Fp1", "C3", "WEIRD_CH"])
 
     wrapper(torch.randn(1, 3, 50), torch.rand(1, 3, 2))
 
@@ -99,8 +106,7 @@ def test_wrapper_drops_unmapped_egi_channels():
     ``ValueError: ch_names contains a name not in LABRAM_CHANNEL_ORDER``.
     """
     union = ["Fp1", "E5", "Cz", "E7", "O2"]
-    remap = {"Fp1": "FP1", "Cz": "CZ", "O2": "O2"}
-    wrapper, inner = _make_wrapper(union, remap)
+    wrapper, inner = _make_wrapper(union, {"Fp1": "FP1"})
 
     B, C, T, D = 1, len(union), 50, 2
     pos = torch.rand(B, C, D)
@@ -123,12 +129,55 @@ def test_wrapper_heterogeneous_batch_uses_intersection():
 
     wrapper(torch.randn(B, C, T), pos)
 
-    assert inner.last_ch_names == ["Fp1"]
+    assert inner.last_ch_names == ["FP1"]
     assert inner.last_x_shape == (B, 1, T)
 
 
+@requires_labram_channel_order
+def test_wrapper_names_channels_per_call():
+    """A montage other than the one built with is named at forward time."""
+    wrapper, inner = _make_wrapper(CH_NAMES)
+    other = ["T7", "T8", "Pz"]
+
+    wrapper(torch.randn(1, 3, 50), torch.rand(1, 3, 2), ch_names=other)
+
+    assert inner.last_ch_names == ["T7", "T8", "PZ"]
+    assert inner.last_x_shape == (1, 3, 50)
+
+
+@requires_labram_channel_order
+def test_wrapper_rejects_width_it_cannot_name():
+    wrapper, _ = _make_wrapper(CH_NAMES)
+
+    with pytest.raises(ValueError, match="selects its channel embedding by name"):
+        wrapper(torch.randn(1, 3, 50), torch.rand(1, 3, 2))
+
+
+@requires_labram_channel_order
+@pytest.mark.parametrize(
+    "n_times, n_patches",
+    [
+        (25, 1),  # shorter than patch_size -> padded
+        (125, 2),  # not divisible -> truncated
+        (150, 3),  # exact multiple
+        (1000, 20),  # more patches than the embedding holds -> interpolated
+    ],
+)
+def test_wrapper_serves_any_window_length(n_times: int, n_patches: int):
+    wrapper, inner = _make_wrapper(CH_NAMES)
+
+    wrapper(
+        torch.randn(1, len(CH_NAMES), n_times),
+        torch.rand(1, len(CH_NAMES), 2),
+    )
+
+    assert inner.last_x_shape == (1, len(CH_NAMES), n_patches * PATCH_SIZE)
+    assert inner.patch_embed[0].n_patchs == n_patches
+    assert inner.temporal_embedding.shape[1] == n_patches + 1
+
+
 # ---------------------------------------------------------------------------
-# NtLabram._build_channel_remapping
+# _build_channel_remapping
 # ---------------------------------------------------------------------------
 
 
@@ -141,30 +190,31 @@ def test_build_channel_remapping():
     already match its internal table.
     """
     # Direct case-2 match: dataset-cased names map to LABRAM-cased canonical.
-    remap, positionless = NtLabram()._build_channel_remapping(["Fp1", "Cz", "O2"])
+    remap, positionless = _build_channel_remapping(["Fp1", "Cz", "O2"])
     assert remap == {"Fp1": "FP1", "Cz": "CZ", "O2": "O2"}
     assert positionless == set()
 
     # Case-insensitive match still resolves, output is canonical.
-    remap, positionless = NtLabram()._build_channel_remapping(["fp1", "cZ"])
+    remap, positionless = _build_channel_remapping(["fp1", "cZ"])
     assert remap == {"fp1": "FP1", "cZ": "CZ"}
     assert positionless == set()
 
     # Unknown channels excluded
-    remap, positionless = NtLabram()._build_channel_remapping(["Fp1", "NONEXISTENT"])
+    remap, positionless = _build_channel_remapping(["Fp1", "NONEXISTENT"])
     assert remap == {"Fp1": "FP1"}
     assert positionless == set()
 
     # Explicit mapping overrides name matching; explicit entries are
     # treated as positionless because they typically denote channel
     # systems whose montage positions cannot be resolved.
-    cfg = NtLabram(channel_mapping={"E1": "FP1", "Fp1": "FP2"})
-    remap, positionless = cfg._build_channel_remapping(["E1", "Fp1", "Cz"])
+    remap, positionless = _build_channel_remapping(
+        ["E1", "Fp1", "Cz"], {"E1": "FP1", "Fp1": "FP2"}
+    )
     assert remap == {"E1": "FP1", "Fp1": "FP2", "Cz": "CZ"}
     assert positionless == {"E1", "Fp1"}
 
     # Bipolar fallback channels are positionless.
-    remap, positionless = NtLabram()._build_channel_remapping(["Fp1-F3", "Cz"])
+    remap, positionless = _build_channel_remapping(["Fp1-F3", "Cz"])
     assert remap == {"Fp1-F3": "FP1", "Cz": "CZ"}
     assert positionless == {"Fp1-F3"}
 
@@ -185,9 +235,9 @@ def test_build_with_chs_info_returns_wrapper():
     )
 
     assert isinstance(model, _LabramChannelWrapper)
-    # Each CH_NAME is in LABRAM_CHANNEL_ORDER; the wrapper stores the
+    # Each CH_NAME is in LABRAM_CHANNEL_ORDER; the wrapper resolves the
     # LABRAM-cased canonical for every union channel.
-    assert model._labram_names == [n.upper() for n in CH_NAMES]
+    assert model._resolve(CH_NAMES)[0] == [n.upper() for n in CH_NAMES]
 
 
 def test_build_without_chs_info_returns_raw_model():
@@ -221,68 +271,53 @@ requires_pretrained = pytest.mark.skipif(
 )
 
 
-@requires_pretrained
-@pytest.mark.parametrize("n_times", [3000, 800])
-def test_pretrained_forward(n_times: int):
-    """Load pretrained weights, forward with a channel subset."""
-    subset = ["Fp1", "Fp2", "C3", "C4", "O1", "O2", "Fz", "Cz"]
-
-    cfg = NtLabram(from_pretrained_name=PRETRAINED_NAME)
-    model = cfg.build(
-        n_spatial_locations=len(subset),
-        n_temporal_samples=n_times,
-        n_outputs=None,
-        chs_info=[{"ch_name": n} for n in subset],
-    )
-
-    assert isinstance(model, _LabramChannelWrapper)
-
-    x = torch.randn(1, len(subset), n_times)
-    pos = torch.rand(1, len(subset), 3)
-
-    with torch.no_grad():
-        out = model(x, pos)
-
-    assert out.shape[0] == 1
-    assert out.ndim == 3  # (B, n_tokens, embed_dim) with return_all_tokens=True
-
-
-@requires_pretrained
-@pytest.mark.parametrize(
-    "n_times, expected_patches, pad_right, truncate_right",
-    [
-        (100, 1, 100, 0),  # shorter than patch_size -> pad
-        (500, 2, 0, 100),  # not divisible -> truncate
-        (800, 4, 0, 0),  # exact multiple -> no adjustment
-        (3000, 15, 0, 0),  # matches pretrained -> no-op
-        (6000, 30, 0, 0),  # longer -> interpolation
-    ],
-)
-def test_adapt_pretrained_dimensions(
-    n_times: int,
-    expected_patches: int,
-    pad_right: int,
-    truncate_right: int,
-):
-    """Temporal adaptation: padding, truncation, and embedding interpolation."""
-    cfg = NtLabram(from_pretrained_name=PRETRAINED_NAME)
-
-    model = cfg.build(
+@pytest.fixture(scope="module")
+def pretrained_wrapper() -> _LabramChannelWrapper:
+    model = NtLabram(from_pretrained_name=PRETRAINED_NAME).build(
         n_spatial_locations=len(CH_NAMES),
-        n_temporal_samples=n_times,
+        n_temporal_samples=800,
         n_outputs=None,
         chs_info=[{"ch_name": n} for n in CH_NAMES],
     )
     assert isinstance(model, _LabramChannelWrapper)
-    assert model._pad_right == pad_right
-    assert model._truncate_right == truncate_right
-    assert model.model.patch_embed[0].n_patchs == expected_patches  # type: ignore[index,union-attr]
-    # cls token + patch tokens
-    assert model.model.temporal_embedding.shape[1] == expected_patches + 1  # type: ignore[index]
+    return model
 
+
+@requires_pretrained
+@pytest.mark.parametrize(
+    "n_times, n_patches",
+    [
+        (100, 1),  # shorter than patch_size -> padded
+        (500, 2),  # not divisible -> truncated
+        (800, 4),  # exact multiple
+        (3000, 15),  # matches pretraining
+        (6000, 30),  # longer than pretraining -> interpolated embedding
+    ],
+)
+def test_pretrained_forward(
+    pretrained_wrapper: _LabramChannelWrapper, n_times: int, n_patches: int
+):
+    """One instance covers every window length, at a channel subset."""
     x = torch.randn(1, len(CH_NAMES), n_times)
     pos = torch.rand(1, len(CH_NAMES), 3)
+
     with torch.no_grad():
-        out = model(x, pos)
-    assert out.shape[0] == 1
-    assert out.ndim == 3
+        out = pretrained_wrapper(x, pos)
+
+    # (B, n_channels * n_patches + [CLS], embed_dim), return_all_tokens=True
+    assert out.shape[:2] == (1, len(CH_NAMES) * n_patches + 1)
+
+
+@requires_pretrained
+def test_pretrained_forward_other_montage(pretrained_wrapper: _LabramChannelWrapper):
+    """The same instance also serves a montage it was not built with."""
+    other = ["T7", "T8", "Pz", "NOT_AN_ELECTRODE"]
+
+    with torch.no_grad():
+        out = pretrained_wrapper(
+            torch.randn(1, len(other), 400),
+            torch.rand(1, len(other), 3),
+            ch_names=other,
+        )
+
+    assert out.shape[:2] == (1, 3 * 2 + 1)  # the unknown name is dropped

--- a/neuraltrain-repo/neuraltrain/models/test_reve.py
+++ b/neuraltrain-repo/neuraltrain/models/test_reve.py
@@ -10,6 +10,7 @@ import braindecode.models
 import pytest
 import torch
 
+from .common import INVALID_POS_VALUE
 from .reve import NtReve, _ReveWrapper
 
 BANK_CH_NAMES = ["Fp1", "Fp2", "C3", "C4", "O1", "O2", "Fz", "Cz"]
@@ -71,6 +72,45 @@ def test_wrapper_forward(encoder_only):
     else:
         assert out.shape == (2, _N_OUTPUTS)
         assert out_sub.shape == (1, _N_OUTPUTS)
+
+
+@pytest.mark.parametrize("unplaced, n_kept", [(None, 4), (1, 3)])
+def test_wrapper_takes_positions_from_the_batch(unplaced, n_kept):
+    """Without a bank, the batch places the channels; unplaced ones are dropped."""
+    wrapper = _ReveWrapper(_make_reve(["Fp1", "Fp2", "C3", "C4"]), encoder_only=True)
+    positions = torch.rand(2, 4, 3) * 0.1
+    if unplaced is not None:
+        positions[:, unplaced] = INVALID_POS_VALUE
+
+    eeg = torch.randn(2, 4, _N_TIMES)
+    with torch.no_grad():
+        out = wrapper(eeg, channel_positions=positions)
+        elsewhere = wrapper(eeg, channel_positions=positions.flip(1))
+
+    assert out.shape == (2, n_kept * _N_PATCHES, _EMBED_DIM)
+    assert not torch.allclose(out, elsewhere), "positions do not reach REVE"
+
+
+@pytest.mark.parametrize("channel_indices, n_chans", [(None, 4), ([0, 3], 2)])
+def test_wrapper_prefers_the_bank_it_was_built_with(channel_indices, n_chans):
+    """A build that named every channel pins the coordinates REVE sees."""
+    ch_names = ["Fp1", "Fp2", "C3", "C4"] if channel_indices is None else ["Fp1", "C4"]
+    model = _make_reve(ch_names)
+    bank = torch.rand(n_chans, 3) * 0.1
+    wrapper = _ReveWrapper(model, channel_indices, True, bank)
+
+    eeg = torch.randn(2, 4, _N_TIMES)
+    # The same model without a bank, handed the bank's coordinates by the batch.
+    as_batch = torch.zeros(2, 4, 3)
+    as_batch[:, channel_indices if channel_indices is not None else slice(None)] = bank
+    plain = _ReveWrapper(model, channel_indices, encoder_only=True)
+
+    with torch.no_grad():
+        out = wrapper(eeg, channel_positions=torch.rand(2, 4, 3) * 0.1)
+        expected = plain(eeg, channel_positions=as_batch)
+
+    assert out.shape == (2, n_chans * _N_PATCHES, _EMBED_DIM)
+    assert torch.equal(out, expected), "the batch's coordinates beat the bank's"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Adds `evaluate_model()`, a way to score a `torch.nn.Module` you built yourself on a NeuralBench suite, without onboarding it into `neuraltrain` and giving it a `models/*.yaml`.

```python
from neuralbench import check_model, evaluate_model

print(check_model(my_model, "eeg", "motor_imagery"))  # shapes only: seconds, no data
scores = evaluate_model(my_model, "eeg", "all", name="my-eeg-fm")
```

`device`/`task`/`dataset` mean what they mean on the CLI, and the results come back as a DataFrame.

### The model contract

One instance serves every task in the selection, so this path only accepts a model that adapts to its input: any channel count, any window length, reading channel identity from `channel_positions` (or `ch_names`) in `forward`. It needs no classifier head — NeuralBench wraps it in a probe sized to each task, so the same backbone can serve a 4-class and a 2-class task unchanged.

`check_model()` enforces that: it pushes synthetic batches of every window and montage width in the selection through a deepcopy of the model, reading only YAML, so it takes seconds and needs no downloaded data. Discovering a shape mismatch that way beats discovering it an hour into a real run.

### Getting the model to the worker

The instance is pickled with `cloudpickle`, which stores the code of classes that are not installed. A model defined in a script, a notebook or a plain checkout therefore survives the trip to a Slurm worker with nothing on its `PYTHONPATH`; previously it died at model build with `ModuleNotFoundError`.

That pickle is not byte-reproducible — `cloudpickle` tags each class definition it stores with a fresh id — so `ExternalModel` identifies the model by a digest of its layout and weights rather than one of the file. This keeps the cache uid stable across calls, which is what makes "call it again to collect" work instead of resubmitting everything.

### Shared config assembly

Turning benchmark selections into experiment configs moves out of `run_benchmark` into `experiment_config.build_experiment_configs`, so the CLI and this API cannot drift; `prepare_task_configs` accepts an inline config dict for a model with no `models/*.yaml`. `BenchmarkAggregator` gains `collect()`, which returns the numbers without writing plots, tables or stats files, and the skip table now marks jobs that errored out with `!n` instead of showing them as merely pending.

### Two onboarded models that could not serve a suite from one instance

- **LaBraM** decided its temporal embedding and channel selection at build time, so one instance served exactly one task. The wrapper now resolves both per call — slicing and interpolating the embedding to the current patch count — which reproduces a per-shape build bit-exactly. Since LaBraM keys channels by electrode name, `ch_names` joins the forward contract: `build_brain_model` returns the names it built against and `BrainModule` passes them to models that name the parameter.
- **REVE**'s wrapper named its positional argument `pos`, so it could not be called with `channel_positions` at all. It now accepts the benchmark's name and subsets its position bank to the channels present, preferring the bank whenever the build resolved one — so results for the onboarded route are unchanged.

### Docs

The CLI, `run_benchmark` and `evaluate_model` launch the same experiments and were hard to tell apart by name alone, so the README, the quickstart gallery header and `api.rst` now compare them side by side on what names the model, what each covers, what it hands back and where it runs. `api.rst` previously filed `run_benchmark` under "CLI" and omitted `evaluate_model` and `check_model` entirely. New tutorial: `docs/neuralbench/tutorials/01_quickstart/03_evaluate_your_own_model.py`.

## Related Issues

<!-- none -->

## Checklist

- [x] Tests added or updated
- [x] Docstrings updated for any changed public APIs
- [x] `pytest` and `mypy` pass locally
