### PR TITLE
docs: fix challenge starter-kit claims found in the post-release audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- docs: EEG/EMG Foundation Challenge 2026 starter-kit corrections from the post-release audit — the pretraining corpus needs an explicit `ssl_example.grids.download` step and `moabb`, `MaeModule` takes no other `neuraltrain` model, freezing comes from `linear_probe_mean` rather than `mae.yaml`, `install.md` lists the six config keys that have no default, Track 3's target is the earliest annotated N2 event, and emg2pose is ~340 GB (#251).
+
 ## [0.3.1] - 2026-09-10
 
 - `neuralbench`: adaptation wrappers (`-w`) apply to every model whose config ships a `downstream_model_wrapper`, not just the published foundation models, so a locally pretrained `mae` encoder is linear-probed as documented instead of silently fine-tuned end to end (#249).

--- a/docs/neuralbench/install.md
+++ b/docs/neuralbench/install.md
@@ -15,8 +15,12 @@
     --index-url https://download.pytorch.org/whl/cu126
   ```
 
-  CPU-only workflows (`--download`, `--prepare`, `--plot-cached`) need none of
-  this.
+  Every training run needs a working GPU, `--debug` included: there is no CPU
+  fallback, so a mismatched driver stops the quick sanity check each task page
+  opens with. `--download` and `--plot-cached` need none of this, and neither
+  does `--prepare` for most tasks -- but one whose target extractor runs a
+  vision or audio model, as `eeg image` embeds its stimuli with DINOv2, uses
+  the GPU to build that cache.
 
 ## Install from PyPI
 
@@ -72,7 +76,8 @@ both up front:
 pip install 'moabb>=1.7.1' 'eegdash>=0.8.2'
 ```
 
-`wandb` is the only extra of the package itself, for the optional experiment
+`wandb` is the package's only runtime extra -- `dev` and `docs` exist for
+working on `neuralbench` itself -- and it enables the optional experiment
 tracking described below:
 
 ```bash
@@ -90,6 +95,25 @@ paths:
 
 The configuration is stored in `~/.neuralbench/config.json` by default, and the
 three directories are created if they do not exist.
+
+A config file you write yourself has to define everything the prompt would have
+written. These six keys have no default, and a missing one fails with a bare
+`KeyError`:
+
+```json
+{
+  "USER": "your-username",
+  "ENTITY_NAME": "your-username",
+  "PROJECT_NAME": "neuralbench",
+  "DATA_DIR": "/path/to/data",
+  "CACHE_DIR": "/path/to/cache",
+  "SAVE_DIR": "/path/to/results"
+}
+```
+
+`USER`, `ENTITY_NAME` and `PROJECT_NAME` only label runs and W&B entries, so
+any string does. Every remaining key -- `CLUSTER`, `SLURM_PARTITION`,
+`SLURM_CONSTRAINT`, `N_CPUS`, `WANDB_HOST` -- is optional.
 
 The prompt needs a terminal. Where stdin is not one -- a SLURM batch script,
 `nohup`, CI, some notebooks -- `neuralbench` skips it, prints a notice, and
@@ -111,7 +135,8 @@ key in `~/.neuralbench/config.json`:
   caches locally when `CLUSTER` is `null`.
 - **`"slurm"`** -- always submit to SLURM.
 
-For example, to run the full benchmark locally without SLURM, set:
+For example, to run the full benchmark locally without SLURM, add this
+alongside the required keys above:
 
 ```json
 {

--- a/docs/neuralbench/tutorials/07_biosignal_challenge_2026/plot_overview.py
+++ b/docs/neuralbench/tutorials/07_biosignal_challenge_2026/plot_overview.py
@@ -20,7 +20,7 @@ distribution shift:
    scoring on later ones without recalibration. Headline metric:
    **balanced accuracy** (higher is better).
 3. **Track 3 -- Sleep onset** (cross-device): predict the latency from
-   recording start to the first stable N2 epoch, on consumer wearable
+   recording start to the first N2 epoch, on consumer wearable
    EEG rather than clinical polysomnography. Headline metric: **binned
    MAE (bMAE) in seconds** (lower is better) -- the absolute error
    averaged inside time-to-onset bins and then across bins with equal
@@ -136,7 +136,7 @@ NeuralBench, using publicly available reference datasets.
 #      - ~7 GB
 #    * - 4 -- EMG pose
 #      - ``Salter2024Emg2pose``
-#      - ~310 GB
+#      - ~340 GB
 #
 # Among Track 1's alternatives, ``Xu2024Alljoined`` is ~24 GB and
 # ``Xu2025Alljoined`` (Alljoined-1.6M) ~250 GB. Track 2's

--- a/docs/neuralbench/tutorials/07_biosignal_challenge_2026/plot_pretrain_mae.py
+++ b/docs/neuralbench/tutorials/07_biosignal_challenge_2026/plot_pretrain_mae.py
@@ -86,36 +86,43 @@ than it ships with.
 # Getting the data
 # ----------------
 #
-# Pretraining adds two requirements to a working ``neuralbench``
+# Pretraining adds three requirements to a working ``neuralbench``
 # install (:doc:`/neuralbench/install`). ``ssl_example`` is a project in
 # the repository rather than part of the ``neuraltrain`` wheel, so it
-# comes from a clone; and the encoder it builds lives behind
-# ``neuraltrain``'s ``models`` extra.
+# comes from a clone; the encoder it builds lives behind
+# ``neuraltrain``'s ``models`` extra; and ``Stieger2021Continuous``
+# reaches its host through ``moabb``, which nothing installs for you.
 #
 # .. code-block:: bash
 #
 #    git clone https://github.com/facebookresearch/neuroai
 #    cd neuroai
-#    pip install './neuraltrain-repo[lightning,models]'
+#    pip install './neuraltrain-repo[lightning,models]' 'moabb>=1.7.1'
 #
 # The example pretrains on four EEG datasets: those behind tracks 1-3
 # (``Gifford2022Large``, ``Stieger2021Continuous``,
 # ``Kemp2000Analysis``) plus one resting-state dataset that belongs to
 # no track (``Miltiadous2023Dice``), together some 240 subjects. Each
-# is fetched from its public source the first time its study runs.
+# comes from its public source, fetched by the download step below.
 #
 # ``ssl_example`` keeps its own paths, set by ``DATADIR``, ``CACHEDIR``
 # and ``SAVEDIR`` at the top of ``defaults.py``: all three sit under
 # ``~/.cache/neuralset`` and are independent of the ``DATA_DIR`` you
 # configured for ``neuralbench``. Repoint them before the first run
-# unless your home directory can take close to a terabyte:
-# ``Stieger2021Continuous`` alone is ~600 GB downloaded plus ~280 GB once
-# MOABB converts it.
+# unless your home directory can take ~1.1 TB: ``Stieger2021Continuous``
+# alone is ~600 GB downloaded plus ~280 GB once MOABB converts it, and
+# ``Gifford2022Large`` adds ~210 GB.
 #
-# Nothing else is needed to start them downloading -- but they are large,
-# and the first run does two slow things before the first gradient step:
+# Training reads what is already on disk and never fetches, so download
+# the corpus first -- once per machine:
 #
-# 1. **Download** each dataset into ``DATADIR`` (once per machine).
+# .. code-block:: bash
+#
+#    python -m ssl_example.grids.download
+#
+# Two slow steps therefore precede the first gradient step:
+#
+# 1. **Download** each dataset into ``DATADIR`` (the command above).
 # 2. **Preprocess and cache** it into ``CACHEDIR``: resampling,
 #    filtering and scaling run once per configuration, and every later
 #    run and every grid job reads the cache instead of redoing them.
@@ -205,13 +212,17 @@ than it ships with.
 # repository at all -- the example is a starting point, and there are
 # three ways past it:
 #
-# - **Keep the loop, change the model.** Any ``neuraltrain`` model
-#   config drops into the same ``MaeModule`` by setting
-#   ``brain_model_config``.
+# - **Keep the loop, change the encoder's shape.** ``MaeModule`` is
+#   written against ``MaeEncoder`` -- it calls that encoder's patching
+#   and token methods, and ``brain_model_config`` is typed to it -- so
+#   vary its fields (``dim``, ``patch_size``,
+#   ``transformer_config.depth``) rather than swapping in another
+#   ``neuraltrain`` model.
 # - **Add your own model to** ``neuraltrain``. A new architecture is a
 #   ``BaseBrainModelConfig`` subclass with a ``build`` method, after
-#   which it is available to this example and to ``neuralbench`` by
-#   name, exactly as ``MaeEncoder`` is.
+#   which ``neuralbench`` can run it by name, exactly as ``MaeEncoder``
+#   is. Pretraining it here also means adapting ``mae_module.py``,
+#   which reconstructs the patches ``MaeEncoder`` produces.
 # - **Train wherever you like.** Nothing about the competition requires
 #   ``neuraltrain``, ``neuralset``, or PyTorch Lightning. Train in your
 #   own codebase, with your own data pipeline and objective, and bring
@@ -294,9 +305,9 @@ than it ships with.
 # accept any channel count and any window length, and take channel
 # identity from a ``channel_positions`` argument to ``forward`` rather
 # than from a montage fixed at construction. It needs no classifier
-# head -- ``neuralbench`` wraps it in a probe sized to each task, the
-# same frozen-backbone linear probe ``mae.yaml`` configures, so the two
-# routes produce comparable scores.
+# head -- ``neuralbench`` wraps it in a probe sized to each task, and
+# defaults to the same frozen-backbone ``linear_probe_mean`` preset that
+# ``-w`` selects above, so the two routes produce comparable scores.
 #
 # The encoder above meets those requirements, so either route works for
 # it. The YAML route additionally pins the preprocessing a checkpoint was

--- a/docs/neuralbench/tutorials/07_biosignal_challenge_2026/plot_track2_eeg_to_bci.py
+++ b/docs/neuralbench/tutorials/07_biosignal_challenge_2026/plot_track2_eeg_to_bci.py
@@ -94,7 +94,7 @@ recalibration allowed.
 # 2. **Split**: replace the default ``SklearnSplit`` with a
 #    predefined per-subject split where sessions 1-3 are train and
 #    sessions 4-6 are test. The
-#    ``neuralset.events.transforms.PredefinedSplit`` already used by
+#    ``neuralbench.transforms.PredefinedSplit`` already used by
 #    ``reaction_time`` and ``psychopathology`` is the right primitive
 #    -- the ``test_split_query`` becomes
 #    ``"subject in evaluation_subjects and session in [4, 5, 6]"``.

--- a/docs/neuralbench/tutorials/07_biosignal_challenge_2026/plot_track3_sleep_onset.py
+++ b/docs/neuralbench/tutorials/07_biosignal_challenge_2026/plot_track3_sleep_onset.py
@@ -3,7 +3,7 @@ Track 3 -- Sleep onset (cross-device latency prediction)
 =========================================================
 
 Given a continuous wearable EEG recording, predict the latency
-(in seconds, from recording start) to the first stable N2 epoch. The
+(in seconds, from recording start) to the first N2 epoch. The
 competition tests **cross-device** generalisation: the seed corpora are
 clinical polysomnography, while the evaluation set is consumer-grade
 home-wearable EEG with its own channels and montage. Precise timing
@@ -14,12 +14,15 @@ per-epoch hypnogram reconstruction.
   sleepers.
 - **Headline metric**: ``bMAE`` in seconds -- onset error averaged with
   equal weight over four time-to-onset bins, so long and short sleep
-  onsets count the same (lower is better). Tolerance rates within
-  30 / 60 / 300 s are reported as diagnostics.
+  onsets count the same (lower is better). The competition additionally
+  reports tolerance rates within 30 / 60 / 300 s; the starter kit logs
+  ``bMAE`` and the usual regression metrics, not those rates.
 - **Data**: continuous Muse wearable EEG, ~1000 training subjects,
-  hidden evaluation set of the same order of magnitude. The reference
-  onset is the first annotated N2 event (or equivalently the first
-  non-Wake epoch satisfying a fixed persistence rule).
+  hidden evaluation set of the same order of magnitude. The onset that
+  ``AddSleepOnsetTargets`` extracts is the earliest annotated N2 event
+  of the recording; it applies no persistence or non-Wake-continuity
+  rule, so check the competition's definition before reshaping the
+  target to match it.
 
 .. note::
    The Muse training set is released through NeuralBench when

--- a/docs/neuralbench/tutorials/07_biosignal_challenge_2026/plot_track4_emg_to_pose.py
+++ b/docs/neuralbench/tutorials/07_biosignal_challenge_2026/plot_track4_emg_to_pose.py
@@ -41,7 +41,7 @@ device placement, and hand kinematics at once.
 #
 # emg2pose is served through EEG-Dash, which the base install does not
 # pull, so install it first: ``pip install 'eegdash>=0.8.2'``. The full
-# release is ~310 GB under ``DATA_DIR``.
+# release is ~340 GB under ``DATA_DIR``.
 #
 # .. code-block:: bash
 #

--- a/neuraltrain-repo/ssl_example/README.md
+++ b/neuraltrain-repo/ssl_example/README.md
@@ -58,45 +58,54 @@ as it will during evaluation.
 **1. Install neuraltrain**
 
 See the [README](../README.md) for installation instructions. The encoder needs
-the `models` extra:
+the `models` extra, and `Stieger2021Continuous` needs `moabb`:
 
 ```
-pip install 'neuraltrain-repo/.[lightning,models]'
+pip install 'neuraltrain-repo/.[lightning,models]' 'moabb>=1.7.1'
 ```
 
 **2. Check the wiring**
 
-The four datasets are downloaded on first use and then preprocessed into a
-cache, which takes a while, so start with the debug config. It swaps them for
-one small bundled recording and runs a single batch:
+Downloading and preprocessing the four datasets takes a while, so start with
+the debug config. It swaps them for one small recording, which MNE fetches on
+first use, and runs a single batch:
 
 ```
 python -m ssl_example.grids.test_run
 ```
 
-**3. Run the real thing**
+**3. Download the datasets**
+
+Training reads what is on disk and never fetches, so download the corpus first
+-- once per machine, and it is ~1.1 TB:
+
+```
+python -m ssl_example.grids.download
+```
+
+**4. Run the real thing**
 
 ```
 python -m ssl_example.grids.defaults
 ```
 
-This downloads the four datasets on first use, caches their preprocessed form,
-and prints the path of the pretrained encoder when it finishes. Set
+This caches the preprocessed form of the four datasets and prints the path of
+the pretrained encoder when it finishes. Set
 `wandb_config` to `None` in `grids/defaults.py` to train without Weights &
 Biases. To pretrain on fewer datasets, or on your own, edit `STUDIES` in the
 same file.
 
-**4. Run example grid**
+**5. Run example grid**
 
 ```
 python -m ssl_example.grids.run_grid
 ```
 
-**5. Evaluate the pretrained encoder**
+**6. Evaluate the pretrained encoder**
 
 Pretraining is only worth as much as the representations it leaves behind, so
 score the encoder on a downstream `neuralbench` task by pointing `--checkpoint`
-at the file from step 3:
+at the file from step 4:
 
 ```
 neuralbench eeg motor_imagery -m mae --checkpoint <path>/encoder.ckpt \

--- a/neuraltrain-repo/ssl_example/grids/download.py
+++ b/neuraltrain-repo/ssl_example/grids/download.py
@@ -1,0 +1,28 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Download the pretraining corpus.
+
+Training reads what is on disk: ``Study.run()`` never fetches, only
+``Study.download()`` does. Run this once per machine before
+``ssl_example.grids.defaults``. The corpus is ~1.1 TB, so check ``DATADIR``
+has room first.
+"""
+
+import neuralset as ns
+
+from .defaults import DATADIR, STUDIES  # type: ignore
+
+
+def download() -> None:
+    """Fetch every study of ``STUDIES``, skipping what is already on disk."""
+    for name in STUDIES:
+        print(f"--- {name} -> {DATADIR}")
+        ns.Study(name=name, path=DATADIR).download()
+
+
+if __name__ == "__main__":
+    download()

--- a/neuraltrain-repo/ssl_example/grids/run_grid.py
+++ b/neuraltrain-repo/ssl_example/grids/run_grid.py
@@ -19,7 +19,7 @@ update = {
     "infra": {
         "cluster": "auto",
         "folder": SAVEDIR,
-        "slurm_partition": "learnfair",
+        "slurm_partition": "learnfair",  # replace with a partition you can submit to
         "timeout_min": 120,
         "gpus_per_node": 1,
         "cpus_per_task": 10,


### PR DESCRIPTION
Follow-up to #249. I repeated the from-scratch participant audit against released 0.3.1 (`pip install neuralbench` in a clean Python 3.12 venv, following only the published pages) and re-checked every claim in the starter kit against the shipped code.

The release itself holds up: every documented CLI invocation parses, every `--dataset` alias resolves, every model and `-w` preset exists, all four headline metric keys match what the tasks log, and all of #249's fixes are live and working — the non-interactive config notice, the GPU-capability warning (it fired on a real driver mismatch here, `torch 2.14.0+cu130` against driver 12.4, and the run continued), and the `moabb>=1.7.1` / `eegdash>=0.8.2` errors, whose floors match the code exactly. `tangermann2012` downloaded in 57 s at 744 MB, the figure the Track 2 page gives.

This PR fixes what the audit found that is wrong in prose rather than in code. Everything here is either under `docs/` or under `neuraltrain-repo/ssl_example/`, which participants get by cloning rather than from the wheel, so **no release is required**.

## Pretraining page: the documented run could not reach the first gradient step

The page said each dataset "is fetched from its public source the first time its study runs" and that "nothing else is needed to start them downloading". `Study.run()` never fetches; only `Study.download()` does, and neither `ssl_example` nor the page ever called it. A participant following the page would have watched all four studies fail — `Gifford2022Large` on a missing file, `Stieger2021Continuous` on the `timelines.csv` that only `_download` writes, and the other two on an empty timeline.

Added `ssl_example/grids/download.py`, which walks `STUDIES` and calls `Study.download()` on each; verified against released 0.3.1 that the call resolves the per-study subfolder itself and is a no-op on already-fetched data. The page and the example README now both route through it.

Three more corrections on the same page:

- The install block asked for `neuraltrain[lightning,models]` only, but `Stieger2021Continuous` needs `moabb>=1.7.1`, which nothing in the dependency graph installs. The sibling Track 2 page and `install.md` both say so already; this page was the odd one out.
- "Any `neuraltrain` model config drops into the same `MaeModule`" is not true: `brain_model_config` is typed `MaeEncoder`, and `MaeModule` calls that encoder's patching and token methods. Passing another model is rejected by pydantic.
- The frozen backbone was attributed to `mae.yaml`, which sets no freeze key and therefore fine-tunes. Freezing comes from the `linear_probe_mean` preset, which `-w` selects and `evaluate_model` defaults to — as the same page correctly says 54 lines earlier. A reader who trusted the later sentence and dropped `-w` would have reported a fine-tune score as a probe score.
- The corpus is ~1.1 TB by the overview page's own measured table, not "close to a terabyte".

## `install.md`: the config it recommends writing by hand crashes

The page tells participants to write a config file for SLURM batch scripts, `nohup`, CI and notebooks, and gives `{"CLUSTER": null}` as its example. Six keys have no default in `config_manager._initialize_module_vars` — `USER`, `ENTITY_NAME`, `PROJECT_NAME`, `DATA_DIR`, `CACHE_DIR`, `SAVE_DIR` — so that example fails with a bare `KeyError: 'USER'`, which I hit before any run started. The page now lists all six with a complete example, says which of them are only labels, and presents the `CLUSTER` snippet as an addition to them.

Two smaller ones there:

- `--prepare` was listed as CPU-only, but `eeg image`'s target extractor embeds its stimuli with DINOv2 and its task config requests a GPU. The section also now says that training, `--debug` included, has no CPU fallback — the driver mismatch this page warns about is what stopped the "quick local sanity check" on my host, after the pipeline had otherwise run through download, preprocessing and model construction.
- "`wandb` is the only extra of the package itself" contradicted the developer install two sections above; `dev` and `docs` exist too.

## Track pages

- **Track 3** described the target as the first *stable* N2 epoch and offered "the first non-Wake epoch satisfying a fixed persistence rule" as an equivalent. `AddSleepOnsetTargets` takes `n2["start"].min()` — the earliest annotated N2 event, with no persistence or non-Wake logic — and the two definitions do not coincide, since N1 normally precedes N2. The page now states what the extractor computes and tells participants to check the competition's definition before reshaping the target. The overview's echo of the same phrase is fixed too.
- **Track 3** also promised tolerance rates within 30 / 60 / 300 s "as diagnostics"; no such metric exists in `neuralbench`. Now attributed to the competition scorer, with the starter kit's own metrics named.
- **Track 4** and the overview gave emg2pose as ~310 GB; `salter2024emg2pose.py` warns the user it is ~340 GB. Aligned to the figure the code prints.
- **Track 2** attributed `PredefinedSplit` to `neuralset.events.transforms`; it lives in `neuralbench.transforms`.
- `ssl_example/grids/run_grid.py` hardcodes `slurm_partition: "learnfair"`, a Meta-internal partition the page points public participants at twice. Flagged in place with a comment.

## Not in this PR

Two findings need code changes and therefore a release; noted here so they are not lost:

- `neuralbench --help` lists each task's default study alongside its selectable variants, but `--dataset` only accepts the variants that have a `datasets/*.yaml`. `--dataset gifford2022large`, `--dataset stieger2021continuous` and `--dataset kemp2000analysis` — the primary dataset of tracks 1, 2 and 3 — all fail with "Unknown dataset", which is a strange first experience for anyone who reads `--help` and types what it shows.
- User errors surface as raw tracebacks: an unknown `--dataset`, a missing optional dependency and a hand-written config each end in an uncaught exception rather than a CLI message, even though the message text itself is good.

Separately, the theme's "View this page" and "Edit this page" links 404 on every sphinx-gallery page, challenge pages included: they point at `docs/neuralbench/auto_examples/.../plot_*.rst`, which is generated at build time and never committed. That is a `docs/conf.py` fix, and I left it out of a content PR.

## Test plan

- `ruff check` and `ruff format --check` pass on `docs/` and `neuraltrain-repo/ssl_example/`.
- `ns.Study(name=..., path=...).download()`, the call `download.py` makes, verified against released 0.3.1 on an already-fetched study.
- Link and anchor check over the 8 published challenge pages plus `install.md`: 3161 link instances, 396 distinct targets, no broken internal links and no missing anchors beyond the pre-existing gallery source links described above.
