### PR TITLE
neuralfetch(cli): polish subcommand help and docstrings

### DIFF
--- a/neuralfetch-repo/neuralfetch/commands/__init__.py
+++ b/neuralfetch-repo/neuralfetch/commands/__init__.py
@@ -26,15 +26,16 @@ _COMMANDS = ("download", "study_info", "export_bids")
 def main(argv: list[str] | None = None) -> None:
     logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
     parser = argparse.ArgumentParser(prog="neuralfetch")
-    subs = parser.add_subparsers(dest="command", required=True)
+    subs = parser.add_subparsers(required=True)
     for name in _COMMANDS:
         mod = importlib.import_module(f"neuralfetch.commands.{name}")
-        sub = subs.add_parser(mod.NAME, help=mod.HELP, description=mod.__doc__)
+        sub = subs.add_parser(
+            mod.NAME,
+            help=mod.HELP,
+            description=mod.__doc__,
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+        )
         mod.add_arguments(sub)
         sub.set_defaults(func=mod.run)
     args = parser.parse_args(argv)
     args.func(args)
-
-
-if __name__ == "__main__":
-    main()

--- a/neuralfetch-repo/neuralfetch/commands/download.py
+++ b/neuralfetch-repo/neuralfetch/commands/download.py
@@ -6,14 +6,12 @@
 
 """Download a registered study's raw dataset.
 
-Usage::
-
+Usage:
     neuralfetch download Grootswagers2022Human
     neuralfetch download --list
-
-The download runner lives in :mod:`neuralfetch.utils.runner`; this module is
-argparse glue only.
 """
+
+# The download runner lives in neuralfetch.utils.runner; this module is argparse glue.
 
 from __future__ import annotations
 

--- a/neuralfetch-repo/neuralfetch/commands/export_bids.py
+++ b/neuralfetch-repo/neuralfetch/commands/export_bids.py
@@ -6,8 +6,7 @@
 
 """Export a study to a BIDS directory tree.
 
-Usage::
-
+Usage:
     neuralfetch export-bids Grootswagers2022Human \\
         --output-dir ~/bids/Grootswagers2022Human \\
         --device Eeg --task thingseeg
@@ -26,10 +25,9 @@ Usage::
         --output-dir ~/bids/Grootswagers2022Human \\
         --device Eeg --task thingseeg \\
         --anonymize-daysback 365
-
-The export logic lives in :mod:`neuralfetch.utils.bids`; this module is argparse
-glue only.
 """
+
+# The export logic lives in neuralfetch.utils.bids; this module is argparse glue.
 
 from __future__ import annotations
 

--- a/neuralfetch-repo/neuralfetch/commands/study_info.py
+++ b/neuralfetch-repo/neuralfetch/commands/study_info.py
@@ -6,14 +6,12 @@
 
 """Compute (or update) StudyInfo for a downloaded study.
 
-Usage::
-
+Usage:
     neuralfetch study-info Grootswagers2022Human
     neuralfetch study-info Grootswagers2022Human --update
-
-The StudyInfo helpers live in :mod:`neuralfetch.utils`; this module is argparse
-glue only.
 """
+
+# The StudyInfo helpers live in neuralfetch.utils; this module is argparse glue.
 
 from __future__ import annotations
 

--- a/neuralfetch-repo/neuralfetch/utils/data.py
+++ b/neuralfetch-repo/neuralfetch/utils/data.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""Study data utilities (moved from neuralset.studies.utils)."""
+"""Study data helpers: events annotation, file scanning, and dataset acquisition."""
 
 import logging
 import os


### PR DESCRIPTION
## Summary

Small follow-up polish to the `neuralfetch` CLI (the `commands/` + `utils/` packages that landed in #223). No behavior change to the commands themselves — just nicer `--help` output and tidier docstrings.

## Changes

- **`commands/__init__.py`**
  - Give each subparser `formatter_class=argparse.RawDescriptionHelpFormatter` so the multi-line `Usage:` examples in each command's docstring survive `--help` (argparse otherwise collapses them).
  - Drop the unused `add_subparsers(dest="command", ...)` — dispatch is via `set_defaults(func=...)`, and nothing reads `args.command`.
  - Remove the redundant `if __name__ == "__main__": main()` guard; the `python -m neuralfetch.commands` entry already lives in `commands/__main__.py`, and the console script uses `neuralfetch.commands:main` directly.
- **`commands/{download,export_bids,study_info}.py`**: convert the RST `Usage::` blocks to plain `Usage:` and move the "argparse glue only" notes from the module docstring into a comment.
- **`utils/data.py`**: reword the module docstring to describe what it does rather than where it moved from.

## Verification

- `ruff check` / `ruff format` / `codespell` clean (pre-commit).
- `python -m neuralfetch.commands --help` and per-subcommand `--help` render correctly; subcommand descriptions now preserve their multi-line usage blocks.
