### PR TITLE
neuralfetch: unify selective download (include/exclude), fold in #25, fix brainai#1751

### DIFF
--- a/neuralfetch-repo/neuralfetch/download.py
+++ b/neuralfetch-repo/neuralfetch/download.py
@@ -416,10 +416,6 @@ class BaseDownload(_Module):
         raise NotImplementedError
 
 
-class Wildcard(BaseModel):
-    folder: str
-
-
 class S3(BaseDownload):
     """Download files from an S3 bucket via ``boto3``.
 
@@ -590,8 +586,8 @@ class Datalad(BaseDownload):
         URL of the DataLad repository to clone.
     threads : int
         Number of parallel download threads for ``datalad get`` (default: 1).
-    folders : list of str or Wildcard
-        Directories or glob patterns to retrieve after cloning.  When empty,
+    paths : list of str
+        paths or glob patterns to retrieve after cloning.  When empty,
         all content is retrieved via ``datalad get "*"``.
     """
 
@@ -600,8 +596,8 @@ class Datalad(BaseDownload):
     repo_url: str
     # number of threads used for the datalad operations
     threads: int = 1
-    # list of folders (or wildcards) to actually clone
-    folders: list[str | Wildcard] = []
+    # list of path to actually fetch
+    paths: list[str] = []
 
     @pydantic.computed_field  # type: ignore
     @property
@@ -611,43 +607,6 @@ class Datalad(BaseDownload):
         if Path(repo_name).suffix == ".git":
             repo_name = repo_name[:-4]
         return repo_name
-
-    def _datalad(self, cmd: str, path: Path | str) -> None:
-        # TODO: do not use subprocess
-        proc = subprocess.run(
-            cmd, cwd=str(path), capture_output=True, text=True, shell=True
-        )
-        if "install(error)" in proc.stdout:
-            logging.warning("Potential error in datalad clone:\n> %s", proc.stdout)
-        if proc.stderr:
-            # NOTE: stderr might be populated even in success case
-            logging.warning("Potential error in datalad clone:\n> %s", proc.stderr)
-            # raise RuntimeError(f"Clone Failed: {proc.stderr}")
-
-    def _dl_item(self, cur_path: Path | str) -> None:
-        threads_ = f" -J {self.threads}" if self.threads > 1 else ""
-        cmd = f'datalad get "{cur_path}"{threads_}'
-        self._datalad(cmd, self._dl_dir / self.repo_name)
-
-    def _expand_folders(self) -> list[Path]:
-        """Resolve :attr:`folders` into absolute paths inside the cloned repo.
-
-        Wildcard entries are glob-expanded against the working tree (which
-        already contains the BIDS layout because ``datalad clone`` populates
-        directory structure and small files even on annex-ignored remotes).
-        Bare strings are appended as-is.
-        """
-        folders = self.folders if self.folders else [Wildcard(folder="*")]
-        all_folders: list[Path] = []
-        for folder in folders:
-            if isinstance(folder, Wildcard):
-                all_folders += [
-                    Path(str(p))
-                    for p in glob(str(self._dl_dir / self.repo_name / folder.folder))
-                ]
-            else:
-                all_folders += [self._dl_dir / self.repo_name / folder]  # type: ignore[list-item]
-        return all_folders
 
     def _download(self, overwrite: bool = False) -> None:
         """Downloads data from datalab
@@ -665,19 +624,25 @@ class Datalad(BaseDownload):
             folders: List of folders to clone explicitly (otherwise everything is cloned).
                 Contains a tuple of str and bool. Bool defines if str is a glob
         """
+        import datalad.api as dlad
+
         # clone repo
-        self._datalad(f"datalad clone {self.repo_url}", self._dl_dir)
+        clone_res = dlad.clone(source=self.repo_url, path=self._dl_dir)
 
-        all_folders = self._expand_folders()
-        print(f"Loading {len(all_folders)} folders: ", all_folders)
+        expanded_paths = []
+        # expand paths
+        if len(self.paths) < 1:
+            expanded_paths = ['.']
+        else:
+            for path in self.paths:
+                if '*' in path:
+                    expanded_paths.extend(self._dl_dir.glob(path))
+                else:
+                    expanded_paths.append(self._dl_dir/path)
+        logging.debug("Downloading %s", expanded_paths)
+        clone_res.get(expanded_paths, jobs=self.threads)
 
-        # download
-        for item in tqdm(all_folders, desc=f"Downloading {self.study}", ncols=100):
-            if not item.is_dir():
-                continue
-            self._dl_item(item)
-
-        print("\nDownloaded Dataset")
+        logging.info("Downloaded Dataset in %s", self._dl_dir)
 
 
 class Gin(Datalad):

--- a/neuralfetch-repo/neuralfetch/download.py
+++ b/neuralfetch-repo/neuralfetch/download.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import contextlib
+import fnmatch
 import json
 import logging
 import os
@@ -15,14 +16,13 @@ import typing as tp
 import urllib.request
 import zipfile
 from abc import abstractmethod
-from glob import glob
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 import mne
 import pydantic
 from tqdm import tqdm
 
-from neuralset.base import BaseModel, PathLike, _Module
+from neuralset.base import PathLike, _Module
 
 logger = logging.getLogger(__name__)
 
@@ -351,6 +351,29 @@ def run_parallel(
             future.result()
 
 
+def _globs_match(patterns: list[str], relpath: str) -> bool:
+    """True if *relpath* matches any of *patterns* (openneuro-py glob semantics).
+
+    ``relpath`` is a dataset-relative POSIX path. ``*``/``?``/``**`` follow
+    ``fnmatch`` semantics (``*`` spans ``/`` as well, matching openneuro-py's
+    documented behaviour, so a pattern like ``sub-1/**/*run-01*`` keeps working).
+    A pattern that names a directory (e.g. ``sub-01`` or ``sub-*``) also selects
+    everything beneath it: each ancestor prefix of ``relpath`` is tested, so
+    ``sub-01`` matches ``sub-01/eeg/x.set``.
+    """
+    rel = relpath.strip("/")
+    parts = PurePosixPath(rel).parts
+    candidates = [rel]
+    # ancestor directory prefixes -> a folder pattern selects its whole subtree
+    for i in range(1, len(parts)):
+        candidates.append("/".join(parts[:i]))
+    for pattern in patterns:
+        pat = pattern.strip("/")
+        if any(fnmatch.fnmatchcase(cand, pat) for cand in candidates):
+            return True
+    return False
+
+
 class BaseDownload(_Module):
     """Abstract base class for all neuralfetch download backends.
 
@@ -358,6 +381,14 @@ class BaseDownload(_Module):
     method wraps ``_download`` with idempotency checks via a *success file*:
     once a dataset has been downloaded successfully, subsequent calls are
     no-ops unless ``overwrite=True`` is passed.
+
+    Selective downloading is unified across backends via the ``include`` and
+    ``exclude`` glob fields (dataset-relative POSIX globs). ``include`` empty
+    means "everything"; ``exclude`` is applied after ``include`` and wins.
+    Backends map these onto their native selection mechanism where possible
+    (see :meth:`_selects`); backends with no usable native filter raise
+    ``NotImplementedError`` when either field is set (see
+    :meth:`_reject_selection_filters`).
 
     Parameters
     ----------
@@ -374,8 +405,33 @@ class BaseDownload(_Module):
     study: str
     dset_dir: PathLike
     folder: str = "download"
+    # dataset-relative POSIX globs; empty ``include`` means everything and
+    # ``exclude`` is applied after ``include`` (exclude wins).
+    include: list[str] = []
+    exclude: list[str] = []
 
     _dl_dir: Path = pydantic.PrivateAttr()
+
+    def _selects(self, relpath: PathLike | str) -> bool:
+        """True if a dataset-relative path passes the include/exclude filter."""
+        rel = str(relpath).strip("/")
+        if self.exclude and _globs_match(self.exclude, rel):
+            return False
+        if not self.include:
+            return True
+        return _globs_match(self.include, rel)
+
+    def _reject_selection_filters(self) -> None:
+        """Raise if include/exclude is set on a backend with no native filter.
+
+        Prevents the silent "filter ignored, whole dataset downloaded" failure
+        mode.
+        """
+        if self.include or self.exclude:
+            raise NotImplementedError(
+                f"{type(self).__name__} does not support selective downloading; "
+                "remove the include/exclude filters or use a backend that does."
+            )
 
     def model_post_init(self, log__: tp.Any) -> None:
         super().model_post_init(log__)
@@ -514,6 +570,8 @@ class S3(BaseDownload):
     def _resolve_mapped(self, skip_existing: bool) -> list[tuple[str, Path]]:
         jobs: list[tuple[str, Path]] = []
         for s3_key, local_rel in self.files_with_destinations:
+            if not self._selects(local_rel):
+                continue
             local_path = (
                 Path(local_rel)
                 if Path(local_rel).is_absolute()
@@ -533,6 +591,8 @@ class S3(BaseDownload):
             if self.prefix:
                 rel = obj.key[len(self.prefix) :].lstrip("/")
             if not rel:
+                continue
+            if not self._selects(rel):
                 continue
             target = self._out / rel
             if skip_existing and target.exists():
@@ -567,6 +627,7 @@ class Dandi(BaseDownload):
     version: str = "draft"
 
     def _download(self, overwrite: bool = False) -> None:
+        self._reject_selection_filters()
         import dandi.download  # type: ignore[import-not-found,import-untyped]
 
         url = f"https://dandiarchive.org/dandiset/{self.study}/{self.version}"
@@ -577,27 +638,27 @@ class Dandi(BaseDownload):
 class Datalad(BaseDownload):
     """Download datasets via DataLad and git-annex.
 
-    Clones a git-annex repository and optionally retrieves a subset of
-    directories.  A password-free SSH key is required for git operations.
+    Clones a git-annex repository into ``download/<repo_name>/`` and fetches
+    its content with the ``datalad`` Python API. Selective downloading uses the
+    inherited ``include``/``exclude`` globs; with no filters the whole dataset
+    is fetched. A password-free SSH key is required for git operations.
 
     Parameters
     ----------
     repo_url : str
         URL of the DataLad repository to clone.
     threads : int
-        Number of parallel download threads for ``datalad get`` (default: 1).
-    paths : list of str
-        paths or glob patterns to retrieve after cloning.  When empty,
-        all content is retrieved via ``datalad get "*"``.
+        Number of parallel ``datalad get`` jobs (default: 1).
+    include, exclude : list of str
+        Dataset-relative POSIX globs selecting a subset to fetch. See
+        :class:`BaseDownload`.
     """
 
-    requirements: tp.ClassVar[tuple[str, ...]] = ("datalad-installer",)
+    requirements: tp.ClassVar[tuple[str, ...]] = ("datalad", "datalad-installer")
     # url of the datalad repo to clone
     repo_url: str
     # number of threads used for the datalad operations
     threads: int = 1
-    # list of path to actually fetch
-    paths: list[str] = []
 
     @pydantic.computed_field  # type: ignore
     @property
@@ -608,42 +669,47 @@ class Datalad(BaseDownload):
             repo_name = repo_name[:-4]
         return repo_name
 
+    def _selected_paths(self, repo_root: Path) -> list[str]:
+        """Resolve include/exclude into concrete paths for ``datalad get``.
+
+        With no filters, returns ``["."]`` (fetch the whole dataset). Otherwise
+        walk the cloned working tree -- ``datalad clone`` populates the
+        directory structure and git-annex pointer files even before content is
+        fetched -- and return the files passing :meth:`_selects`. Broken annex
+        pointer symlinks (content not yet fetched) are treated as files.
+        """
+        if not self.include and not self.exclude:
+            return ["."]
+        selected: list[str] = []
+        for path in sorted(repo_root.rglob("*")):
+            if path.is_dir():  # real directories only; broken symlinks are files
+                continue
+            rel = path.relative_to(repo_root)
+            if rel.parts and rel.parts[0] in {".git", ".datalad"}:
+                continue
+            if self._selects(rel.as_posix()):
+                selected.append(str(path))
+        return selected
+
     def _download(self, overwrite: bool = False) -> None:
-        """Downloads data from datalab
+        """Clone the repo and fetch the selected content via ``datalad.api``.
 
         ``datalad get`` is idempotent and self-repairing, so ``overwrite`` needs
-        no special handling here: re-running fetches any missing/broken content.
-
-        Since this requires a git connection to handle, make sure that
-        git ssh-key is password free
-
-        Parameters
-            path: Path to store the dataset (will clone repo to that folder)
-            url: Url of the datalad repository
-            threads: Number of threads to parallelize dataset download
-            folders: List of folders to clone explicitly (otherwise everything is cloned).
-                Contains a tuple of str and bool. Bool defines if str is a glob
+        no special handling: re-running fetches any missing/broken content.
+        Requires a password-free git SSH key. If ``datalad`` is not installed
+        the import raises here (and ``_check_requirements`` earlier), so no
+        success marker is written over an empty folder.
         """
         import datalad.api as dlad
 
         logging.getLogger("datalad").setLevel(logging.WARNING)
-        # clone repo
-        clone_res = dlad.clone(source=self.repo_url, path=self._dl_dir)
+        repo_root = self._dl_dir / self.repo_name
+        dataset = dlad.clone(source=self.repo_url, path=repo_root)
 
-        expanded_paths = []
-        # expand paths
-        if len(self.paths) < 1:
-            expanded_paths = ['.']
-        else:
-            for path in self.paths:
-                if '*' in path:
-                    expanded_paths.extend(self._dl_dir.glob(path))
-                else:
-                    expanded_paths.append(self._dl_dir/path)
-        logging.debug("Downloading %s", expanded_paths)
-        clone_res.get(expanded_paths, jobs=self.threads)
-
-        logging.info("Downloaded Dataset in %s", self._dl_dir)
+        paths = self._selected_paths(repo_root)
+        logging.debug("datalad get %d path(s) under %s", len(paths), repo_root)
+        dataset.get(paths, jobs=self.threads)
+        logging.info("Downloaded dataset in %s", repo_root)
 
 
 class Gin(Datalad):
@@ -659,20 +725,21 @@ class Gin(Datalad):
 
     This backend works around the limitation by:
 
-    1. Cloning the repo (same as :class:`Datalad`; only pointer files
-       are materialised).
-    2. Scanning the requested ``folders`` for git-annex pointer files
-       (v8 in-tree pointers and v7 symlinks under ``.git/annex/objects``).
-    3. Batch-registering ``https://gin.g-node.org/<owner>/<repo>/raw/<branch>/<relpath>``
-       URLs against each annex key via ``git annex registerurl --batch``.
+    1. Cloning the repo with the ``datalad`` API (same as :class:`Datalad`;
+       only pointer files are materialised).
+    2. Scanning the selected files (per the inherited ``include``/``exclude``
+       globs) for git-annex pointers, in either representation: unlocked
+       in-tree pointer files or locked symlinks into ``.git/annex/objects``.
+    3. Registering ``https://gin.g-node.org/<owner>/<repo>/raw/<branch>/<relpath>``
+       URLs against each annex key via datalad's ``AnnexRepo`` (``registerurl``).
        GIN serves annexed content over plain HTTPS at that path.
-    4. Running ``git annex get --from=web --jobs=<threads>`` per folder
-       to actually pull content.
+    4. Fetching the selected paths from the built-in ``web`` special remote via
+       ``AnnexRepo.get(..., options=["--from=web"])``.
 
     Studies pass the same arguments as :class:`Datalad` (``repo_url``,
-    ``folders``, ``threads``) and additionally set ``branch=`` when the
-    default branch is not ``master``. No other plumbing is required in
-    the study class.
+    ``include``/``exclude``, ``threads``) and additionally set ``branch=`` when
+    the default branch is not ``master``. No other plumbing is required in the
+    study class.
 
     Parameters
     ----------
@@ -684,10 +751,10 @@ class Gin(Datalad):
         (default ``"master"``; some repos use ``"main"``).
     threads : int
         Number of parallel ``git annex get`` jobs (default 1).
-    folders : list of str or Wildcard
-        Same semantics as :attr:`Datalad.folders`. Restricts the URL
-        registration scan as well, so we avoid walking the whole tree
-        when only a subset is requested.
+    include, exclude : list of str
+        Dataset-relative POSIX globs selecting a subset to fetch. Restricts the
+        URL-registration scan as well, so we avoid registering the whole tree
+        when only a subset is requested. See :class:`BaseDownload`.
     """
 
     branch: str = "master"
@@ -705,9 +772,10 @@ class Gin(Datalad):
     def _read_pointer_key(path: Path) -> str | None:
         """Return the git-annex key for *path*, or None if it's not a pointer.
 
-        Handles both modern v8 pointer files (small ASCII files whose
-        first line is ``"/annex/objects/<key>"``) and legacy v7 symlinks
-        targeting ``.git/annex/objects/.../<key>``.
+        Handles both representations of an annexed file: an unlocked pointer
+        file (a small ASCII file whose first line is
+        ``"/annex/objects/<key>"``) and a locked symlink targeting
+        ``.git/annex/objects/.../<key>``.
         """
         if path.is_symlink():
             target = os.readlink(path)
@@ -730,92 +798,73 @@ class Gin(Datalad):
             return None
         return first_line[len("/annex/objects/") :]
 
-    def _iter_pointers(
-        self, repo_root: Path, folders: list[Path]
-    ) -> tp.Iterator[tuple[str, Path]]:
-        """Yield ``(annex_key, repo_relative_path)`` for every pointer file."""
-        seen: set[Path] = set()
-        for folder in folders:
-            if not folder.is_dir():
-                continue
-            for path in folder.rglob("*"):
-                if path in seen:
-                    continue
-                seen.add(path)
-                if not (path.is_file() or path.is_symlink()):
-                    continue
-                key = self._read_pointer_key(path)
-                if key is None:
-                    continue
-                try:
-                    rel = path.relative_to(repo_root)
-                except ValueError:
-                    continue
-                yield key, rel
+    def _selected_pointers(self, repo_root: Path) -> list[tuple[str, Path]]:
+        """``(annex_key, repo-relative path)`` for every selected pointer file.
 
-    def _register_urls(self, repo_root: Path, folders: list[Path]) -> int:
-        """Register web URLs for every pointer file. Returns the count."""
-        pairs = list(self._iter_pointers(repo_root, folders))
-        if not pairs:
-            return 0
-        batch = "".join(
-            f"{key} {self._https_base}/{rel.as_posix()}\n" for key, rel in pairs
-        )
-        proc = subprocess.run(
-            ["git", "annex", "registerurl", "--batch"],
-            input=batch,
-            text=True,
-            cwd=str(repo_root),
-            capture_output=True,
-            check=False,
-        )
-        if proc.returncode != 0:
-            logger.warning(
-                "git annex registerurl exited %d:\n%s", proc.returncode, proc.stderr
-            )
+        Walks the cloned working tree and keeps files whose dataset-relative
+        path passes :meth:`_selects` and that are git-annex pointers, in either
+        representation: unlocked in-tree pointer files or locked symlinks into
+        ``.git/annex/objects``.
+        """
+        pairs: list[tuple[str, Path]] = []
+        for path in sorted(repo_root.rglob("*")):
+            if path.is_dir():  # real directories only; broken symlinks are files
+                continue
+            rel = path.relative_to(repo_root)
+            if rel.parts and rel.parts[0] in {".git", ".datalad"}:
+                continue
+            if not self._selects(rel.as_posix()):
+                continue
+            key = self._read_pointer_key(path)
+            if key is None:
+                continue
+            pairs.append((key, rel))
+        return pairs
+
+    def _register_urls(self, annex: tp.Any, pairs: list[tuple[str, Path]]) -> int:
+        """Register a GIN web URL for every ``(key, relpath)`` pair. Returns count.
+
+        Uses datalad's ``AnnexRepo`` (``registerurl``) rather than a raw
+        ``git annex`` subprocess.
+        """
+        for key, rel in pairs:
+            url = f"{self._https_base}/{rel.as_posix()}"
+            annex.call_annex(["registerurl", key, url])
         return len(pairs)
 
-    def _annex_get_web(self, target: Path, repo_root: Path) -> None:
-        """Fetch annexed content for *target* via the built-in web remote."""
-        cmd = [
-            "git",
-            "annex",
-            "get",
-            "--from=web",
-            f"--jobs={self.threads}",
-            str(target),
-        ]
-        proc = subprocess.run(
-            cmd, cwd=str(repo_root), capture_output=True, text=True, check=False
+    def _annex_get_web(self, annex: tp.Any, rels: list[Path]) -> None:
+        """Fetch the given repo-relative paths from git-annex's ``web`` remote.
+
+        Uses ``AnnexRepo.get`` (datalad renders its own download progress).
+        ``web`` is a git-annex special remote, not a git remote, so it is
+        passed via ``--from web`` (datalad's ``remote=`` only accepts git
+        remotes and would raise ``RemoteNotAvailableError`` for ``web``).
+        """
+        if not rels:
+            return
+        annex.get(
+            [rel.as_posix() for rel in rels],
+            options=["--from", "web"],
+            jobs=self.threads,
         )
-        if proc.returncode != 0:
-            logger.warning(
-                "git annex get --from=web exited %d on %s:\n%s",
-                proc.returncode,
-                target,
-                proc.stderr,
-            )
 
     def _download(self, overwrite: bool = False) -> None:
-        self._datalad(f"datalad clone {self.repo_url}", self._dl_dir)
+        import datalad.api as dlad
+        from datalad.support.annexrepo import AnnexRepo
+
+        logging.getLogger("datalad").setLevel(logging.WARNING)
         repo_root = self._dl_dir / self.repo_name
+        # clone only materialises pointer files: GIN's HTTPS remote is
+        # annex-ignored, so datalad get would no-op (see class docstring).
+        dlad.clone(source=self.repo_url, path=repo_root)
+        annex = AnnexRepo(str(repo_root))
 
-        all_folders = self._expand_folders()
-        print(f"Loading {len(all_folders)} folders: ", all_folders, flush=True)
-
-        # registerurl --batch is slow and silent on large datasets; flush to timestamp it
-        print(
-            f"Registering GIN web URLs for pointer files under {len(all_folders)} folders...",
-            flush=True,
-        )
-        n_registered = self._register_urls(repo_root, all_folders)
+        pairs = self._selected_pointers(repo_root)
+        print(f"Registering GIN web URLs for {len(pairs)} pointer files...", flush=True)
+        n_registered = self._register_urls(annex, pairs)
         print(f"Registered {n_registered} GIN web URLs against annex keys", flush=True)
 
-        for item in tqdm(all_folders, desc=f"Downloading {self.study}", ncols=100):
-            if not item.is_dir():
-                continue
-            self._annex_get_web(item, repo_root)
-
+        self._annex_get_web(annex, [rel for _, rel in pairs])
         print("\nDownloaded Dataset", flush=True)
 
 
@@ -861,6 +910,7 @@ class Donders(BaseDownload):
         self._password = password
 
     def _download(self, overwrite: bool = False) -> None:
+        self._reject_selection_filters()
         # ``overwrite`` is best-effort for the Donders WebDAV mirror: wget
         # already refetches over the existing tree.
         command = "wget -r -nH -np --cut-dirs=1"
@@ -964,6 +1014,12 @@ class Dryad(BaseDownload):
 
         import requests as req
 
+        # The bulk endpoint returns a zip of the whole dataset with no way to
+        # filter, so selective downloads must go file-by-file.
+        if self.include or self.exclude:
+            self._download_individual_files(overwrite=overwrite)
+            return
+
         encoded = quote(f"doi:{self.doi}", safe="")
         api_url = f"{self._DRYAD_API}/datasets/{encoded}/download"
 
@@ -996,6 +1052,8 @@ class Dryad(BaseDownload):
         print(f"Downloading {len(files)} files individually from Dryad...")
         for i, f in enumerate(files, 1):
             name = f.get("path", f"file_{i}")
+            if not self._selects(name):
+                continue
             dl_href = f.get("_links", {}).get("stash:download", {}).get("href")
             if not dl_href:
                 logger.warning(f"Skipping {name}: no download link")
@@ -1054,7 +1112,9 @@ class Eegdash(BaseDownload):
 
     def _download(self, overwrite: bool = False) -> None:
         # ``overwrite`` is best-effort: eegdash's client manages its own cache
-        # and refetches missing recordings on demand.
+        # and refetches missing recordings on demand. Path globs are not
+        # supported (use ``subject`` for subject-level selection).
+        self._reject_selection_filters()
         from eegdash import EEGDashDataset  # type: ignore[import-not-found]
 
         kwargs: dict[str, tp.Any] = {}
@@ -1118,6 +1178,8 @@ class Figshare(BaseDownload):
         file_info = json.loads(r.text)
 
         for k in tqdm(file_info):
+            if not self._selects(k["name"]):
+                continue
             dest = self._dl_dir / k["name"]
             expected_md5 = k.get("computed_md5") or k.get("supplied_md5")
 
@@ -1283,6 +1345,8 @@ class Globus(BaseDownload):
                     stack.append(full)
                 elif etype == "file":
                     rel = full[len(root) :].lstrip("/")
+                    if not self._selects(rel):
+                        continue
                     local_path = self._dl_dir / rel
                     if skip_existing and local_path.exists():
                         continue
@@ -1343,6 +1407,10 @@ class Huggingface(BaseDownload):
         Hugging Face organisation or user that owns the dataset
         (e.g. ``"BrainAI"`` or ``"openai"``).  Combined with *study* to
         form ``repo_id``.
+    include, exclude : list of str
+        Dataset-relative globs, forwarded natively to
+        ``snapshot_download`` as ``allow_patterns``/``ignore_patterns``.
+        See :class:`BaseDownload`.
     """
 
     requirements: tp.ClassVar[tuple[str, ...]] = ("huggingface_hub",)
@@ -1356,6 +1424,8 @@ class Huggingface(BaseDownload):
             repo_type="dataset",
             local_dir=self._dl_dir,
             force_download=overwrite,
+            allow_patterns=self.include or None,
+            ignore_patterns=self.exclude or None,
         )
         print("\nDownloaded Dataset")
 
@@ -1363,15 +1433,13 @@ class Huggingface(BaseDownload):
 class Openneuro(BaseDownload):
     """Download datasets from OpenNeuro.
 
-    The ``include`` parameter follows the openneuro-py API: files and
-    directories to download. Only these files and directories will be
-    retrieved. Uses Unix path expansion (``*`` for any number of wildcard
-    characters and ``?`` for one wildcard character; e.g.
-    ``'sub-1_task-*.fif'``). As an example, if you would like to download
-    only subject '1' and run '01' files, you can do so via
-    ``'sub-1/**/*run-01*'``. The pattern ``**`` will match any files and
-    zero or more directories, subdirectories and symbolic links to
-    directories.
+    The inherited ``include``/``exclude`` globs map directly onto the
+    openneuro-py API (files and directories to download / skip). Uses Unix
+    path expansion (``*`` for any number of wildcard characters and ``?`` for
+    one; e.g. ``'sub-1_task-*.fif'``). As an example, to download only subject
+    '1' and run '01' files use ``include=['sub-1/**/*run-01*']``. The pattern
+    ``**`` matches any files and zero or more directories, subdirectories and
+    symbolic links to directories. See :class:`BaseDownload`.
 
     The ``nworkers`` parameter controls how many files are downloaded in
     parallel (forwarded to ``openneuro.download`` as
@@ -1380,8 +1448,6 @@ class Openneuro(BaseDownload):
     """
 
     requirements: tp.ClassVar[tuple[str, ...]] = ("openneuro-py>=2026.4.0",)
-    excluded_patterns: list[str] = []
-    include: list[str] | None = None
     nworkers: int = 5
 
     def _download(self, overwrite: bool = False) -> None:
@@ -1400,7 +1466,8 @@ class Openneuro(BaseDownload):
         on.download(
             dataset=self.study,
             target_dir=self._dl_dir,
-            include=self.include,
+            include=self.include or None,
+            exclude=self.exclude or None,
             max_concurrent_downloads=self.nworkers,
         )
 
@@ -1448,6 +1515,9 @@ class Osf(BaseDownload):
                 path = source.path
                 if path.startswith("/"):
                     path = path[1:]
+
+                if not self._selects(path):
+                    continue
 
                 file_ = self._dl_dir / path
 
@@ -1519,6 +1589,7 @@ class Synapse(BaseDownload):
     def _download(self, overwrite: bool = False) -> None:
         # ``overwrite`` is best-effort: syncFromSynapse manages its own local
         # cache and refetches changed/missing entities on each sync.
+        self._reject_selection_filters()
         import synapseclient
         import synapseutils
 
@@ -1561,6 +1632,8 @@ class Zenodo(BaseDownload):
             file_checksums = {}
             for file_info in data.get("files", []):
                 filename = file_info["key"]
+                if not self._selects(filename):
+                    continue
                 # Zenodo provides checksums in format "md5:xxxxx" or "sha256:xxxxx"
                 checksum_str = file_info["checksum"]
                 file_checksums[filename] = checksum_str

--- a/neuralfetch-repo/neuralfetch/download.py
+++ b/neuralfetch-repo/neuralfetch/download.py
@@ -626,6 +626,7 @@ class Datalad(BaseDownload):
         """
         import datalad.api as dlad
 
+        logging.getLogger("datalad").setLevel(logging.WARNING)
         # clone repo
         clone_res = dlad.clone(source=self.repo_url, path=self._dl_dir)
 

--- a/neuralfetch-repo/neuralfetch/studies/hebart2023things.py
+++ b/neuralfetch-repo/neuralfetch/studies/hebart2023things.py
@@ -390,7 +390,7 @@ class Hebart2023ThingsBold(_Hebart2023Things):
                 dset_dir=self.path,
                 repo_url="https://github.com/OpenNeuroDatasets/ds004192.git",
                 threads=4,
-                folders=[download.Wildcard(folder="sub-*")],
+                include=["sub-*"],
             ).download(overwrite=overwrite)
             self._write_test_categories()
 

--- a/neuralfetch-repo/neuralfetch/test_download.py
+++ b/neuralfetch-repo/neuralfetch/test_download.py
@@ -7,9 +7,11 @@
 """Offline tests for download backends — no network access required."""
 
 import os
+import sys
+import types
 import typing as tp
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -192,16 +194,16 @@ def test_gin_https_base_strips_dot_git_and_appends_branch(tmp_path: Path) -> Non
     assert gin_bare._https_base == "https://gin.g-node.org/CUBRIC/WAND/raw/master"
 
 
-def test_gin_read_pointer_key_v8(tmp_path: Path) -> None:
-    """A v8 in-tree pointer file parses to its annex key."""
+def test_gin_read_pointer_key_unlocked_pointer(tmp_path: Path) -> None:
+    """An unlocked in-tree pointer file parses to its annex key."""
     key = "MD5-s976320008--eea09d82b05cc6d6edb5b147f8579575"
     pointer = tmp_path / "sub-001.meg4"
     pointer.write_text(f"/annex/objects/{key}\n")
     assert download.Gin._read_pointer_key(pointer) == key
 
 
-def test_gin_read_pointer_key_v7_symlink(tmp_path: Path) -> None:
-    """A v7 symlink into ``.git/annex/objects/...`` resolves to its key."""
+def test_gin_read_pointer_key_locked_symlink(tmp_path: Path) -> None:
+    """A locked symlink into ``.git/annex/objects/...`` resolves to its key."""
     key = "SHA256E-s100--abc"
     target = f"../../../.git/annex/objects/Wp/g8/{key}/{key}"
     symlink = tmp_path / "sub-001.res4"
@@ -224,59 +226,80 @@ def test_gin_read_pointer_key_rejects_non_pointers(tmp_path: Path) -> None:
     assert download.Gin._read_pointer_key(elsewhere) is None
 
 
-def test_gin_download_invokes_clone_register_and_get(
-    tmp_path: Path, mocker: tp.Any
-) -> None:
+def test_gin_download_invokes_clone_register_and_get(tmp_path: Path) -> None:
     """End-to-end ``Gin._download`` wires clone -> registerurl -> annex get.
 
-    The clone step is stubbed to materialise the WAND-like directory
-    structure with one pointer file; the rest is mocked so the test stays
-    offline.
+    ``datalad.api.clone`` is stubbed to materialise the WAND-like directory
+    structure with one pointer file, and datalad's ``AnnexRepo`` is mocked, so
+    the test stays offline and does not require ``datalad`` to be installed.
     """
     gin = _make_gin(
         tmp_path,
-        folders=[download.Wildcard(folder="sub-*/ses-01/meg")],
+        include=["sub-*/ses-01/meg"],
         threads=3,
     )
 
     pointer_rel = Path("sub-00395/ses-01/meg/sub-00395_ses-01_task-resting.meg4")
-    pointer_abs = gin._dl_dir / gin.repo_name / pointer_rel
+    repo_root = gin._dl_dir / gin.repo_name
+    pointer_abs = repo_root / pointer_rel
     annex_key = "MD5-s976320008--eea09d82b05cc6d6edb5b147f8579575"
 
-    def fake_clone(cmd: str, path: tp.Any) -> None:
-        # `datalad clone` should populate the working tree; emulate that
-        # by writing the pointer file under the expected repo root.
+    def fake_clone(source: str, path: tp.Any) -> tp.Any:
+        # `datalad clone` populates the working tree; emulate that by writing
+        # the pointer file under the expected repo root.
+        Path(path).mkdir(parents=True, exist_ok=True)
         pointer_abs.parent.mkdir(parents=True, exist_ok=True)
         pointer_abs.write_text(f"/annex/objects/{annex_key}\n")
+        return MagicMock()
 
-    mocker.patch.object(download.Gin, "_datalad", side_effect=fake_clone)
-    run_mock = mocker.patch(
-        "neuralfetch.download.subprocess.run",
-        return_value=mocker.Mock(returncode=0, stderr="", stdout=""),
-    )
+    annex = MagicMock()
+    clone_mock = MagicMock(side_effect=fake_clone)
+    annex_cls = MagicMock(return_value=annex)
 
-    gin._download()
+    # Inject fake ``datalad`` modules so the test runs whether or not datalad is
+    # installed (CI does not install it). ``_download`` does
+    # ``import datalad.api as dlad`` (resolved via ``datalad.api``) and
+    # ``from datalad.support.annexrepo import AnnexRepo``.
+    fake_api = types.ModuleType("datalad.api")
+    fake_api.clone = clone_mock  # type: ignore[attr-defined]
+    fake_datalad = types.ModuleType("datalad")
+    fake_datalad.api = fake_api  # type: ignore[attr-defined]
+    fake_annexrepo = types.ModuleType("datalad.support.annexrepo")
+    fake_annexrepo.AnnexRepo = annex_cls  # type: ignore[attr-defined]
+    fake_support = types.ModuleType("datalad.support")
+    fake_support.annexrepo = fake_annexrepo  # type: ignore[attr-defined]
+    fake_modules = {
+        "datalad": fake_datalad,
+        "datalad.api": fake_api,
+        "datalad.support": fake_support,
+        "datalad.support.annexrepo": fake_annexrepo,
+    }
+
+    with patch.dict(sys.modules, fake_modules):
+        gin._download()
+
+    # 0. clone was invoked into download/<repo_name>/, AnnexRepo built on it
+    clone_mock.assert_called_once()
+    assert clone_mock.call_args.kwargs["path"] == repo_root
+    annex_cls.assert_called_once_with(str(repo_root))
 
     # 1. registerurl invoked with key + correct GIN HTTPS URL
     expected_url = (
         "https://gin.g-node.org/CUBRIC/WAND/raw/master/" + pointer_rel.as_posix()
     )
     register_calls = [
-        c
-        for c in run_mock.call_args_list
-        if c.args[0][:3] == ["git", "annex", "registerurl"]
+        c for c in annex.call_annex.call_args_list if c.args[0][:1] == ["registerurl"]
     ]
     assert len(register_calls) == 1
-    assert register_calls[0].kwargs["input"] == f"{annex_key} {expected_url}\n"
-    assert register_calls[0].kwargs["cwd"] == str(gin._dl_dir / gin.repo_name)
+    assert register_calls[0].args[0] == ["registerurl", annex_key, expected_url]
 
-    # 2. annex get --from=web invoked per resolved folder with --jobs=threads
-    get_calls = [
-        c for c in run_mock.call_args_list if c.args[0][:3] == ["git", "annex", "get"]
-    ]
-    assert len(get_calls) == 1
-    assert "--from=web" in get_calls[0].args[0]
-    assert "--jobs=3" in get_calls[0].args[0]
+    # 2. AnnexRepo.get invoked from the web special remote (via --from web,
+    #    since datalad's remote= only accepts git remotes) with jobs + the file
+    annex.get.assert_called_once()
+    get_args, get_kwargs = annex.get.call_args
+    assert pointer_rel.as_posix() in get_args[0]
+    assert get_kwargs["options"] == ["--from", "web"]
+    assert get_kwargs["jobs"] == 3
 
 
 def test_globus_missing_credentials_raises(tmp_path: Path) -> None:
@@ -426,3 +449,151 @@ def test_nsd_data_access_agreement(tmp_path: Path, study_name: str) -> None:
             url = mock_browser.call_args[0][0]
             assert "__other_option__" in url
             assert "Researcher" in url
+
+
+# ---------------------------------------------------------------------------
+# Unified selective-download matcher (include / exclude)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "patterns,relpath,expected",
+    [
+        (["sub-01"], "sub-01/eeg/x.set", True),  # bare folder selects its subtree
+        (["sub-*"], "sub-01/eeg/x.set", True),  # glob folder selects subtree
+        (["sub-02"], "sub-01/eeg/x.set", False),
+        (["sub-1/**/*run-01*"], "sub-1/ses-a/func/x_run-01_bold.nii", True),
+        (["*.set"], "sub-01/eeg/x.set", True),  # '*' spans '/'
+        (["derivatives"], "sub-01/eeg/x.set", False),
+        (["/sub-01/"], "sub-01/eeg/x.set", True),  # leading/trailing slashes ignored
+        ([], "anything/at/all", False),  # empty pattern list never matches
+    ],
+)
+def test_globs_match(patterns: list[str], relpath: str, expected: bool) -> None:
+    assert download._globs_match(patterns, relpath) is expected
+
+
+def _s3(tmp_path: Path, **kwargs: tp.Any) -> download.S3:
+    return download.S3(study="s", dset_dir=tmp_path / "s", bucket="b", **kwargs)
+
+
+def test_selects_empty_include_matches_everything(tmp_path: Path) -> None:
+    assert _s3(tmp_path)._selects("sub-01/eeg/x.set") is True
+
+
+def test_selects_include_only(tmp_path: Path) -> None:
+    obj = _s3(tmp_path, include=["sub-01"])
+    assert obj._selects("sub-01/eeg/x.set") is True
+    assert obj._selects("sub-02/eeg/x.set") is False
+
+
+def test_selects_exclude_beats_include(tmp_path: Path) -> None:
+    obj = _s3(tmp_path, include=["sub-*"], exclude=["*/derivatives/*", "sub-02"])
+    assert obj._selects("sub-01/eeg/x.set") is True
+    assert obj._selects("sub-02/eeg/x.set") is False  # excluded by name
+    assert obj._selects("sub-01/derivatives/y.tsv") is False  # excluded by subpath
+
+
+def test_reject_selection_filters(tmp_path: Path) -> None:
+    with pytest.raises(NotImplementedError, match="selective downloading"):
+        _s3(tmp_path, include=["sub-01"])._reject_selection_filters()
+    with pytest.raises(NotImplementedError, match="selective downloading"):
+        _s3(tmp_path, exclude=["sub-01"])._reject_selection_filters()
+    # no filters -> no raise
+    _s3(tmp_path)._reject_selection_filters()
+
+
+# ---------------------------------------------------------------------------
+# Per-backend selection wiring
+# ---------------------------------------------------------------------------
+
+
+def test_s3_resolve_prefix_filters(tmp_path: Path) -> None:
+    """S3._resolve_prefix keeps only keys whose dataset-relative path selects."""
+    obj = _s3(tmp_path, prefix="ds/1.0.0", include=["sub-01"])
+    keys = [
+        "ds/1.0.0/sub-01/eeg/a.set",
+        "ds/1.0.0/sub-02/eeg/b.set",
+        "ds/1.0.0/README",
+    ]
+    bucket = MagicMock()
+    bucket.objects.filter.return_value = [MagicMock(key=k) for k in keys]
+
+    jobs = obj._resolve_prefix(bucket, skip_existing=False)
+    rels = sorted(str(p.relative_to(obj._out).as_posix()) for _, p in jobs)
+    assert rels == ["sub-01/eeg/a.set"]
+
+
+def _datalad(tmp_path: Path, **kwargs: tp.Any) -> download.Datalad:
+    return download.Datalad(
+        study="s",
+        dset_dir=tmp_path / "s",
+        repo_url="https://example.com/ds004192.git",
+        **kwargs,
+    )
+
+
+def test_datalad_selected_paths_filters(tmp_path: Path) -> None:
+    obj = _datalad(tmp_path, include=["sub-01"])
+    repo_root = obj._dl_dir / obj.repo_name
+    for rel in [
+        "sub-01/eeg/a.set",
+        "sub-02/eeg/b.set",
+        "dataset_description.json",
+        ".git/config",
+    ]:
+        p = repo_root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("x")
+    assert obj._selected_paths(repo_root) == [str(repo_root / "sub-01" / "eeg" / "a.set")]
+
+
+def test_datalad_selected_paths_no_filter_returns_dot(tmp_path: Path) -> None:
+    obj = _datalad(tmp_path)
+    assert obj._selected_paths(obj._dl_dir / obj.repo_name) == ["."]
+
+
+@pytest.mark.parametrize("name", ["Dandi", "Synapse", "Eegdash", "Donders"])
+def test_backend_rejects_selection_filters(name: str, tmp_path: Path) -> None:
+    """Backends with no native filter raise NotImplementedError when include set."""
+    cls = getattr(download, name)
+    extra = _EXTRA_KWARGS.get(name, {})
+    env = _ENV_VARS.get(name, {})
+    with patch.dict(os.environ, env):
+        obj = cls(study="s", dset_dir=tmp_path / name, include=["sub-01"], **extra)
+    with pytest.raises(NotImplementedError, match="selective downloading"):
+        obj._download()
+
+
+# ---------------------------------------------------------------------------
+# #1751 / neuroai#51 regression: never write a success marker on failure
+# ---------------------------------------------------------------------------
+
+
+def test_download_does_not_mark_success_on_failure(tmp_path: Path) -> None:
+    obj = _s3(tmp_path)
+    with (
+        patch.object(type(obj), "_check_requirements"),
+        patch.object(obj, "_download", side_effect=RuntimeError("boom")),
+    ):
+        with pytest.raises(RuntimeError, match="boom"):
+            obj.download()
+    assert not obj.get_success_file().exists()
+
+
+def test_datalad_missing_binary_raises_no_marker(tmp_path: Path) -> None:
+    """#1751: a missing datalad install must error, not warn + mark success.
+
+    With the move to ``datalad.api``, ``_check_requirements`` raises before
+    ``_download`` runs, so no success marker is written over an empty folder.
+    """
+    obj = _datalad(tmp_path)
+    with patch.object(
+        download.Datalad,
+        "_check_requirements",
+        side_effect=ModuleNotFoundError("No module named 'datalad'"),
+    ):
+        with pytest.raises(ModuleNotFoundError):
+            obj.download()
+    assert not obj.get_success_file().exists()
+    assert list(obj._dl_dir.iterdir()) == []

--- a/neuralfetch-repo/pyproject.toml
+++ b/neuralfetch-repo/pyproject.toml
@@ -60,20 +60,13 @@ extend = "../pyproject.toml"
   plugins = ['pydantic.mypy']
   show_error_codes = true
 [[tool.mypy.overrides]]
-  module = [
-  'mne', 'mne.io', 'mne.io.constants', 'mne.io.fiff', 'mne.datasets', 'mne.utils', 'mne_bids', 'mne_bids.*',
-  'exca', 'exca.*',
-  'scipy.*', 'nibabel', 'h5py',
-  'osfclient', 'boto3', 'botocore', 'openneuro', 'pyunpack',
-  'synapseclient', 'synapseutils',
-  'moviepy',
-  'hcp_utils',
-  'nilearn',
+  module = ['mne', 'mne.io', 'mne.io.constants', 'mne.io.fiff', 'mne.datasets',
+  'mne.utils', 'mne_bids', 'mne_bids.*', 'exca', 'exca.*', 'scipy.*', 'nibabel', 'h5py',
+  'osfclient', 'boto3', 'botocore', 'openneuro', 'pyunpack', 'synapseclient',
+  'synapseutils', 'datalad', 'datalad.*', 'moviepy', 'hcp_utils', 'nilearn',
   'moabb.datasets.utils', 'moabb.datasets.base', 'moabb.datasets.bnci.*', 'pymatreader',
-  'praatio', 'praatio.*',
-  'sklearn.*', 'pooch', 'matio', 'matio.*',
-  'globus_sdk', 'globus_sdk.*',
-  ]
+  'praatio', 'praatio.*', 'sklearn.*', 'pooch', 'matio', 'matio.*',
+  'globus_sdk', 'globus_sdk.*']
   ignore_missing_imports = true
 
 [tool.pydantic-mypy]

--- a/neuralset-repo/neuralset/events/study.py
+++ b/neuralset-repo/neuralset/events/study.py
@@ -77,7 +77,8 @@ def _set_dir_permissions(path: Path) -> None:
                     skipped += 1
                     continue
                 os.chmod(item, 0o777)
-            except PermissionError:
+            # FileNotFoundError for broken symlinks: partial Datalad download
+            except (PermissionError, FileNotFoundError):
                 logger.debug("Cannot chmod %s (not owner), skipping.", item)
                 skipped += 1
     if skipped:


### PR DESCRIPTION
## Summary

Unifies **selective downloading** across every neuralfetch download backend behind two inherited glob fields on `BaseDownload` — `include` and `exclude` (dataset-relative POSIX globs; empty `include` means "everything", `exclude` is applied after and wins) — resolved through a single centralized matcher, `_selects()`. This completes the proposal in #257 (follow-up to the now-closed #51).

It also folds in and supersedes #25 (thanks @bpinsard) — his commits are **cherry-picked here with authorship preserved** — moving Datalad off `subprocess` onto the `datalad` Python API. As a natural consequence, a missing `datalad` install now **errors instead of silently warning and writing a bogus success marker over an empty folder** (fixes fairinternal/brainai#1751).

## What changed

- **`BaseDownload`**: new `include`/`exclude` fields, `_globs_match()` helper (openneuro-py glob semantics: `*`/`?`/`**`, folder patterns select their subtree), `_selects()` matcher, and `_reject_selection_filters()`.
- **Datalad / Gin**: fetch selected paths via `datalad.api` (built on @bpinsard's rewrite). Clone still lands in `download/<repo_name>/` (preserving existing study layout). `datalad` added to `requirements`. Gin keeps its git-annex web-URL registration, now driven by `include`/`exclude`.
- **Native pass-through**: `Openneuro` (`include`/`exclude`), `Huggingface` (`allow_patterns`/`ignore_patterns`). Removes the dead `Openneuro.excluded_patterns` field.
- **List/API filtering** through `_selects`: `S3`/`Physionet`, `Globus`, `Osf`, `Zenodo`, `Figshare`, `Dryad`.
- **No native filter**: `Dandi`, `Synapse`, `Eegdash`, `Donders` now raise `NotImplementedError` when `include`/`exclude` is set, instead of silently ignoring it.
- **Call sites**: `hebart2023things` migrated from `folders=[Wildcard("sub-*")]` to `include=["sub-*"]`; the existing `include=` study call sites are unchanged.

## Tests

- Matcher unit tests (`_globs_match` / `_selects` precedence).
- Per-backend selection wiring (`S3._resolve_prefix`, `Datalad._selected_paths`, `Gin` end-to-end).
- `NotImplementedError` for the unsupported backends.
- Regression: `download()` never writes a success marker when `_download` raises, and a missing `datalad` install leaves the folder empty (neuroai#51 / brainai#1751).

All of `test_download.py` passes; `ruff`, `ruff-format`, and `codespell` are clean.

## Issues

- Closes #257
- Supersedes #25 (its commits are included with credit to @bpinsard — this PR can replace it)
- Fixes fairinternal/brainai#1751 — that issue lives in another repo and must be closed manually after this syncs into brainai.
