### PR TITLE
neuralfetch: bump openneuro-py floor to >=2026.7.1 (closes #182)

### DIFF
--- a/neuralfetch-repo/neuralfetch/download.py
+++ b/neuralfetch-repo/neuralfetch/download.py
@@ -1447,7 +1447,7 @@ class Openneuro(BaseDownload):
     speed up datasets with many files when network bandwidth allows.
     """
 
-    requirements: tp.ClassVar[tuple[str, ...]] = ("openneuro-py>=2026.4.0",)
+    requirements: tp.ClassVar[tuple[str, ...]] = ("openneuro-py>=2026.7.1",)
     nworkers: int = 5
 
     def _download(self, overwrite: bool = False) -> None:

--- a/neuralfetch-repo/neuralfetch/studies/bel2026petit.py
+++ b/neuralfetch-repo/neuralfetch/studies/bel2026petit.py
@@ -77,8 +77,6 @@ def _clean_text(text: str) -> str:
 
 
 class _Bel2026PetitBase(study.Study):
-    requirements: tp.ClassVar[tuple[str, ...]] = ("openneuro-py",)
-
     task: tp.ClassVar[str]
 
     def model_post_init(self, log__: tp.Any) -> None:

--- a/neuralfetch-repo/neuralfetch/studies/chang2019bold5000.py
+++ b/neuralfetch-repo/neuralfetch/studies/chang2019bold5000.py
@@ -78,8 +78,6 @@ class Chang2019Bold5000(study.Study):
         "Preprocessed BOLD data (in MNI152NLin2009aSym) for"
         "4 participants watching still images in 3T fMRI"
     )
-    requirements: tp.ClassVar[tuple[str, ...]] = ("openneuro-py>=2025.2.0",)
-
     _info: tp.ClassVar[study.StudyInfo] = study.StudyInfo(
         num_timelines=510,
         num_subjects=4,

--- a/neuralfetch-repo/neuralfetch/studies/li2022petit.py
+++ b/neuralfetch-repo/neuralfetch/studies/li2022petit.py
@@ -88,7 +88,7 @@ class Li2022Petit(study.Study):
         "listening to 'The Little Prince' audiobook in their native language "
         "(French, English, Chinese)."
     )
-    requirements: tp.ClassVar[tuple[str, ...]] = ("openneuro-py", "praatio")
+    requirements: tp.ClassVar[tuple[str, ...]] = ("praatio",)
     dataset_id: tp.ClassVar[str] = "ds003643"
     TR_FMRI_S: tp.ClassVar[float] = 2.0
 

--- a/neuralfetch-repo/pyproject.toml
+++ b/neuralfetch-repo/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
 [project.optional-dependencies]
 all = ["neuralset[all]", "matplotlib"]
 quickstart = [
-  "openneuro-py>=2026.4.0",
+  "openneuro-py>=2026.7.1",
   "praatio",
   "pyunpack",
   "boto3",


### PR DESCRIPTION
## Summary

Bumps the `openneuro-py` floor to `>=2026.7.1`, which closes #182 (large OpenNeuro studies stalling under a connection leak + retry storm).

The root cause was **upstream**: older `openneuro-py` created a new `AsyncClient` per file, so open TCP connections scaled with *file count* rather than `max_concurrent_downloads` (measured >2,300 connections on `ds007523`). Two upstream releases fix this:

- **`2026.7.0`** — [Share a single `AsyncClient` across download tasks](https://github.com/openneuro-py/openneuro-py/pull/351) (fixes [openneuro-py#317](https://github.com/openneuro-py/openneuro-py/issues/317)). Open connections are now bounded by the pool size, not the number of files.
- **`2026.7.1`** — [Make downloads resilient to per-file failures](https://github.com/openneuro-py/openneuro-py/pull/361), which addresses the retry-storm symptom directly.

Pinning `>=2026.7.1` picks up both.

## Changes

Pin the floor in the two places that matter, and consolidate the requirement at the downloader level:

- `neuralfetch-repo/pyproject.toml`: `openneuro-py>=2026.4.0` → `openneuro-py>=2026.7.1` (the **install floor** for the `quickstart`/`all` extras).
- `neuralfetch/download.py` (`Openneuro` backend): `requirements = ("openneuro-py>=2026.4.0",)` → `("openneuro-py>=2026.7.1",)` (the **runtime import guard** / copy-pasteable `pip install` hint, inherited by every OpenNeuro-backed study).
- Removed the now-redundant **per-study** `openneuro-py` declarations:
  - `studies/bel2026petit.py` — dropped `requirements = ("openneuro-py",)` (empty → default).
  - `studies/chang2019bold5000.py` — dropped `requirements = ("openneuro-py>=2025.2.0",)`.
  - `studies/li2022petit.py` — `("openneuro-py", "praatio")` → `("praatio",)` (keeps its praatio requirement).

### Why consolidate at the downloader level

`openneuro-py` is an **optional** dependency (in the `quickstart` extra, not core), so a bare `neuralfetch` install doesn't pull it. `_check_requirements` runs at download time and emits a friendly `pip install ...` hint if it's missing. This check runs on the **backend** (`BaseDownload.download` → `Openneuro.requirements`) for every study that uses the downloader, so declaring `openneuro-py` on individual studies was redundant and inconsistent (only 3 of 7 OpenNeuro-backed studies did it). Declaring it once on the `Openneuro` backend covers them all uniformly.

Note: `_check_requirements` only gates *importability* (not the version); the version floor is enforced by the `pyproject.toml` dependency.

## Notes

- Distinct from the selective-download work (#257); the `include=`-scoping path referenced in #182's workaround is tracked separately under #51.
- The full `Bel2026PetitListen` study (~446 GB) still exceeds typical Colab/VM disk regardless of this fix, so it remains a cluster/large-disk job.

Closes #182
