### PR TITLE
Bump versions to 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-09-10
+
 - `neuralbench`: adaptation wrappers (`-w`) apply to every model whose config ships a `downstream_model_wrapper`, not just the published foundation models, so a locally pretrained `mae` encoder is linear-probed as documented instead of silently fine-tuned end to end (#249).
 - `neuralbench`: the GPU capability check warns rather than aborting when the driver is too old for the installed torch, so `--download`, `--prepare` and `--plot-cached` still run on such a host (#249).
 - `neuralbench`: `load_config` creates the directories a hand-written `config.json` names, and reports the `/tmp` fallback it takes when no config exists and stdin is not a terminal (#249).

--- a/neuralbench-repo/pyproject.toml
+++ b/neuralbench-repo/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "neuralbench"
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 authors = [{name = "Meta FAIR"}]
 license = "MIT"
 license-files = ["LICENSE"]
@@ -19,9 +19,9 @@ dependencies = [
   "cloudpickle",
   # Siblings release in lockstep; stay within the release line.
   # Study catalog: registered through an entry point, never imported directly
-  "neuralfetch[quickstart]~=0.3.0",
-  "neuralset~=0.3.0",
-  "neuraltrain~=0.3.0",
+  "neuralfetch[quickstart]~=0.3.1",
+  "neuralset~=0.3.1",
+  "neuraltrain~=0.3.1",
   "exca",
   "lightning>=2.0.8",
   "peft>=0.13",

--- a/neuralfetch-repo/pyproject.toml
+++ b/neuralfetch-repo/pyproject.toml
@@ -6,11 +6,11 @@ description = "Download backends and data-fetching utilities for neuralset."
 license = "MIT"
 license-files = ["LICENSE"]
 requires-python = ">=3.12"
-version = "0.3.0"
+version = "0.3.1"
 
 dependencies = [
   # Siblings release in lockstep; stay within the release line.
-  "neuralset~=0.3.0",
+  "neuralset~=0.3.1",
   "h5py",
   "pybv>=0.7.3",
   "mne_bids>=0.19",

--- a/neuralset-repo/pyproject.toml
+++ b/neuralset-repo/pyproject.toml
@@ -6,7 +6,7 @@ description = "A Python toolkit for building neuroimaging data pipelines."
 license = "MIT"
 license-files = ["LICENSE"]
 requires-python = ">=3.12"
-version = "0.3.0"
+version = "0.3.1"
 
 dependencies = [
   "pandas>=2.2.2",

--- a/neuraltrain-repo/pyproject.toml
+++ b/neuraltrain-repo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neuraltrain"
-version = "0.3.0"
+version = "0.3.1"
 authors = [{name = "Meta FAIR"}]
 license = "MIT"
 license-files = ["LICENSE"]


### PR DESCRIPTION
Releases the challenge starter-kit fixes from #249, the first of which changes results rather than just wording: adaptation wrappers reached only the published foundation models, so `-w linear_probe_mean` on a locally pretrained `mae` encoder silently ran a full fine-tune. Participants of the EEG/EMG Foundation Challenge 2026 need that on PyPI, not just in the docs.

- All four packages go to `0.3.1`.
- The sibling pins move from `~=0.3.0` to `~=0.3.1`. `~=0.3.0` would already have admitted 0.3.1, but the fix spans `neuralbench`, `neuralfetch` and `neuralset`, so pinning to the line keeps the "siblings release in lockstep" comment above them true — a 0.3.1 `neuralbench` on a 0.3.0 `neuralset` would have the adaptation fix without the extractor one.
- `CHANGELOG.md` closes the `0.3.1` section; `docs/conf.py` reads the release from package metadata and needs no edit.
