### PR TITLE
Fix EEG/EMG Foundation Challenge 2026 starter-kit issues found in a from-scratch walkthrough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- `neuralbench`: adaptation wrappers (`-w`) apply to every model whose config ships a `downstream_model_wrapper`, not just the published foundation models, so a locally pretrained `mae` encoder is linear-probed as documented instead of silently fine-tuned end to end (#TBD).
+- `neuralbench`: the GPU capability check warns rather than aborting when the driver is too old for the installed torch, so `--download`, `--prepare` and `--plot-cached` still run on such a host (#TBD).
+- `neuralbench`: `load_config` creates the directories a hand-written `config.json` names, and reports the `/tmp` fallback it takes when no config exists and stdin is not a terminal (#TBD).
+- `neuralfetch`: a MOABB study whose subjects all fail to download raises an error naming the counts and chaining the underlying failure, instead of asserting that `timelines.csv` is missing (#TBD).
+- `neuralset`: `ChannelPositions` names the montage it resolved against, and the fix, when no channel has a valid position (#TBD).
+- docs: EEG/EMG Foundation Challenge 2026 starter-kit corrections — Track 1's headline metric key, Track 3's per-window target, the Track 4 aggregation command, the dataset clients and download footprints each track needs, `ssl_example`'s clone step and its own cache paths, and the Codabench submission route (#TBD).
+
 ## [0.3.0] - 2026-09-09
 
 - `neuralbench`: added the `emg pose` task — 20-joint hand-angle trajectory regression on EMG2Pose (NEMAR NM000281), in the paper's regression setting (#229).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-- `neuralbench`: adaptation wrappers (`-w`) apply to every model whose config ships a `downstream_model_wrapper`, not just the published foundation models, so a locally pretrained `mae` encoder is linear-probed as documented instead of silently fine-tuned end to end (#TBD).
-- `neuralbench`: the GPU capability check warns rather than aborting when the driver is too old for the installed torch, so `--download`, `--prepare` and `--plot-cached` still run on such a host (#TBD).
-- `neuralbench`: `load_config` creates the directories a hand-written `config.json` names, and reports the `/tmp` fallback it takes when no config exists and stdin is not a terminal (#TBD).
-- `neuralfetch`: a MOABB study whose subjects all fail to download raises an error naming the counts and chaining the underlying failure, instead of asserting that `timelines.csv` is missing (#TBD).
-- `neuralset`: `ChannelPositions` names the montage it resolved against, and the fix, when no channel has a valid position (#TBD).
-- docs: EEG/EMG Foundation Challenge 2026 starter-kit corrections — Track 1's headline metric key, Track 3's per-window target, the Track 4 aggregation command, the dataset clients and download footprints each track needs, `ssl_example`'s clone step and its own cache paths, and the Codabench submission route (#TBD).
+- `neuralbench`: adaptation wrappers (`-w`) apply to every model whose config ships a `downstream_model_wrapper`, not just the published foundation models, so a locally pretrained `mae` encoder is linear-probed as documented instead of silently fine-tuned end to end (#249).
+- `neuralbench`: the GPU capability check warns rather than aborting when the driver is too old for the installed torch, so `--download`, `--prepare` and `--plot-cached` still run on such a host (#249).
+- `neuralbench`: `load_config` creates the directories a hand-written `config.json` names, and reports the `/tmp` fallback it takes when no config exists and stdin is not a terminal (#249).
+- `neuralfetch`: a MOABB study whose subjects all fail to download raises an error naming the counts and chaining the underlying failure, instead of asserting that `timelines.csv` is missing (#249).
+- `neuralset`: `ChannelPositions` names the montage it resolved against, and the fix, when no channel has a valid position (#249).
+- docs: EEG/EMG Foundation Challenge 2026 starter-kit corrections — Track 1's headline metric key, Track 3's per-window target, the Track 4 aggregation command, the dataset clients and download footprints each track needs, `ssl_example`'s clone step and its own cache paths, and the Codabench submission route (#249).
 
 ## [0.3.0] - 2026-09-09
 

--- a/docs/neuralbench/install.md
+++ b/docs/neuralbench/install.md
@@ -3,6 +3,20 @@
 ## Prerequisites
 
 - Python >= 3.12
+- For GPU training, an NVIDIA driver new enough for the `torch` wheel that pip
+  resolves. `pip install neuralbench` takes the default PyPI `torch`, which
+  tracks the newest CUDA release, so an older driver fails on every GPU call.
+  Check with `python -c "import torch; print(torch.cuda.get_device_capability(0))"`
+  -- if it raises (typically `The NVIDIA driver on your system is too old`),
+  install a build matching your driver, for example CUDA 12.6:
+
+  ```bash
+  pip install --force-reinstall torch torchvision torchaudio \
+    --index-url https://download.pytorch.org/whl/cu126
+  ```
+
+  CPU-only workflows (`--download`, `--prepare`, `--plot-cached`) need none of
+  this.
 
 ## Install from PyPI
 
@@ -26,8 +40,9 @@ pip install .
 ```
 
 (Use `pip install -e .` instead if you intend to modify the source -- see
-[Developer install](#developer-install) below.)
+[Developer install](developer-install) below.)
 
+(developer-install)=
 ## Developer install
 
 Editable mode picks up local source changes without reinstalling, and the
@@ -41,13 +56,27 @@ pre-commit install
 
 ## Optional dependencies
 
-The base install is enough to download datasets (via `neuralfetch[quickstart]`),
-load pretrained model weights (via `braindecode[hub]`), and run and score every
-task. The only extra a user may want is `wandb`, for the optional experiment
+The base install loads pretrained model weights (via `braindecode[hub]`) and
+downloads most datasets (via `neuralfetch[quickstart]`). Two dataset families
+reach their host through a client `neuralbench` does not depend on:
+
+| Package | Needed by |
+| --- | --- |
+| `moabb>=1.7.1` | every MOABB-backed EEG dataset, including the `eeg motor_imagery` default |
+| `eegdash>=0.8.2` | every EEG-Dash-served dataset, including `emg pose` |
+
+The error names the missing package, so installing on demand works; to have
+both up front:
+
+```bash
+pip install 'moabb>=1.7.1' 'eegdash>=0.8.2'
+```
+
+`wandb` is the only extra of the package itself, for the optional experiment
 tracking described below:
 
 ```bash
-pip install 'neuralbench-repo/.[wandb]'
+pip install 'neuralbench[wandb]'
 ```
 
 ## First-run configuration
@@ -59,7 +88,14 @@ paths:
 - **`CACHE_DIR`** -- where preprocessed data is cached.
 - **`SAVE_DIR`** -- where results are saved.
 
-The configuration is stored in `~/.neuralbench/config.json` by default.
+The configuration is stored in `~/.neuralbench/config.json` by default, and the
+three directories are created if they do not exist.
+
+The prompt needs a terminal. Where stdin is not one -- a SLURM batch script,
+`nohup`, CI, some notebooks -- `neuralbench` skips it, prints a notice, and
+falls back to `/tmp/neuralbench/{data,cache,save}`. Write the config file
+beforehand, or point `NEURALBENCH_CONFIG` at one, to keep such runs off local
+disk.
 
 ### Execution backend (SLURM vs. local)
 

--- a/docs/neuralbench/tutorials/07_biosignal_challenge_2026/plot_overview.py
+++ b/docs/neuralbench/tutorials/07_biosignal_challenge_2026/plot_overview.py
@@ -107,6 +107,43 @@ NeuralBench, using publicly available reference datasets.
 # the task logs ``val/mae`` in radians: multiply by 180 / pi to compare.
 
 # %%
+# Budgeting the first download
+# -----------------------------
+#
+# ``--download`` is a one-off step per machine, but not a small one, and
+# the track pages put it first for that reason: the default corpora run
+# from a few gigabytes to several hundred, and the upstream server is
+# usually slower than your disk. Check free space on ``DATA_DIR`` before
+# starting one, and run it somewhere you can leave going for hours.
+#
+# Footprints measured under ``DATA_DIR`` after a full download:
+#
+# .. list-table::
+#    :header-rows: 1
+#    :widths: 20 35 45
+#
+#    * - Track
+#      - Default dataset
+#      - Disk under ``DATA_DIR``
+#    * - 2 -- BCI
+#      - ``Stieger2021Continuous``
+#      - ~600 GB, plus ~280 GB for the copy MOABB converts on first read
+#    * - 3 -- Sleep onset
+#      - ``Kemp2000Analysis``
+#      - ~7 GB
+#    * - 4 -- EMG pose
+#      - ``Salter2024Emg2pose``
+#      - ~310 GB
+#
+# Track 1's ``Gifford2022Large`` default is the one we have no measured
+# figure for; among its alternatives, ``Xu2024Alljoined`` is ~24 GB and
+# ``Xu2025Alljoined`` (Alljoined-1.6M) ~250 GB.
+#
+# ``--prepare`` then writes a separate preprocessing cache under
+# ``CACHE_DIR``, so the two directories are worth pointing at different
+# filesystems if only one of them is large.
+
+# %%
 # Collecting and plotting your results
 # -------------------------------------
 #
@@ -124,7 +161,7 @@ NeuralBench, using publicly available reference datasets.
 #    neuralbench eeg image motor_imagery sleep_onset -m eegnet reve --plot-cached
 #
 #    # 3. Track 4 lives under another device -- aggregate separately
-#    neuralbench emg typing -m emg2qwerty --plot-cached
+#    neuralbench emg pose -m vemg2pose --plot-cached
 #
 # ``--plot-cached`` aggregates within a single device, so the EMG
 # track is collected by its own invocation. It produces, under
@@ -147,10 +184,11 @@ NeuralBench, using publicly available reference datasets.
 # This starter kit relies on the following organiser-maintained
 # open-source libraries:
 #
-# - `NeuralBench <https://facebookresearch.github.io/neuroai/>`_
-#   (this package): unified benchmark suite.
-# - `NeuralSet <https://arxiv.org/abs/2605.03169>`_: data
-#   loading, study registry, event system.
+# - :doc:`NeuralBench </neuralbench/index>` (this package): unified
+#   benchmark suite.
+# - :doc:`NeuralSet </neuralset/index>`
+#   (`paper <https://arxiv.org/abs/2605.03169>`_): data loading, study
+#   registry, event system.
 # - `Braindecode <https://github.com/braindecode/braindecode>`_ and
 #   `MOABB <https://github.com/NeuroTechX/moabb>`_: deep-learning EEG
 #   architectures and BCI benchmarks.

--- a/docs/neuralbench/tutorials/07_biosignal_challenge_2026/plot_overview.py
+++ b/docs/neuralbench/tutorials/07_biosignal_challenge_2026/plot_overview.py
@@ -125,6 +125,9 @@ NeuralBench, using publicly available reference datasets.
 #    * - Track
 #      - Default dataset
 #      - Disk under ``DATA_DIR``
+#    * - 1 -- Image
+#      - ``Gifford2022Large``
+#      - ~210 GB
 #    * - 2 -- BCI
 #      - ``Stieger2021Continuous``
 #      - ~600 GB, plus ~280 GB for the copy MOABB converts on first read
@@ -135,9 +138,10 @@ NeuralBench, using publicly available reference datasets.
 #      - ``Salter2024Emg2pose``
 #      - ~310 GB
 #
-# Track 1's ``Gifford2022Large`` default is the one we have no measured
-# figure for; among its alternatives, ``Xu2024Alljoined`` is ~24 GB and
-# ``Xu2025Alljoined`` (Alljoined-1.6M) ~250 GB.
+# Among Track 1's alternatives, ``Xu2024Alljoined`` is ~24 GB and
+# ``Xu2025Alljoined`` (Alljoined-1.6M) ~250 GB. Track 2's
+# ``tangermann2012`` is under 1 GB, small enough to exercise the whole
+# pipeline before committing to a default.
 #
 # ``--prepare`` then writes a separate preprocessing cache under
 # ``CACHE_DIR``, so the two directories are worth pointing at different

--- a/docs/neuralbench/tutorials/07_biosignal_challenge_2026/plot_pretrain_mae.py
+++ b/docs/neuralbench/tutorials/07_biosignal_challenge_2026/plot_pretrain_mae.py
@@ -86,25 +86,37 @@ than it ships with.
 # Getting the data
 # ----------------
 #
-# Pretraining adds one requirement to a working ``neuralbench``
-# install (:doc:`/neuralbench/install`): the encoder lives behind
+# Pretraining adds two requirements to a working ``neuralbench``
+# install (:doc:`/neuralbench/install`). ``ssl_example`` is a project in
+# the repository rather than part of the ``neuraltrain`` wheel, so it
+# comes from a clone; and the encoder it builds lives behind
 # ``neuraltrain``'s ``models`` extra.
 #
 # .. code-block:: bash
 #
-#    pip install 'neuraltrain-repo/.[lightning,models]'
+#    git clone https://github.com/facebookresearch/neuroai
+#    cd neuroai
+#    pip install './neuraltrain-repo[lightning,models]'
 #
 # The example pretrains on four EEG datasets: those behind tracks 1-3
 # (``Gifford2022Large``, ``Stieger2021Continuous``,
 # ``Kemp2000Analysis``) plus one resting-state dataset that belongs to
 # no track (``Miltiadous2023Dice``), together some 240 subjects. Each
-# is fetched from its public source the first time its study runs, into
-# the ``DATA_DIR`` you configured at install time. Nothing else is
-# needed to start them downloading -- but they are large, and the first
-# run does two slow things before the first gradient step:
+# is fetched from its public source the first time its study runs.
 #
-# 1. **Download** each dataset into ``DATA_DIR`` (once per machine).
-# 2. **Preprocess and cache** it into ``CACHE_DIR``: resampling,
+# ``ssl_example`` keeps its own paths, set by ``DATADIR``, ``CACHEDIR``
+# and ``SAVEDIR`` at the top of ``defaults.py``: all three sit under
+# ``~/.cache/neuralset`` and are independent of the ``DATA_DIR`` you
+# configured for ``neuralbench``. Repoint them before the first run
+# unless your home directory can take close to a terabyte:
+# ``Stieger2021Continuous`` alone is ~600 GB downloaded plus ~280 GB once
+# MOABB converts it.
+#
+# Nothing else is needed to start them downloading -- but they are large,
+# and the first run does two slow things before the first gradient step:
+#
+# 1. **Download** each dataset into ``DATADIR`` (once per machine).
+# 2. **Preprocess and cache** it into ``CACHEDIR``: resampling,
 #    filtering and scaling run once per configuration, and every later
 #    run and every grid job reads the cache instead of redoing them.
 #
@@ -114,9 +126,9 @@ than it ships with.
 # machine with a good connection.
 #
 # Because it is a long first step, check the wiring before paying for
-# it. The debug config swaps the four datasets for one small bundled
-# recording -- MNE's sample dataset, already used by the
-# ``neuralbench`` quickstart -- and runs a single batch:
+# it. The debug config swaps the four datasets for one small recording
+# -- MNE's sample dataset, downloaded on first use and already used by
+# the ``neuralbench`` quickstart -- and runs a single batch:
 #
 # .. code-block:: bash
 #
@@ -128,8 +140,10 @@ than it ships with.
 # ------------------------
 #
 # With the wiring checked, run the real thing. It downloads and caches
-# as described above, then prints the path of the pretrained encoder
-# when it finishes:
+# as described above, then finishes on a line reading ``Pretrained
+# encoder: <SAVEDIR>/ssl_example.main.Experiment.run,1/<uid>/encoder.ckpt``.
+# The ``<uid>`` is a hash of the config, so copy that path rather than
+# reconstruct it:
 #
 # .. code-block:: bash
 #
@@ -217,7 +231,7 @@ than it ships with.
 # .. code-block:: bash
 #
 #    neuralbench eeg motor_imagery -m mae \
-#        --checkpoint <savedir>/encoder.ckpt \
+#        --checkpoint <the encoder.ckpt path printed above> \
 #        -w linear_probe_mean
 #
 # ``neuralbench`` builds the encoder with no output head and loads the

--- a/docs/neuralbench/tutorials/07_biosignal_challenge_2026/plot_submission_guide.py
+++ b/docs/neuralbench/tutorials/07_biosignal_challenge_2026/plot_submission_guide.py
@@ -5,11 +5,11 @@ How to Submit a Model
 This page describes how to package and submit a model to the
 EEG/EMG Foundation Challenge 2026.
 
-.. warning::
-   The submission portal is **not yet open**. This page is a
-   placeholder that documents the expected submission workflow.
-   It will be updated with concrete instructions and URLs once
-   the competition is officially launched.
+Submissions are handled on `Codabench <https://www.codabench.org/>`_,
+with a separate registration for each track you enter. The `competition
+website <https://neural-interfaces26.github.io/>`_ carries the per-track
+Codabench links, the submission window, and the rules, and is the
+authoritative source for all three.
 """
 
 # %%
@@ -23,8 +23,8 @@ EEG/EMG Foundation Challenge 2026.
 #    pipeline.
 # 2. **Package** the model weights and a minimal inference script
 #    into the required format.
-# 3. **Upload** the package to the competition portal, where
-#    organisers run evaluation on the hidden test set.
+# 3. **Upload** the package to your track's Codabench competition,
+#    where the organisers run evaluation on the hidden test set.
 #
 
 # %%
@@ -39,12 +39,12 @@ EEG/EMG Foundation Challenge 2026.
 # Next steps
 # ----------
 #
-# While the portal is not yet open, you can already:
+# Before you submit:
 #
 # - Run the track baselines from the starter kit to familiarise
 #   yourself with the tasks and metrics.
 # - Register a new model in NeuralBench and iterate on your
 #   architecture (see
 #   :doc:`/neuralbench/auto_examples/adding_model/create_new_model`).
-# - Watch the competition repository for announcements on portal
-#   availability and dataset releases.
+# - Watch the competition website for announcements on the remaining
+#   dataset releases.

--- a/docs/neuralbench/tutorials/07_biosignal_challenge_2026/plot_track1_eeg_to_image.py
+++ b/docs/neuralbench/tutorials/07_biosignal_challenge_2026/plot_track1_eeg_to_image.py
@@ -28,7 +28,11 @@ generalisation: training images and test images do not overlap.
 # - **Target**: frozen ``facebook/dinov2-giant`` image embeddings
 #   (1536-d), aligned with a CLIP contrastive loss -- the same
 #   embedding space the competition scorer uses.
-# - **Headline metric key**: ``test/batch_top5_acc`` (Top-5 retrieval).
+# - **Headline metric key**: ``test/full_retrieval/top5_acc_subject-agg``
+#   -- Top-5 accuracy against every candidate in the test set, averaged
+#   over subjects. ``val/batch_top5_acc``, which early stopping
+#   monitors, ranks within a batch instead, so it reads far higher and
+#   is not comparable.
 #
 # .. dropdown:: Show ``tasks/eeg/image/config.yaml``
 #

--- a/docs/neuralbench/tutorials/07_biosignal_challenge_2026/plot_track2_eeg_to_bci.py
+++ b/docs/neuralbench/tutorials/07_biosignal_challenge_2026/plot_track2_eeg_to_bci.py
@@ -50,7 +50,8 @@ recalibration allowed.
 # ``Stieger2021Continuous`` and the alternative MI datasets are served by
 # MOABB, which the base install does not pull, so install it first:
 # ``pip install 'moabb>=1.7.1'``. Budget ~600 GB under ``DATA_DIR`` for the
-# download, plus ~280 GB for the copy MOABB converts on first read.
+# download, plus ~280 GB for the copy MOABB converts on first read -- or
+# start on the much smaller ``tangermann2012`` described below.
 #
 # .. code-block:: bash
 #
@@ -73,6 +74,12 @@ recalibration allowed.
 # :doc:`/neuralbench/tasks/eeg/motor_imagery` (MOABB, Dreyer2023,
 # BCI Competition IV, ...) can also be selected with ``--dataset
 # <name>`` and are useful for stress-testing cross-subject behaviour.
+#
+# ``--dataset tangermann2012`` is the one to reach for first: BCI
+# Competition IV-2a is 9 subjects of 22-channel four-class MI in under
+# 1 GB, so the whole download-prepare-train loop can be exercised
+# against a well-known published baseline before committing ~900 GB to
+# ``Stieger2021Continuous``.
 
 # %%
 # Adapting to the competition setup

--- a/docs/neuralbench/tutorials/07_biosignal_challenge_2026/plot_track2_eeg_to_bci.py
+++ b/docs/neuralbench/tutorials/07_biosignal_challenge_2026/plot_track2_eeg_to_bci.py
@@ -47,6 +47,11 @@ recalibration allowed.
 # Reproducing the baseline
 # ------------------------
 #
+# ``Stieger2021Continuous`` and the alternative MI datasets are served by
+# MOABB, which the base install does not pull, so install it first:
+# ``pip install 'moabb>=1.7.1'``. Budget ~600 GB under ``DATA_DIR`` for the
+# download, plus ~280 GB for the copy MOABB converts on first read.
+#
 # .. code-block:: bash
 #
 #    # 1. Download Stieger2021Continuous

--- a/docs/neuralbench/tutorials/07_biosignal_challenge_2026/plot_track3_sleep_onset.py
+++ b/docs/neuralbench/tutorials/07_biosignal_challenge_2026/plot_track3_sleep_onset.py
@@ -32,13 +32,20 @@ per-epoch hypnogram reconstruction.
 # NeuralBench mapping
 # -------------------
 #
+# The matching task in NeuralBench is
+# :doc:`/neuralbench/tasks/eeg/sleep_onset`.
+#
 # - **CLI**: ``neuralbench eeg sleep_onset``
 # - **Default dataset**: ``Kemp2000Analysis`` (Sleep-EDF Expanded,
-#   78 nights, 2 EEG channels, full polysomnography).
-# - **Target**: latency from recording start to the first N2 epoch,
-#   extracted by ``AddSleepOnsetTargets`` + ``SleepOnsetTargetExtractor``
-#   and capped at 600 s. This matches the competition's reference
-#   definition.
+#   78 participants recorded over up to two nights each, 2 EEG
+#   channels, full polysomnography).
+# - **Target**: the time *remaining* until the first N2 epoch, which
+#   ``AddSleepOnsetTargets`` + ``SleepOnsetTargetExtractor`` recompute for
+#   every window as ``clip(n2_onset - window_stop, 0, 600)`` seconds. The
+#   task therefore predicts once per 5-second window rather than once per
+#   recording, and the competition's single ``tau_hat`` is
+#   ``window_stop + prediction`` read off any window within 600 s of
+#   onset, where the cap has not saturated the target.
 # - **Headline metric key**: ``test/bmae`` (binned MAE in seconds).
 #
 # .. dropdown:: Show ``tasks/eeg/sleep_onset/config.yaml``
@@ -104,4 +111,5 @@ per-epoch hypnogram reconstruction.
 # - per-window time-to-onset predictions, **or**
 # - per-window sleep probabilities.
 #
-# The current NeuralBench head produces the first format directly.
+# The current NeuralBench head produces the second format directly, and
+# the first by the conversion above.

--- a/docs/neuralbench/tutorials/07_biosignal_challenge_2026/plot_track4_emg_to_pose.py
+++ b/docs/neuralbench/tutorials/07_biosignal_challenge_2026/plot_track4_emg_to_pose.py
@@ -20,6 +20,8 @@ device placement, and hand kinematics at once.
 # NeuralBench mapping
 # -------------------
 #
+# The matching task in NeuralBench is :doc:`/neuralbench/tasks/emg/pose`.
+#
 # - **CLI**: ``neuralbench emg pose``
 # - **Default dataset**: ``Salter2024Emg2pose`` (16-channel sEMG paired
 #   with motion-capture hand pose).
@@ -36,6 +38,10 @@ device placement, and hand kinematics at once.
 # %%
 # Reproducing the baseline
 # ------------------------
+#
+# emg2pose is served through EEG-Dash, which the base install does not
+# pull, so install it first: ``pip install 'eegdash>=0.8.2'``. The full
+# release is ~310 GB under ``DATA_DIR``.
 #
 # .. code-block:: bash
 #

--- a/neuralbench-repo/neuralbench/config_manager.py
+++ b/neuralbench-repo/neuralbench/config_manager.py
@@ -38,6 +38,14 @@ def prompt_user_for_path(
         return response
 
 
+def _make_dirs(config: dict[str, Any]) -> list[Path]:
+    """Create the three configured directories, returning them in config order."""
+    paths = [Path(str(config[key])) for key in ("CACHE_DIR", "SAVE_DIR", "DATA_DIR")]
+    for path in paths:
+        path.mkdir(parents=True, exist_ok=True)
+    return paths
+
+
 def setup_config(config_path: Path | None = None) -> dict[str, Any]:
     """
     Set up neuralbench configuration.
@@ -117,10 +125,7 @@ def setup_config(config_path: Path | None = None) -> dict[str, Any]:
         "DATA_DIR - Where to download and store datasets",
     )
 
-    # Create directories if they don't exist
-    for key in ["CACHE_DIR", "SAVE_DIR", "DATA_DIR"]:
-        path = Path(config[key])
-        path.mkdir(parents=True, exist_ok=True)
+    for path in _make_dirs(config):
         print(f"Created directory: {path}")
 
     # Prompt for W&B host
@@ -160,8 +165,7 @@ def _default_config() -> dict[str, Any]:
         "N_CPUS": 10,
         "CLUSTER": "auto",
     }
-    for key in ["CACHE_DIR", "SAVE_DIR", "DATA_DIR"]:
-        Path(str(config[key])).mkdir(parents=True, exist_ok=True)
+    _make_dirs(config)
     return config
 
 
@@ -189,11 +193,23 @@ def load_config(config_path: Path | None = None) -> dict[str, Any]:
 
     if not config_path.exists():
         if not _is_interactive():
-            return _default_config()
+            config = _default_config()
+            print(
+                f"No configuration file at {config_path}, and stdin is not a "
+                "terminal so the setup prompt is skipped: datasets, caches and "
+                f"results go under {Path(config['DATA_DIR']).parent}. Run "
+                "neuralbench from a terminal, or point NEURALBENCH_CONFIG at a "
+                "config file, to choose your own paths.",
+                file=sys.stderr,
+            )
+            return config
         return setup_config(config_path)
 
     with config_path.open() as f:
-        return json.load(f)
+        config = json.load(f)
+    # a hand-written config names directories the wizard would have created
+    _make_dirs(config)
+    return config
 
 
 # Global config instance (will be initialized when module is imported)

--- a/neuralbench-repo/neuralbench/config_manager.py
+++ b/neuralbench-repo/neuralbench/config_manager.py
@@ -11,6 +11,7 @@ import sys
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+from warnings import warn
 
 
 def _is_interactive() -> bool:
@@ -39,11 +40,21 @@ def prompt_user_for_path(
 
 
 def _make_dirs(config: dict[str, Any]) -> list[Path]:
-    """Create the three configured directories, returning them in config order."""
-    paths = [Path(str(config[key])) for key in ("CACHE_DIR", "SAVE_DIR", "DATA_DIR")]
-    for path in paths:
-        path.mkdir(parents=True, exist_ok=True)
-    return paths
+    """Create the configured directories, returning those that now exist."""
+    created = []
+    for key in ("CACHE_DIR", "SAVE_DIR", "DATA_DIR"):
+        if config.get(key) is None:
+            continue
+        path = Path(str(config[key]))
+        try:
+            path.mkdir(parents=True, exist_ok=True)
+        except OSError as error:
+            # an unmounted or read-only path must not stop a command that never
+            # touches it, such as --plot-cached on a login node
+            warn(f"Could not create {key} {path}: {error}")
+            continue
+        created.append(path)
+    return created
 
 
 def setup_config(config_path: Path | None = None) -> dict[str, Any]:

--- a/neuralbench-repo/neuralbench/experiment_config.py
+++ b/neuralbench-repo/neuralbench/experiment_config.py
@@ -320,6 +320,14 @@ def prepare_task_configs(
     return configs
 
 
+def _adapts_a_backbone(model: str) -> bool:
+    """Whether *model*'s config describes how to adapt a pretrained backbone."""
+    from neuralbench.registry import _resolve_model_config_path
+
+    config = load_yaml_config(_resolve_model_config_path(model)) or {}
+    return "downstream_model_wrapper" in config
+
+
 def build_experiment_configs(
     device: str,
     task: str | list[str],
@@ -349,8 +357,6 @@ def build_experiment_configs(
     from neuralbench.config_manager import _ensure_initialized
     from neuralbench.registry import (
         ALL_DOWNSTREAM_WRAPPERS,
-        DEVICE_FM_MODELS,
-        FM_MODELS,
         _expand_models,
         _resolve_datasets,
         _resolve_tasks,
@@ -408,26 +414,30 @@ def build_experiment_configs(
             else list(_expand_models(model, device=device, task_name=task_name))  # type: ignore[arg-type]
         )
         datasets = _resolve_datasets(device, task_name, dataset)
-        # adaptation needs a pretrained backbone: non-FMs get an overlay-free grid
+        # adaptation needs a pretrained backbone: the rest get an overlay-free grid
         model_groups: list[tuple[ConfDict, list[ModelSpec]]]
         if overlays is not None:
-            # An out-of-tree model is a backbone by assumption: it is not in the
-            # in-tree FM list, but adaptation is exactly why it is being run.
-            fm_names = set(DEVICE_FM_MODELS.get(device, FM_MODELS))
+            # An out-of-tree model is a backbone by assumption: it has no
+            # models/*.yaml to say so, but adaptation is exactly why it is
+            # being run.
+            backbones = {
+                m for m in models if isinstance(m, str) and _adapts_a_backbone(m)
+            }
             inline = inline_model is not None
-            fm_models = [m for m in models if inline or m in fm_names]
-            other_models = [m for m in models if not inline and m not in fm_names]
-            if not fm_models:
+            adapted = [m for m in models if inline or m in backbones]
+            other_models = [m for m in models if not inline and m not in backbones]
+            if not adapted:
                 LOGGER.warning(
-                    "Adaptation wrappers requested (-w) but no foundation model "
-                    "selected for task %r; running without adaptation.",
+                    "Adaptation wrappers requested (-w) but no selected model "
+                    "adapts a pretrained backbone for task %r; running without "
+                    "adaptation.",
                     task_name,
                 )
             model_groups = []
-            if fm_models:
-                fm_grid = grid_conf.copy()
-                fm_grid["_adaptation_overlay"] = overlays
-                model_groups.append((fm_grid, fm_models))
+            if adapted:
+                adapted_grid = grid_conf.copy()
+                adapted_grid["_adaptation_overlay"] = overlays
+                model_groups.append((adapted_grid, adapted))
             if other_models:
                 model_groups.append((grid_conf, other_models))
         else:
@@ -506,9 +516,24 @@ def _warn_unsupported_gpu() -> None:
     }
     if not built:
         return
+    try:
+        capabilities = [
+            torch.cuda.get_device_capability(index)
+            for index in range(torch.cuda.device_count())
+        ]
+    except RuntimeError as error:
+        # a driver too old for the wheel raises here; this check must not be
+        # what surfaces it, since --download and --plot-cached never touch a GPU
+        warn(
+            f"Could not query the visible GPU(s) with torch {torch.__version__} "
+            f"({error}). GPU runs will fail; to fix, install a torch build "
+            "matching your driver, e.g. pip install --force-reinstall torch "
+            "torchvision torchaudio --index-url "
+            "https://download.pytorch.org/whl/cu126"
+        )
+        return
     warned: set[tuple[int, int]] = set()
-    for index in range(torch.cuda.device_count()):
-        capability = torch.cuda.get_device_capability(index)
+    for index, capability in enumerate(capabilities):
         major, minor = capability
         if capability in warned or any(
             major == bmajor and minor >= bminor for bmajor, bminor in built

--- a/neuralbench-repo/neuralbench/test_config_manager.py
+++ b/neuralbench-repo/neuralbench/test_config_manager.py
@@ -4,7 +4,9 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
+import json
 from collections.abc import Callable
+from pathlib import Path
 
 from . import config_manager
 
@@ -13,6 +15,16 @@ def test_default_config_includes_cluster() -> None:
     """The non-interactive default config exposes CLUSTER='auto'."""
     config = config_manager._default_config()
     assert config["CLUSTER"] == "auto"
+
+
+def test_load_config_creates_the_configured_dirs(tmp_path: Path) -> None:
+    names = ("cache", "save", "data")
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps({f"{n.upper()}_DIR": str(tmp_path / n) for n in names})
+    )
+    config_manager.load_config(config_path)
+    assert all((tmp_path / name).is_dir() for name in names)
 
 
 def test_cluster_resolves_to_none_when_configured_null(

--- a/neuralbench-repo/neuralbench/test_config_manager.py
+++ b/neuralbench-repo/neuralbench/test_config_manager.py
@@ -8,6 +8,8 @@ import json
 from collections.abc import Callable
 from pathlib import Path
 
+import pytest
+
 from . import config_manager
 
 
@@ -25,6 +27,17 @@ def test_load_config_creates_the_configured_dirs(tmp_path: Path) -> None:
     )
     config_manager.load_config(config_path)
     assert all((tmp_path / name).is_dir() for name in names)
+
+
+def test_load_config_warns_rather_than_fails_on_an_uncreatable_dir(
+    tmp_path: Path,
+) -> None:
+    blocker = tmp_path / "blocker"
+    blocker.write_text("")
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"DATA_DIR": str(blocker / "data")}))
+    with pytest.warns(UserWarning, match="DATA_DIR"):
+        config_manager.load_config(config_path)
 
 
 def test_cluster_resolves_to_none_when_configured_null(

--- a/neuralbench-repo/neuralbench/test_experiment_config.py
+++ b/neuralbench-repo/neuralbench/test_experiment_config.py
@@ -7,9 +7,14 @@
 import functools
 
 import pytest
+import torch
 from exca import ConfDict
 
-from neuralbench.experiment_config import _expand_grid
+from neuralbench.experiment_config import (
+    _adapts_a_backbone,
+    _expand_grid,
+    _warn_unsupported_gpu,
+)
 from neuralbench.registry import (
     ALL_DOWNSTREAM_WRAPPERS,
     DEFAULTS_DIR,
@@ -77,6 +82,33 @@ def _base_and_model_config(model_name: str) -> ConfDict:
     config = ConfDict(load_yaml_config(DEFAULTS_DIR / "config.yaml"))
     config.update(load_yaml_config(_resolve_model_config_path(model_name)))
     return config
+
+
+@pytest.mark.parametrize(
+    ("model_name", "expected"),
+    # mae is a backbone without published weights, so it is absent from FM_MODELS
+    [
+        *((name, True) for name in [*FM_MODELS, "mae"]),
+        ("eegnet", False),
+        ("chance", False),
+    ],
+)
+def test_adaptation_applies_to_backbones_only(model_name: str, expected: bool):
+    assert _adapts_a_backbone(model_name) is expected
+
+
+def test_unsupported_gpu_check_survives_a_driver_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _too_old(index: int) -> tuple[int, int]:
+        raise RuntimeError("driver too old")
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "get_arch_list", lambda: ["sm_90"])
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 1)
+    monkeypatch.setattr(torch.cuda, "get_device_capability", _too_old)
+    with pytest.warns(UserWarning, match="driver too old"):
+        _warn_unsupported_gpu()
 
 
 @pytest.mark.parametrize("preset", list(ALL_DOWNSTREAM_WRAPPERS))

--- a/neuralfetch-repo/neuralfetch/studies/moabb2025.py
+++ b/neuralfetch-repo/neuralfetch/studies/moabb2025.py
@@ -221,6 +221,7 @@ class _BaseMoabb(studies.Study):
                     ds = self._get_dataset()
                     rows: list[dict[str, tp.Any]] = []
                     failed_subjects: list[tp.Any] = []
+                    last_error: Exception | None = None
                     for subject in ds.subject_list:
                         try:
                             subj_data = ds.get_data(
@@ -233,6 +234,7 @@ class _BaseMoabb(studies.Study):
                                 f"{self.aliases[0]}: {e}"
                             )
                             failed_subjects.append(subject)
+                            last_error = e
                             continue
                         for session, runs in subj_data[subject].items():
                             for run in runs:
@@ -250,9 +252,14 @@ class _BaseMoabb(studies.Study):
                         )
 
                 timelines = pd.DataFrame(rows)
-                assert not timelines.empty, (
-                    f"Failed to create timelines.csv at {timeline_path}"
-                )
+                if timelines.empty:
+                    raise RuntimeError(
+                        f"{timeline_path} not written: none of the "
+                        f"{len(ds.subject_list)} subject(s) of "
+                        f"{self.aliases[0]} could be read "
+                        f"({len(failed_subjects)} failed; the last error is "
+                        "chained below, and each is logged above)"
+                    ) from last_error
                 timelines.to_csv(timeline_path, index=False)
                 logger.info(
                     f"Downloaded dataset to {dl_path} "

--- a/neuralset-repo/neuralset/extractors/neuro.py
+++ b/neuralset-repo/neuralset/extractors/neuro.py
@@ -2335,7 +2335,12 @@ class ChannelPositions(BaseStatic):
         invalid_names = [n for n in ch_names if n and n not in pos_mapping]
 
         if not valid_inds:
-            raise ValueError(f"No channel has valid positions: {ta_ch_names}.")
+            raise ValueError(
+                f"No channel has valid positions: {ta_ch_names}. Positions come "
+                f"from {self.layout_or_montage_name or 'the recording ch_locs'}; "
+                "set layout_or_montage_name to a montage naming these channels, "
+                "or to None to read them off the recording."
+            )
 
         if len(valid_inds) < 0.1 * len(ch_names):
             unique_invalid_names = set(invalid_names)


### PR DESCRIPTION
Fixes what a from-scratch walkthrough of the [EEG/EMG Foundation Challenge 2026 starter kit](https://facebookresearch.github.io/neuroai/neuralbench/auto_examples/biosignal_challenge_2026/index.html) turned up, following the published pages only, on a clean `pip install neuralbench` environment.

## Code

- **Adaptation wrappers reached only the published foundation models.** `-w linear_probe_mean` was dropped with a warning for `mae`, so the pretraining page's own linear probe silently ran a full fine-tune instead — a wrong number, not an error. The gate now asks whether the model's config ships a `downstream_model_wrapper`, which is exactly the six FMs plus `mae` today and stays right as models are added.
- **The GPU capability check aborted the CLI.** On a driver older than the installed torch, `torch.cuda.get_device_capability` raises, and it did so inside the warning helper that every command runs — including `--download` and `--plot-cached`, which never touch a GPU. It now warns and names the reinstall.
- **`load_config` ignored a hand-written config's directories** and failed later with `Parent folder ... must exist first`; it now creates them, as the wizard already did. Creation is best-effort, so an unmounted or read-only `DATA_DIR` still cannot break a command that never touches it. The non-interactive `/tmp` fallback also says so on stderr rather than silently redirecting a batch job's datasets to local disk.
- **A MOABB study whose subjects all fail to download** asserted `Failed to create timelines.csv`, discarding the real cause. It now names the counts and chains the last error.
- **`ChannelPositions`** names the montage it resolved against, and the fix, when no channel has a position.

## Docs

- Track 1's headline metric key was `test/batch_top5_acc`, the in-batch number early stopping monitors; the scored one is `test/full_retrieval/top5_acc_subject-agg`.
- Track 3 described the target as a single latency from recording start. The task predicts the time remaining per 5-second window; the page now gives that, and the conversion back to the competition's `tau_hat`.
- The overview's Track 4 aggregation command named `emg typing -m emg2qwerty`.
- Tracks 2 and 4 need `moabb` and `eegdash`, which the base install does not pull and the install page said were unnecessary.
- No page mentioned download size. Measured footprints for all four defaults are now on the overview and the two heaviest track pages: `Gifford2022Large` is ~210 GB, `Salter2024Emg2pose` ~310 GB, and `Stieger2021Continuous` ~600 GB plus ~280 GB once MOABB converts it — which also makes the pretraining example close to a terabyte rather than a laptop job.
- Track 2 now points at `--dataset tangermann2012` (BCI Competition IV-2a, under 1 GB) as the way to exercise the pipeline against a known baseline before committing ~900 GB to the default.
- The pretraining page installed `neuraltrain-repo/.[lightning,models]` without saying `ssl_example` only exists in a clone, and pointed at `DATA_DIR`/`CACHE_DIR` when the example uses its own `DATADIR`/`CACHEDIR` under `~/.cache/neuralset`.
- The submission page still said the portal was not open; it now names Codabench and the per-track registration.
- Sleep-EDF is 78 participants over up to two nights each, not "78 nights"; `install.md`'s `#developer-install` anchor resolves.

## Checks

`ruff check`, `ruff format --check`, `mypy` on the three touched packages, `pytest` on the two touched test modules (59 passed), and a full `make -C docs html`.

Four tests are added: adaptation applies to backbones only, the GPU check survives a driver error, and `load_config` both creates the configured directories and warns rather than fails on one it cannot create.
