### PR TITLE
fix: support Conformer padding lengths

### DIFF
--- a/neuraltrain-repo/neuraltrain/models/conformer.py
+++ b/neuraltrain-repo/neuraltrain/models/conformer.py
@@ -68,15 +68,18 @@ class Conformer(BaseModelConfig):
     def build(self, dim: int) -> nn.Module:
         from torchaudio.models import Conformer
 
-        # Subclass with forward method that infers `lengths` and returns only the output tensor
+        # Subclass with forward method that returns only the output tensor
         class ConformerSimpleOutput(Conformer):
-            def forward(self, x: torch.Tensor) -> torch.Tensor:
-                lengths = torch.full(
-                    (x.shape[0],),
-                    fill_value=x.shape[1],
-                    dtype=torch.long,
-                    device=x.device,
-                )
+            def forward(
+                self, x: torch.Tensor, lengths: torch.Tensor | None = None
+            ) -> torch.Tensor:
+                if lengths is None:
+                    lengths = torch.full(
+                        (x.shape[0],),
+                        fill_value=x.shape[1],
+                        dtype=torch.long,
+                        device=x.device,
+                    )
                 out, _ = super().forward(input=x, lengths=lengths)
                 return out
 

--- a/neuraltrain-repo/neuraltrain/models/test_conformer.py
+++ b/neuraltrain-repo/neuraltrain/models/test_conformer.py
@@ -45,3 +45,28 @@ def test_conformer(fake_input, use_default_config):
 
     # Check shape of the output
     assert out.shape == (batch_size, n_times, n_in_channels)
+
+
+def test_conformer_uses_lengths():
+    x = torch.randn(2, 12, 4)
+    lengths = torch.tensor([7, 12])
+    model = _conformer.Conformer(
+        num_heads=2,
+        num_layers=1,
+        ffn_dim=8,
+        dropout=0.0,
+        depthwise_conv_kernel_size=3,
+    ).build(dim=x.shape[-1])
+
+    masks = []
+
+    def capture_mask(module, args, kwargs):
+        masks.append(kwargs["key_padding_mask"])
+
+    model.conformer_layers[0].self_attn.register_forward_pre_hook(
+        capture_mask, with_kwargs=True
+    )
+    model(x, lengths=lengths)
+
+    expected = torch.arange(x.shape[1]).expand(x.shape[0], -1) >= lengths.unsqueeze(1)
+    torch.testing.assert_close(masks[0], expected)


### PR DESCRIPTION
Allow callers to provide sequence lengths to the Conformer wrapper while preserving the existing full-length default. This enables correct attention masking for padded batches without changing existing callers.