### PR TITLE
docs: fix the view/edit source links on gallery pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- docs: the theme's "View this page" and "Edit this page" buttons on a sphinx-gallery page point at the example they are built from, rather than at the rst sphinx-gallery generates at build time and never commits, which 404'd on all 42 gallery pages (#252).
+
 ## [0.3.1] - 2026-09-10
 
 - `neuralbench`: adaptation wrappers (`-w`) apply to every model whose config ships a `downstream_model_wrapper`, not just the published foundation models, so a locally pretrained `mae` encoder is linear-probed as documented instead of silently fine-tuned end to end (#249).

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -316,6 +316,7 @@ def setup(app):
     app.connect("builder-inited", _regen_code_builder_data)
     app.connect("builder-inited", _regen_neuralfetch_explore_studies)
     app.connect("missing-reference", _resolve_short_paths)
+    app.connect("html-page-context", _gallery_source_links)
 
     listeners = app.events.listeners.get("autodoc-skip-member", [])
     for i, ev in enumerate(listeners):
@@ -421,3 +422,27 @@ sphinx_gallery_conf = {
     "remove_config_comments": True,
     "within_subsection_order": "FileNameSortKey",
 }
+
+
+def _gallery_source_links(app, pagename, templatename, context, doctree):
+    """Point the theme's view/edit buttons at the file a gallery page comes from.
+
+    The buttons default to ``<source_directory>/<pagename>.rst``, but
+    sphinx-gallery writes that rst under ``gallery_dirs`` at build time and it is
+    never committed, so the default 404s. The committed source is the example
+    itself, under the paired ``examples_dirs`` entry.
+    """
+    repo = html_theme_options["source_repository"].rstrip("/")
+    branch = html_theme_options["source_branch"]
+    directory = html_theme_options["source_directory"].strip("/")
+    pairs = zip(sphinx_gallery_conf["examples_dirs"], sphinx_gallery_conf["gallery_dirs"])
+    for examples_dir, gallery_dir in pairs:
+        if not pagename.startswith(f"{gallery_dir}/"):
+            continue
+        name = pagename[len(gallery_dir) + 1 :]
+        # each gallery's index page is rendered from the header rst, not an example
+        basename = "GALLERY_HEADER.rst" if name == "index" else f"{name}.py"
+        source = f"{directory}/{examples_dir}/{basename}"
+        context["theme_source_view_link"] = f"{repo}/blob/{branch}/{source}?plain=true"
+        context["theme_source_edit_link"] = f"{repo}/edit/{branch}/{source}"
+        return


### PR DESCRIPTION
## Problem

On every sphinx-gallery page, the theme's "View this page" and "Edit this page"
buttons link to a 404. The theme (`sphinx-basic-ng`, via furo) builds those URLs
as `<source_directory>/<pagename>.rst`, which for a gallery page is the rst
sphinx-gallery generates under `gallery_dirs` at build time — a file that is
never committed. For example, the challenge overview links to

```
docs/neuralbench/auto_examples/biosignal_challenge_2026/plot_overview.rst   404
```

when the committed source is

```
docs/neuralbench/tutorials/07_biosignal_challenge_2026/plot_overview.py
```

This affects all 42 gallery pages across the 14 galleries of the four packages,
not just the challenge starter kit. Found while auditing the released 0.3.1
docs as a competition participant.

## Fix

An `html-page-context` handler in `docs/conf.py` rewrites `theme_source_view_link`
and `theme_source_edit_link` for gallery pages only, mapping a page back to the
example it was built from through the existing `examples_dirs`/`gallery_dirs`
pairing. Each gallery's `index` page maps to its `GALLERY_HEADER.rst`. Repo,
branch and source directory are read from `html_theme_options`, so the URLs stay
in one place. Pages outside a gallery keep the theme default.

## Testing

- All 42 gallery pages (14 gallery indexes + 28 examples) map to a path that is
  tracked by git, and each of the 42 resulting "view" URLs returns HTTP 200.
- Pages outside a gallery (`index`, `neuralbench/install`, `neuralset/index`) are
  left untouched, so they keep the theme's default behaviour.
- The URLs contain no braces, so they survive the theme's
  `.format(filename=...)` pass unchanged.
- `ruff check` and `ruff format` clean; `docs/conf.py` still imports.

The mapping was checked directly rather than by diffing a full docs build, since
a build executes every gallery example across all four packages. The rendered
result is worth a glance on the docs preview before merge.
